### PR TITLE
docs: PT comment rule + CUDA Context thread doc (#3 M3/LOW)

### DIFF
--- a/.claude/rules/coding.md
+++ b/.claude/rules/coding.md
@@ -14,7 +14,7 @@ Rules:
 ## Language
 
 - All code, variable names, function names, macros, and filenames: **English**
-- Code comments (inline, block, doc): **English**
+- Code comments (inline, block, doc): **Portuguese (BR)** — alinhado ao projeto (autor, docs e PRs em PT-BR). Identificadores (nomes, funções, macros, arquivos) seguem em **inglês**, convenção do kernel.
 - Root documentation files (`README.md`, `ARCHITECTURE.md`): **Portuguese (BR)**
 - Commit messages and PR titles: **English** (Conventional Commits format)
 - PR descriptions (body) and Issues: **Portuguese (BR)**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ O source of truth para regras de arquitetura e código está em:
 
 ### Linguagem
 
-- **Inglês** em: código fonte (`.c`, `.rs`, `.h`), headers, makefiles, comments, commit titles, Kconfig.
-- **Português (BR)** em: `README.md`, `AGENTS.md`, `CLAUDE.md`, `MEMORY.md`, PR descriptions, Issue titles+bodies, e documentação de arquitetura.
+- **Inglês** em: código fonte (`.c`, `.rs`, `.h`), headers, makefiles, commit titles, Kconfig.
+- **Português (BR)** em: comentários de código, `README.md`, `AGENTS.md`, `CLAUDE.md`, `MEMORY.md`, PR descriptions, Issue titles+bodies, e documentação de arquitetura.
 
 ## Commits e Patches
 

--- a/crates/ramshared-cuda/src/driver.rs
+++ b/crates/ramshared-cuda/src/driver.rs
@@ -174,6 +174,11 @@ impl Device {
 }
 
 /// Contexto CUDA. `Drop` faz `cuCtxDestroy`.
+///
+/// **Afinidade de thread:** a corrente do contexto CUDA é *thread-local*. Use este
+/// `Context` (e os `DeviceMem` derivados) **na mesma thread** que o criou — por isso
+/// o daemon roda todo o I/O de VRAM numa única thread. Chamar de outra thread exigiria
+/// `cuCtxSetCurrent` (não feito aqui). A thread de DEMOTE só roda `swapoff`, não CUDA.
 pub struct Context<'a> {
     cuda: &'a Cuda,
     raw: CuContext,


### PR DESCRIPTION
## Resumo

Fecha os itens "fáceis" restantes do #3, conforme decisão: **a regra de idioma passa a permitir comentários em PT-BR** (alinhada à realidade do projeto — autor, docs e PRs são PT; identificadores seguem em inglês, convenção do kernel), evitando reescrever todos os comentários dos 6 crates. E documenta o **M3** (afinidade de thread do `Context` CUDA).

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `4beee05` | Regra: comentários de código em **PT-BR** (`coding.md` + `AGENTS.md`) | Revisão apontou PT vs regra-EN; projeto é PT-BR → alinhar a regra (sem churn no código) | <details><summary>detalhes</summary>**Arquivos:** .claude/rules/coding.md, AGENTS.md<br>**Validação:** governance **sync rule** satisfeita (2 arquivos no mesmo commit)<br>**Risco/rollback:** nenhum (regra/docs)</details> |
| `497cccf` | Doc da afinidade de thread do `Context` CUDA | M3: currency do contexto é thread-local; documentar o requisito (daemon roda CUDA numa thread só) | <details><summary>detalhes</summary>**Arquivos:** crates/ramshared-cuda/src/driver.rs (doc-comment)<br>**Validação:** clippy + testes do cuda ok<br>**Risco/rollback:** nenhum (comentário)</details> |

## Issue

Parte de #3 — item **M3** e a decisão **LOW** (idioma dos comentários). Seguem abertos no #3: C1-full, H1, e os outros LOW (erros tipados, clap).

## Responsavel

@emersonbusson

## Labels

`type:docs`, `area:core`

## Validacao

- [x] `cargo clippy -p ramshared-cuda --all-targets -- -D warnings`
- [x] `cargo test -p ramshared-cuda`
- [x] governance sync rule (regra mudou em coding.md + AGENTS.md no mesmo commit)
- [ ] N/A: `checkpatch.pl`/`make modules` (docs/Rust)

## Rollback trigger

- Nenhum gatilho operacional (mudança de regra + doc-comment). Reverter os commits se a política de idioma for revista.
