### PR TITLE
fix: review hardening batch 2 (M2/M4/M5 + name-buffer)

### DIFF
--- a/crates/ramshared-block/src/handshake.rs
+++ b/crates/ramshared-block/src/handshake.rs
@@ -20,6 +20,7 @@ const NBD_REP_INFO: u32 = 3;
 const NBD_REP_ERR_UNSUP: u32 = 0x8000_0001;
 const NBD_INFO_EXPORT: u16 = 0;
 const NBD_FLAG_C_NO_ZEROES: u32 = 1 << 1;
+const MAX_OPT_LEN: usize = 4096; // opções NBD são pequenas; teto anti-alloc.
 
 #[derive(Debug)]
 pub enum HandshakeError {
@@ -93,6 +94,12 @@ pub fn server_handshake<R: Read, W: Write>(
         let _opt_magic = read_u64(r)?; // IHAVEOPT (ignorado: confiamos no fluxo)
         let opt = read_u32(r)?;
         let len = read_u32(r)? as usize;
+        if len > MAX_OPT_LEN {
+            return Err(HandshakeError::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "opção NBD com len excessivo",
+            )));
+        }
         let mut data = vec![0u8; len];
         r.read_exact(&mut data)?;
 
@@ -194,5 +201,19 @@ mod tests {
         let mut out = Vec::new();
         let res = server_handshake(&mut r, &mut out, 4096, 1);
         assert!(matches!(res, Err(HandshakeError::Aborted)));
+    }
+
+    #[test]
+    fn rejects_oversized_option_len() {
+        // opção com len gigante deve falhar ANTES de alocar (M4 anti-DoS).
+        let mut v = Vec::new();
+        v.extend_from_slice(&0u32.to_be_bytes()); // client_flags
+        v.extend_from_slice(&IHAVEOPT.to_be_bytes()); // opt magic
+        v.extend_from_slice(&NBD_OPT_INFO.to_be_bytes()); // opt
+        v.extend_from_slice(&u32::MAX.to_be_bytes()); // len absurdo
+        let mut r = Cursor::new(v);
+        let mut out = Vec::new();
+        let res = server_handshake(&mut r, &mut out, 4096, 1);
+        assert!(matches!(res, Err(HandshakeError::Io(_))));
     }
 }

--- a/crates/ramshared-cli/src/cascade.rs
+++ b/crates/ramshared-cli/src/cascade.rs
@@ -150,6 +150,11 @@ pub fn up() -> Result<(), String> {
             "lzo-rle",
         ],
     )?;
+    // M5: zramctl deveria devolver /dev/zramN; valida antes de passar a cmds privilegiados.
+    if !matches!(zdev.strip_prefix("/dev/zram"), Some(s) if !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()))
+    {
+        return Err(format!("zramctl retornou device inesperado: {zdev}"));
+    }
     sh("mkswap", &[&zdev])?;
     sh("swapon", &["-p", &prios.zram.to_string(), &zdev])?;
     fs::write(ZRAM_DEV_FILE, &zdev).map_err(|e| e.to_string())?;

--- a/crates/ramshared-cuda/src/driver.rs
+++ b/crates/ramshared-cuda/src/driver.rs
@@ -141,7 +141,8 @@ impl Cuda {
             (self.syms.device_get_name)(buf.as_mut_ptr() as *mut c_char, buf.len() as i32, raw)
         };
         check(&self.syms, r, "cuDeviceGetName")?;
-        // SAFETY: buf foi preenchido com C-string válida pela API.
+        buf[buf.len() - 1] = 0; // garante terminação mesmo se a API preencher os 128 bytes
+        // SAFETY: buf preenchido pela API e com NUL final garantido acima.
         let name = unsafe { CStr::from_ptr(buf.as_ptr() as *const c_char) }
             .to_string_lossy()
             .into_owned();
@@ -299,10 +300,9 @@ unsafe fn load_sym<T: Copy>(handle: *mut c_void, name: &CStr) -> Result<T, CudaE
     if sym.is_null() {
         return Err(CudaError::Symbol(name.to_string_lossy().into_owned()));
     }
-    debug_assert_eq!(
-        core::mem::size_of::<T>(),
-        core::mem::size_of::<*mut c_void>()
-    );
+    const {
+        assert!(core::mem::size_of::<T>() == core::mem::size_of::<*mut c_void>());
+    }
     // SAFETY: T é fn-pointer C do mesmo tamanho de um data pointer; materializa o endereço.
     Ok(unsafe { core::mem::transmute_copy::<*mut c_void, T>(&sym) })
 }


### PR DESCRIPTION
## Resumo

Lote 2 de hardening dos achados **MEDIUM/LOW** da revisão adversarial do PR #2 — correções pequenas, localizadas e de baixo risco:

- **M2** (`ramshared-cuda`): troca `debug_assert_eq!` por um `const { assert!(...) }` no tamanho do fn-pointer em `load_sym` — vira checagem de **compile-time** (não some em release).
- **name-buffer (LOW, `ramshared-cuda`):** garante NUL final no buffer de `cuDeviceGetName` antes do `CStr::from_ptr` (defesa caso a API preencha os 128 bytes).
- **M4** (`ramshared-block`): teto de 4096 no `len` de opção do handshake NBD, com teste — evita alloc grande por opção malformada.
- **M5** (`ramshared-cli`): valida que o `zramctl --find` devolveu `/dev/zramN` antes de passar a `mkswap`/`swapon`.

Diff: ` 3 files changed, 31 insertions(+), 5 deletions(-)`.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `c121ae9` | M2 const-assert + NUL no name-buffer (cuda); cap de opção no handshake + teste (block); validação do zdev (cli) | Hardening dos achados MEDIUM/LOW da revisão (defesa em profundidade) | <details><summary>detalhes</summary>**Arquivos:** driver.rs, handshake.rs, cascade.rs<br>**Validação:** `clippy --workspace -D warnings` + `cargo test` (18 testes do block, inclui `rejects_oversized_option_len`)<br>**Risco/rollback:** baixíssimo (checagens defensivas); se o `const{}` quebrar num toolchain antigo, voltar ao `debug_assert_eq!`</details> |

## Issue

Parte de #3 — itens **M2, M4, M5** e o **name-buffer** (issue segue aberta para C1-full, H1, e as decisões LOW restantes).

## Responsavel

@emersonbusson

## Labels

`type:refactor`, `area:core`

## Validacao

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (novo teste `rejects_oversized_option_len` cobre o M4)
- [ ] N/A: `checkpatch.pl`/`make modules` (Rust userspace)

## Rollback trigger

- `const { assert! }` do M2 falhar em build (toolchain sem const-block com genéricos) → reverter ao `debug_assert_eq!`.
- `up` recusando um `/dev/zramN` legítimo (regressão do M5) → afrouxar a validação do zdev.
