### PR TITLE
docs: root docs (README, ARCHITECTURE, ROADMAP)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,94 @@
+# Arquitetura — RamShared
+
+Foco: a implementação **WSL2** (SPECv3), única viável no guest GPU-PV. O destino
+bare-metal (NUMA/HMM/CXL) está no [ROADMAP.md](ROADMAP.md).
+
+## Visão geral
+
+O RamShared **orquestra** uma cascata de swap por prioridade e **gerencia o tier
+VRAM**; `zram` e `VHDX` são mecanismos do kernel que ele apenas configura.
+
+```text
+pressão de memória ─► zram  (RAM comprimida)  prio 200  HOT
+                   ─► VRAM  (daemon CUDA+NBD)  prio 100  COLD
+                   ─► VHDX  (swap do WSL2)     prio  -2  LAST
+```
+
+## Modelo de segurança (o pivô)
+
+A Fase 0 mediu, em GPU real, que a eviction WDDM é:
+
+- **data-safe** — o hash da página continua íntegro após a eviction;
+- **latency-unsafe** — uma leitura 4K com a VRAM cheia custou **1,18 s**.
+
+Como swap quente, a VRAM congelaria o sistema. Como tier **frio** atrás do zram, só
+recebe o spill de acesso raro — escondendo a latência. Quando o sinal de latência
+dispara (host reavendo VRAM), o **DEMOTE** faz `swapoff` do tier VRAM e o kernel
+migra as páginas vivas para o VHDX, **sem derrubar processos**.
+
+Invariante **A1**: o DEMOTE só é seguro se existe um tier *estritamente abaixo* da
+VRAM para drenar (checado em `up` e na rede de segurança do `ramshared-tier`).
+
+## Componentes
+
+| Crate | Responsabilidade | `unsafe` |
+|---|---|---|
+| `ramshared-tier` | prioridades (`zram 200 > vram 100 > vhdx -2`), `validate_order`, rede A1 | `forbid` |
+| `ramshared-cuda` | `libcuda` via `dlopen` (runtime, sem toolkit/`build.rs`); RAII (`Cuda`→`Context`→`DeviceMem`) | **isolado aqui** |
+| `ramshared-block` | NBD fixed-newstyle: parse/encode, validação §8, handshake | `forbid` |
+| `ramshared-integrity` | checksum (FNV-1a) + padrões de teste | `forbid` |
+| `ramshared-wsl2d` | daemon: máquina de estados §7, `VramBackend` (liga CUDA↔NBD), `mlockall`/`oom_score_adj`, canário/DEMOTE | só `mlockall` |
+| `ramshared-cli` | `check`/`doctor` (preflight) + `up`/`down`/`status` (orquestração) | `forbid` |
+
+Todo o `unsafe` do projeto vive no `ramshared-cuda` (FFI), com `// SAFETY:` por bloco;
+a exceção é o `mlockall` do daemon, justificado e isolado. Zero dependências externas
+(`std` + FFI).
+
+## Fluxo de execução
+
+1. **`up`** valida a ordem de prioridade e a rede A1, sobe o `zram`, sobe o daemon e
+   conecta `/dev/nbd0` via `nbd-client -unix` — **o daemon não faz ioctl nem `unsafe`**
+   (o `nbd-client` faz a fiação do kernel). `mkswap` + `swapon -p` montam os tiers.
+2. **Daemon** aloca e zera a VRAM, trava memória (`mlockall`) e se protege do OOM
+   (`oom_score_adj=-1000`, Disciplina 3), e serve NBD: cada READ/WRITE vira
+   `cuMemcpyDtoH/HtoD` na VRAM.
+3. **Canário §9 (inline):** o daemon cronometra a latência do I/O; após a baseline,
+   arma o `Canary`; sob spike (latência > N× baseline por M amostras) dispara o
+   **DEMOTE** numa thread (`swapoff <nbd>`) e segue servindo o read-back. Só desarma
+   se o `swapoff` confirmar; senão re-arma.
+4. **`down`** faz `swapoff` do NBD **antes** de desconectar (senão: kernel panic),
+   depois desmonta o zram; espera o daemon zerar a VRAM (§11) antes de qualquer
+   `pkill`.
+
+## Decisões-chave
+
+- **NBD, não ublk** (Fase A): `CONFIG_BLK_DEV_NBD=m` existe; `ublk` exigiria kernel
+  custom. Mantém o daemon sem `unsafe`.
+- **`dlopen` em runtime**, não link-time: o WSL2 só tem a stub `libcuda` do host, sem
+  toolkit → sem `build.rs`.
+- **Cascata por `swapon -p`**, não writeback: `CONFIG_ZRAM_WRITEBACK` não está setado
+  neste kernel; o writeback direto (zram grava frio na VRAM) fica para a Fase B.
+- **Decisão pura vs. efeito:** a lógica do canário (`residency.rs`) e da cascata
+  (`tier`) é pura e testável sem GPU/root; só o daemon executa CUDA e `swapoff`.
+
+## Metodologia
+
+- **SSDV3** — Spec-Driven Development: PRD → SPEC → IMPL, com auditoria Passo 2.5
+  (go/no-go) entre versões. Ver [`docs/methodology/`](docs/methodology/) e
+  [`.claude/rules/ssdv3.md`](.claude/rules/ssdv3.md).
+- **Disciplinas Kahneman** — toda decisão de lock/DMA/arquitetura registra
+  counterfactual e *rollback trigger* numérico ([`docs/methodology/KAHNEMAN-DISCIPLINES.md`](docs/methodology/KAHNEMAN-DISCIPLINES.md)).
+- **Day-0** e **governança** (template de PR, sync rule) em [`.claude/rules/`](.claude/rules/).
+
+## Validação
+
+Aceitação §14 no sistema vivo (cgroup-confined): spill de **511 MiB** para a VRAM
+(332.800 páginas íntegras) e DEMOTE de **481 MiB** vivos migrados sem corrupção. Ver
+[`docs/vram-as-ram/VALIDATION-CASCADE.md`](docs/vram-as-ram/VALIDATION-CASCADE.md).
+
+## Limitações conhecidas (rastreadas)
+
+- Canário inline usa **só latência** (WDDM é data-safe). Conteúdo/free-floor exigem o
+  canário dedicado §9.4 — issue #3 (C1).
+- Serve loop **serial** (1 conexão = a vida do swap); o read-back do DEMOTE não tem
+  leitor dedicado — issue #3 (H1).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# RamShared
+
+VRAM de GPU como tier de **swap** no Linux/WSL2. Em cargas não-gráficas a VRAM passa
+~90% ociosa enquanto a RAM estoura e o sistema faz swap para SSD — dezenas de vezes
+mais lento que a VRAM. O RamShared põe a VRAM no meio desse caminho.
+
+## Abordagem
+
+A VRAM **não** é swap quente. Sob pressão, a eviction do WDDM (WSL2/GPU-PV) preserva
+os dados mas injeta latência: uma leitura 4K mediu **1,18 s** com a VRAM cheia —
+*data-safe, latency-unsafe*. Por isso ela entra como tier **frio** numa cascata por
+prioridade de `swapon`:
+
+```text
+pressão de memória ─► zram  (RAM comprimida, lzo-rle)  prio 200  HOT
+                   ─► VRAM  (CUDA + NBD)               prio 100  COLD
+                   ─► VHDX  (swap do WSL2)             prio  -2  LAST
+```
+
+O zram absorve o working set quente; a VRAM pega só o spill frio (esconde a fraqueza
+de latência, usa a força de capacidade/banda). Um **canário** demove a VRAM
+(`swapoff`) sob spike de latência, sem derrubar processos.
+
+## Status
+
+Validado end-to-end no WSL2 (RTX 2060), pressão confinada por cgroup v2:
+
+- **spill:** 511 MiB caíram na VRAM, **332.800 páginas íntegras**;
+- **DEMOTE:** 481 MiB vivos migraram VRAM→VHDX via `swapoff`, **0 corrupção**.
+
+Evidência: [`docs/vram-as-ram/VALIDATION-CASCADE.md`](docs/vram-as-ram/VALIDATION-CASCADE.md).
+
+## Uso
+
+> **WSL2:** builds Rust pesados podem travar o ambiente — mantenha o `cargo` escopado
+> por crate, sem `--release`.
+
+```bash
+cargo build -p ramshared-cli -p ramshared-wsl2d
+
+sudo ./target/debug/ramshared check        # preflight: WSL2/CUDA/kernel/tiers
+sudo ./target/debug/ramshared up --vram 1024 --zram 1024
+swapon --show                              # zram(200) > nbd0(100) > vhdx(-2)
+sudo ./target/debug/ramshared down         # swapoff antes do disconnect (anti-panic)
+```
+
+## Estrutura (6 crates, zero deps externas)
+
+| Crate | Papel |
+|---|---|
+| `ramshared-tier` | prioridades da cascata + rede de segurança A1 do DEMOTE |
+| `ramshared-cuda` | CUDA Driver API via `dlopen` (**único `unsafe` do projeto**) |
+| `ramshared-block` | protocolo NBD fixed-newstyle + I/O (lib pura) |
+| `ramshared-integrity` | checksum + padrões de teste |
+| `ramshared-wsl2d` | daemon: máquina de estados, `VramBackend`, canário/DEMOTE |
+| `ramshared-cli` | `check`/`doctor`/`up`/`down`/`status` |
+
+## Documentação
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — arquitetura, componentes e fluxo
+- [ROADMAP.md](ROADMAP.md) — onde esteve e para onde vai
+- [MANIFESTO.md](MANIFESTO.md) — princípios (bare-metal first)
+- [`docs/vram-as-ram/SPECv3-WSL2.md`](docs/vram-as-ram/SPECv3-WSL2.md) — spec ativo
+- [`docs/methodology/`](docs/methodology/) — SSDV3 + disciplinas Kahneman
+- [CLAUDE.md](CLAUDE.md) / [AGENTS.md](AGENTS.md) / [`.claude/rules/`](.claude/rules/) — regras
+
+## Requisitos
+
+Rust (edition 2024). WSL2 com NVIDIA via GPU-PV (`/dev/dxg` + `libcuda`),
+`CONFIG_BLK_DEV_NBD`, `CONFIG_ZRAM`, `nbd-client`, `zramctl`.
+
+## Aviso
+
+Projeto de P&D. Mexe em **swap real** e na **GPU** — rode confinado e com cuidado.
+Política **Day-0**: sem shims nem workarounds; cada mudança é a versão definitiva.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,50 @@
+# Roadmap — RamShared
+
+O caminho executável hoje é o **WSL2**; o destino é o **ring 0 bare-metal**
+(ver [MANIFESTO.md](MANIFESTO.md)). Datas são omitidas de propósito — P&D.
+
+## Feito
+
+- **Avaliação dos 6 PRDs** + ambiente real (WSL2/GPU-PV): só o PRD-2 (block device +
+  CUDA) é viável no guest; os demais exigem DRM/BAR/DAMON ausentes.
+- **Fase 0** (GPU real): eviction WDDM é *data-safe, latency-unsafe* (4K → 1,18 s);
+  cascata provada (zram cheio + VRAM absorveu 983 MiB de overflow).
+- **SPECv3-WSL2** — convergência via Passo 2.5 (SPEC → SPECv2 → SPECv3): VRAM como
+  tier frio + DEMOTE.
+- **Port Rust** (6 crates) e **validação de aceitação §14** no sistema vivo (spill
+  511 MiB íntegro; DEMOTE 481 MiB migrado, 0 corrupção).
+- **Hardening pós-revisão adversarial** (issue #3): C3 (FFI CUDA duplicada removida,
+  CLI `forbid(unsafe_code)`), M1/M2/M3/M4/M5 + name-buffer.
+
+## Agora — issue #3 (Fase A, WSL2)
+
+- **C1 — canário dedicado (§9.4):** região-canário com checagem de **conteúdo**
+  (sentinela write/read) e **free-floor** (`cuMemGetInfo` periódico), ativando
+  `Demote(Corruption)`/`Demote(FreeFloor)` além da latência. _Em esteira SSDV3
+  (PRD → SPEC)._
+- **H1 — daemon multi-thread / leitor dedicado:** servir o NBD sem
+  head-of-line-blocking, encurtando a janela do DEMOTE sob eviction.
+- **LOW:** erros tipados (enum) no daemon/cascade; `clap` no parse de args.
+
+## Fase B — kernel custom (WSL2 + kernel próprio)
+
+- `CONFIG_ZRAM_WRITEBACK`: writeback do zram frio direto na VRAM (elimina o salto por
+  userspace no caminho frio).
+- `ublk` no lugar do NBD (menos cópias, menos context-switch).
+
+## Visão maior — bare-metal (gated em sair do WSL2)
+
+Exploratórios; precisam de DRM/BAR/DAMON/CXL indisponíveis no guest GPU-PV. Cada um
+tem PRD:
+
+- **NUMA node** para a VRAM ([`PRD`](docs/vram-as-ram/PRD.md), [`PRD-4`](docs/vram-as-ram/PRD-4.md) com DAMON/tiering proativo).
+- **zswap/zpool backend** na VRAM via BAR ([`PRD-3`](docs/vram-as-ram/PRD-3.md)).
+- **HMM `DEVICE_PRIVATE` + SDMA + eBPF** ([`PRD-6`](docs/vram-as-ram/PRD-6.md)).
+- **CXL / PCIe Gen5** — memória coerente como tier nativo.
+
+## Princípios de avanço
+
+- Cada item estrutural passa pela esteira **SSDV3** (PRD → SPEC → IMPL) e pelas
+  **disciplinas Kahneman** (counterfactual + rollback trigger numérico).
+- Nada vira swap quente sem evidência de latência; **medir antes de codar** (Fase 0).
+- **Day-0:** sem shims; a saída do WSL2 reescreve os caminhos, não os empilha.


### PR DESCRIPTION
## Resumo

Adiciona os três docs de raiz pedidos, em **PT-BR** (regra `coding.md`), terse e ancorados no estado real do projeto:

- **README.md** — o quê/porquê, a cascata, status validado, uso (`check`/`up`/`down`), estrutura dos 6 crates, requisitos.
- **ARCHITECTURE.md** — modelo data-safe/latency-unsafe + DEMOTE, componentes e onde vive o `unsafe`, fluxo de execução, decisões-chave (NBD vs ublk, dlopen, cascata por prioridade), validação §14, limitações rastreadas (#3 C1/H1).
- **ROADMAP.md** — feito (Fase 0 → SPECv3 → impl → validação → hardening), agora (#3), Fase B (kernel custom) e a visão bare-metal (PRDs NUMA/zswap/HMM/CXL).

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `8233636` | Cria README, ARCHITECTURE, ROADMAP (PT-BR) | Faltavam docs de raiz; orientam quem chega ao repo | <details><summary>detalhes</summary>**Arquivos:** README.md, ARCHITECTURE.md, ROADMAP.md<br>**Validação:** fatos conferidos contra SPECv3/crates/VALIDATION-CASCADE; links relativos válidos<br>**Risco/rollback:** nenhum (docs)</details> |

## Issue

N/A (documentação de raiz; não fecha issue).

## Responsavel

@emersonbusson

## Labels

`type:docs`, `area:docs`

## Validacao

- [x] PT-BR (regra de idioma para docs de raiz)
- [x] Fatos conferidos (cascata, §14, crates, métodos)
- [ ] N/A: `checkpatch.pl`/`make modules`/`cargo` (sem código)

## Rollback trigger

- Nenhum gatilho operacional (documentação). Corrigir/reverter se algum fato divergir do SPECv3 ativo.
