### PR TITLE
docs(ssdv3): PRD + SPEC for dedicated residency canary (#8, §9.4)

### DIFF
--- a/docs/008-vram-residency-canary/PRD.md
+++ b/docs/008-vram-residency-canary/PRD.md
@@ -1,0 +1,172 @@
+---
+slug: 008-vram-residency-canary
+title: Canário de residência dedicado (§9.4) — gatilhos de conteúdo e free-floor
+milestone: —
+issues: [8]
+---
+# PRD — Issue #8 — Canário de residência dedicado (§9.4)
+
+## 1. Resumo
+
+O daemon do tier VRAM (`ramshared-wsl2d`) detecta eviction WDDM por um **canário de
+residência** (SPECv3 §9). Hoje a fiação inline alimenta a decisão só com a **latência
+do `serve()`** — `sample(lat, content_ok=true, free=u64::MAX)` — deixando os gatilhos
+de **conteúdo** (`Demote(Corruption)`) e **free-floor** (`Demote(FreeFloor)`) como
+**código morto**. _(Confirmado no codebase: `crates/ramshared-wsl2d/src/main.rs`.)_
+
+Esta feature implementa o **canário dedicado** previsto na SPECv3 §9.4: uma
+região-canário separada na VRAM + uma sonda periódica que produz os três sinais reais
+(latência de round-trip fixo, integridade de conteúdo, free do `cuMemGetInfo`). Valor:
+a segurança do tier frio deixa de repousar num único proxy de latência e ganha uma
+**guarda de integridade** explícita antes do kernel ler swap potencialmente corrompido.
+
+## 2. Contexto técnico
+
+- **Módulo alvo:** `crates/ramshared-wsl2d` (daemon). Reusa `crates/ramshared-cuda`
+  (I/O VRAM) e a decisão pura de `residency.rs`. _(Confirmado no codebase.)_
+- **Estado atual a reutilizar:**
+  - `residency.rs`: `Canary::new(cfg, baseline_us)`, `sample(latency_us, content_ok, free_bytes) -> Verdict`, `ResidencyConfig { latency_mult: 8, consecutive: 3, free_floor_bytes: 0 }`, `DemoteReason { Latency, Corruption, FreeFloor }`. **A decisão já trata os 3 gatilhos e tem 5 testes.** _(Confirmado no codebase.)_
+  - `driver.rs`: `Context::alloc(bytes) -> DeviceMem`, `DeviceMem::write_at/read_at/zero`, `Context::mem_info() -> (free, total)`. _(Confirmado no codebase.)_
+  - `main.rs`: serve loop com `canary: Option<Canary>`, `baseline`, `demoted`, `demote_rx` (DEMOTE confirmado por canal, re-arma se falhar). _(Confirmado no codebase.)_
+- **Escopo de memória:** VRAM via CUDA Driver API (`cuMemAlloc`/`cuMemcpy*`), userspace; sem kernel-space. CUDA é **thread-local** — tudo roda na thread do serve loop. _(Confirmado no codebase: doc do `Context`.)_
+- **Evidência de plataforma:** eviction WDDM é **data-safe / latency-unsafe** (4K → 1,18 s). _(Confirmado em docs: `FASE0-FINAL.md`, SPECv3 §9.5.)_
+- **Confirmado em docs:** SPECv3 §9.3 (3 gatilhos), §9.4 (canário dedicado — previsto, não implementado).
+- **Proposto:** região-canário como `DeviceMem` separado; sonda em cadência por contagem de requests; `free_floor_bytes` default não-zero.
+
+## 3. Opção recomendada
+
+**Sonda inline com região-canário dedicada**, amostrando a cada `CANARY_EVERY` requests
+dentro do serve loop. Cada amostra: escreve um padrão-sentinela (derivado de um
+contador) na região-canário, relê, compara (`content_ok`); cronometra esse round-trip
+de tamanho fixo (`latency_us`); chama `mem_info()` (`free_bytes`). Alimenta o `Canary`
+existente; qualquer `Verdict::Demote(_)` aciona o caminho de DEMOTE já existente.
+
+- **Motivo:** reusa 100% da decisão (`residency.rs`) e do I/O (`ramshared-cuda`);
+  zero `unsafe` novo; latência de tamanho fixo é sinal mais limpo que a do `serve()`
+  (que varia com o tamanho do request); ativa os 3 gatilhos.
+- **Alternativas descartadas:**
+  - *Thread amostradora dedicada* — CUDA é thread-local; exigiria `cuCtxSetCurrent`
+    (acopla a H1, multi-thread). Fica fora (ver §12).
+  - *Canário no fim da região de swap* — obrigaria reduzir o tamanho anunciado e
+    arriscaria sobrepor dado de swap. Região separada é mais limpa (Day-0).
+  - *Manter só latência do serve* — é o estado atual; não dá guarda de integridade.
+- **Trade-offs aceitos:** sem tráfego de swap (idle) a sonda não roda — aceitável,
+  pois sem swap ativo não há página em risco (detecção em idle = H1, futuro).
+
+## 4. Requisitos funcionais
+
+- **RF-1 — Região-canário isolada.** Aloca um `DeviceMem` separado de `CANARY_BYTES`,
+  independente da região de swap. **Aceite:** o tamanho NBD anunciado continua = região
+  de swap; a região-canário não é endereçável por requests. **Isolamento:** região
+  distinta na VRAM; sem exposição a userspace além do já existente.
+- **RF-2 — Gatilho de conteúdo.** A sonda escreve sentinela, relê e compara;
+  divergência → `content_ok=false` → `Demote(Corruption)`. **Aceite:** teste com leitura
+  divergente injetada produz `Verdict::Demote(DemoteReason::Corruption)`.
+- **RF-3 — Gatilho de latência dedicado.** A latência alimentada ao `Canary` passa a
+  ser o round-trip de tamanho fixo da sonda (não a do `serve()`). **Aceite:** o baseline
+  e as amostras vêm da sonda; sob spike, `Demote(Latency)` após `consecutive` amostras.
+- **RF-4 — Gatilho de free-floor.** A sonda lê `mem_info().free` e alimenta o `Canary`;
+  `free_floor_bytes` passa a ter default > 0. **Aceite:** `free < free_floor_bytes` →
+  `Demote(FreeFloor)`.
+- **RF-5 — Cadência amortizada.** A sonda roda a cada `CANARY_EVERY` requests de I/O.
+  **Aceite:** overhead por request amortizado ≤ ~1 round-trip 4K a cada `CANARY_EVERY`.
+- **RF-6 — DEMOTE unificado.** Qualquer `Verdict::Demote(_)` (Latency/Corruption/
+  FreeFloor) aciona o `swapoff` confirmado por canal já existente. **Aceite:** os 3
+  motivos chegam ao mesmo caminho de DEMOTE e logam a razão.
+
+## 5. Requisitos não-funcionais
+
+- **Performance:** overhead amortizado pequeno (1 round-trip de `CANARY_BYTES` a cada
+  `CANARY_EVERY` requests). Sem cópia extra no caminho de dados de swap.
+- **Segurança:** sem `unsafe` novo (usa `ramshared-cuda`); região-canário sem dado de
+  usuário; nenhum endereço de VRAM logado.
+- **Observabilidade:** o log de DEMOTE inclui a razão e os valores (latência/free) que
+  dispararam — _(estende o log já existente)_.
+- **Resiliência:** erro CUDA na sonda (write/read/mem_info) é sinal de perda de
+  residência → tratado como DEMOTE conservador (decisão a fechar no SPEC).
+- **Escalabilidade:** N/A (1 daemon por device, 1 conexão = vida do swap).
+- **LGPD:** N/A (sem dado pessoal; sentinela é padrão sintético).
+
+## 6. Fluxos
+
+**Sonda por ciclo (a cada `CANARY_EVERY` requests, durante swap ativo):**
+
+1. `seq += 1`; escreve `seq`-derived pattern na região-canário (`write_at`).
+2. relê a região (`read_at`) e compara → `content_ok`.
+3. cronometra (1)+(2) → `latency_us`.
+4. `free = mem_info().free`.
+5. `canary.sample(latency_us, content_ok, free)`:
+   - `Verdict::Ok` → segue;
+   - `Verdict::Demote(reason)` → dispara `swapoff <nbd>` (thread, confirmado por canal;
+     re-arma se falhar) e loga `reason`.
+
+Baseline: as primeiras `N` latências da sonda formam a mediana (como hoje, mas da
+sonda).
+
+## 7. Modelo de dados
+
+- **Sentinela:** `CANARY_BYTES` bytes derivados de `seq` (ex.: FNV/contador por palavra)
+  — reusa o padrão de `ramshared-integrity` se couber, ou um preenchimento simples.
+  _(Inferência: detalhe fechado no SPEC.)_
+- **Estado da sonda** (no daemon): `region: DeviceMem`, `seq: u64`, `counter: u32`,
+  `every: u32`. Sem persistência. _(Proposto.)_
+
+## 8. API / Interfaces
+
+Nenhuma uAPI/ABI nova. Mudança interna ao daemon. Reusa `residency.rs::Canary` e
+`ramshared-cuda` (sem novas funções públicas exigidas; possivelmente um helper interno
+no daemon). _(Confirmado no codebase: APIs já existem.)_
+
+## 9. Dependências e riscos
+
+- **Dep:** `ramshared-cuda` (`alloc`/`write_at`/`read_at`/`mem_info`) e
+  `residency.rs` — ambos prontos. _(Confirmado no codebase.)_
+- **Risco R1:** `cuMemGetInfo` no WSL2/GPU-PV pode não refletir host eviction → free-
+  floor ruidoso. **Mitigação:** `free_floor_bytes` conservador/tunável; latência segue
+  primário. _(Inferência.)_
+- **Risco R2:** cadência mal calibrada (alta = overhead; baixa = detecção lenta).
+  **Mitigação:** `CANARY_EVERY` constante tunável; default medido. _(Inferência.)_
+- **Risco R3:** sonda não roda em idle (serve loop bloqueado no `read`). **Mitigação:**
+  declarado fora de escopo (H1). _(Confirmado no codebase: serve serial.)_
+- **Risco R4:** conteúdo nunca diverge se WDDM é data-safe → `Demote(Corruption)` raro.
+  **Aceito:** é guarda de defesa-em-profundidade (dispara só se a premissa falhar).
+
+## 10. Estratégia de implementação
+
+1. Alocar a região-canário (`DeviceMem`) no daemon, após a região de swap.
+2. Helper de sonda no daemon: write sentinela → read → compare + `mem_info`.
+3. Substituir o feed `sample(lat_serve, true, u64::MAX)` pela sonda em cadência.
+4. Default `ResidencyConfig.free_floor_bytes > 0`.
+5. Tratar erro CUDA da sonda como DEMOTE conservador.
+6. Testes: `residency.rs` já cobre a decisão; adicionar teste unit da **cadência**
+   (sem GPU) e um teste `--ignored` da sonda real (com GPU).
+
+## 11. Documentos a atualizar (mesmo commit do IMPL)
+
+- `docs/008-vram-residency-canary/SPEC.md` (Passo 2) e `IMPL.md` (Passo 3).
+- `docs/vram-as-ram/SPECv3-WSL2.md` §9.4 → marcar implementado.
+- `docs/vram-as-ram/IMPL.md`, `ARCHITECTURE.md` (limitação C1 resolvida), `MEMORY.md`.
+
+## 12. Fora de escopo
+
+- Detecção em **idle** (thread amostradora + `cuCtxSetCurrent`) — depende de H1.
+- Daemon multi-conexão / multi-thread (H1).
+- Writeback do zram na VRAM (Fase B).
+
+## 13. Critérios de aceitação
+
+- `Demote(Corruption)` e `Demote(FreeFloor)` deixam de ser código morto: alcançáveis a
+  partir da sonda do daemon (não mais `true`/`u64::MAX` fixos).
+- Os 3 gatilhos chegam ao mesmo caminho de DEMOTE confirmado por canal.
+- Sem regressão na aceitação §14 (spill + DEMOTE por latência continuam OK).
+- `clippy --workspace -D warnings` + testes verdes; daemon sem `unsafe` novo.
+
+## 14. Validação
+
+- **Unit (sem GPU/root):** `cargo test -p ramshared-wsl2d` — decisão (`residency.rs`,
+  já existe) + novo teste de cadência.
+- **GPU (`--ignored`):** sonda real escreve/relê a região-canário (round-trip íntegro).
+- **Ao vivo (opcional, root+GPU):** `vramhog` reduz `free` abaixo do `free_floor` →
+  `Demote(FreeFloor)` observável no log; re-rodar `cascade-validate.sh`/`cascade-demote.sh`
+  (sem regressão).
+- **checkpatch.pl/make modules:** N/A (Rust userspace).

--- a/docs/008-vram-residency-canary/SPEC.md
+++ b/docs/008-vram-residency-canary/SPEC.md
@@ -1,0 +1,221 @@
+# SPEC — Issue #8 — Canário de residência dedicado (§9.4)
+
+Fonte: [`PRD.md`](PRD.md). Implementa a SPECv3 [`§9.4`](../vram-as-ram/SPECv3-WSL2.md).
+Decisões fechadas, sem ambiguidade para o Passo 3.
+
+## Escopo fechado desta implementação
+
+**Entra agora:**
+- Região-canário dedicada na VRAM (`DeviceMem` separado).
+- Sonda periódica: round-trip de tamanho fixo → `(latency_us, content_ok)`; `free` via
+  `cuMemGetInfo`.
+- Fiação no serve loop: a sonda (em cadência) substitui o proxy de latência do
+  `serve()` como entrada do `Canary`; os 3 gatilhos passam a ser alcançáveis.
+- `ResidencyConfig.free_floor_bytes` default > 0.
+
+**Fica fora agora:** detecção em idle (thread amostradora / `cuCtxSetCurrent` — H1);
+multi-conexão; writeback.
+
+**Dependências prontas:** `ramshared-cuda` (`alloc`/`write_at`/`read_at`/`mem_info`),
+`residency.rs` (decisão + 5 testes), `ramshared-integrity` (`fill_block`/`verify_block`).
+
+## Matriz de rastreabilidade PRD → SPEC
+
+| PRD  | Implementação no SPEC |
+| ---- | --------------------- |
+| RF-1 | ITEM-1, DT-1 |
+| RF-2 | ITEM-2, DT-4 |
+| RF-3 | ITEM-2, ITEM-4, DT-6 |
+| RF-4 | ITEM-4, ITEM-5, DT-3 |
+| RF-5 | ITEM-3, DT-2 |
+| RF-6 | ITEM-4 (reusa o caminho de DEMOTE existente) |
+
+## Decisões técnicas
+
+| #    | Decisão | Justificativa |
+| ---- | ------- | ------------- |
+| DT-1 | `CANARY_BYTES = 4096` (1 bloco) | round-trip mínimo representativo (1 página), alinhado ao `BLOCK_SIZE`. |
+| DT-2 | `CANARY_EVERY = 64` requests | amortiza overhead; sob pressão há tráfego abundante → detecção em < ~64 I/Os. |
+| DT-3 | `free_floor_bytes` default = `64 * 1024 * 1024` | "GPU criticamente cheia" conservador; tunável; latência segue gatilho primário (PRD R1). |
+| DT-4 | Sentinela = `ramshared_integrity::fill_block`/`verify_block` com `Pattern::Random` e `idx = seq` | reuso (regra SSDV3) + padrão reprodutível; `idx` por ciclo pega também **leitura stale**. |
+| DT-5 | Erro CUDA na sonda (`run()`/`mem_info()` → `Err`) ⇒ **DEMOTE conservador** | disciplina #5 (worst-case): se não dá para *provar* residência, drena antes de arriscar. |
+| DT-6 | A latência da **sonda** substitui a do `serve()` como entrada do `Canary`; baseline passa a ser da sonda | sinal de tamanho fixo, não confundido pelo tamanho do request (PRD RF-3). |
+
+## Fronteira de atomicidade e política de rollback
+
+- **Atomicidade:** cada ciclo de sonda é independente (1 ciclo = 1 amostra; sem
+  multi-write transacional). A ação de DEMOTE (`swapoff`) é atômica no kernel e já é
+  coberta pelo caminho existente (confirmação por canal + re-arm). Nenhum estado parcial
+  novo é introduzido.
+- **Rollback:** **app-only** (reverter os commits desta issue). Sem migration, sem
+  dados persistidos, sem `forward-only`. Proibido em qualquer ambiente: nada (mudança
+  reversível por revert).
+
+## Mapa Kahneman por etapa crítica
+
+| Etapa / ITEM | Disciplina | Link | Pergunta obrigatória | Evidência mínima | Abort trigger |
+| --- | --- | --- | --- | --- | --- |
+| ITEM-4 (DEMOTE por free-floor / erro de sonda) | #5 Worst-case / pré-mortem + #2 Counterfactual/rollback | [`KAHNEMAN-DISCIPLINES.md`](../methodology/KAHNEMAN-DISCIPLINES.md) | "free baixo / erro de sonda é eviction real ou ruído do GPU-PV?" | teste injeta `free < floor` → `Demote(FreeFloor)`; ao vivo `vramhog` reduz free → DEMOTE no log | em operação normal (sem `vramhog`) o DEMOTE dispara por free-floor → subir `free_floor`/desabilitar (tunável) e reverter |
+| ITEM-2 (gatilho de conteúdo) | #13 Ilusão de validade | [`KAHNEMAN-DISCIPLINES.md`](../methodology/KAHNEMAN-DISCIPLINES.md) | "e se a VRAM devolver dado stale/corrompido apesar de 'data-safe'?" | teste com leitura divergente → `Demote(Corruption)` | N/A (é guarda; não deve disparar em operação sã) |
+
+## Checklist de segurança (pré-implementação)
+
+- [x] Isolamento: a região-canário é um `DeviceMem` separado, **não endereçável** por
+  requests NBD (o tamanho anunciado continua = região de swap).
+- [x] Buffer overflow / OOB: `write_at`/`read_at` já fazem bounds-check (`driver.rs::bounds`);
+  `wbuf`/`rbuf` têm exatamente `CANARY_BYTES`.
+- [x] Permissões: o daemon já roda como root (subido pelo `up`); sem novo caminho privilegiado.
+- [x] Input validation: a sonda não recebe input externo (sentinela sintética).
+- [x] Ponteiros: nenhum endereço de VRAM é logado.
+- [x] Sem `unsafe` novo (usa `ramshared-cuda`; `lib.rs` segue `forbid(unsafe_code)`).
+
+## Arquivos a CRIAR
+
+### `crates/ramshared-wsl2d/src/canary_probe.rs`
+
+- **Propósito:** sonda da região-canário (round-trip + integridade) e cadência pura.
+- **Requisitos cobertos:** RF-2, RF-3, RF-5, DT-1, DT-2, DT-4, DT-6.
+- **Structs/Types:**
+  ```rust
+  use ramshared_cuda::{CudaError, DeviceMem};
+  use ramshared_integrity::{Pattern, fill_block, verify_block};
+
+  pub const CANARY_BYTES: usize = 4096; // DT-1
+  pub const CANARY_EVERY: u32 = 64;     // DT-2
+
+  /// Cadência pura (testável sem GPU): dispara a cada `every` ticks.
+  pub struct Cadence {
+      every: u32,
+      counter: u32,
+  }
+
+  /// Resultado de um ciclo de sonda.
+  pub struct ProbeOutcome {
+      pub latency_us: u64,
+      pub content_ok: bool,
+  }
+
+  /// Sonda da região-canário. Empresta o `DeviceMem` da região (separada da swap).
+  pub struct CanaryProbe<'c, 'a> {
+      region: DeviceMem<'c, 'a>,
+      wbuf: Vec<u8>,
+      rbuf: Vec<u8>,
+      seq: u64,
+  }
+  ```
+- **Funções:**
+  ```rust
+  impl Cadence {
+      pub fn new(every: u32) -> Self;          // { every, counter: 0 }
+      pub fn tick(&mut self) -> bool;          // counter+=1; if counter>=every {counter=0; true} else {false}
+  }
+
+  impl<'c, 'a> CanaryProbe<'c, 'a> {
+      pub fn new(region: DeviceMem<'c, 'a>) -> Self; // wbuf/rbuf = vec![0u8; CANARY_BYTES], seq: 0
+      /// Um ciclo: fill(seq) -> write_at(0) -> read_at(0) -> verify(seq); cronometra o round-trip.
+      pub fn run(&mut self) -> Result<ProbeOutcome, CudaError>;
+  }
+  ```
+  `run` (passos exatos): `self.seq += 1`; `fill_block(&mut self.wbuf, self.seq, Pattern::Random)`;
+  `let t0 = std::time::Instant::now()`; `self.region.write_at(0, &self.wbuf)?`;
+  `self.region.read_at(0, &mut self.rbuf)?`; `let latency_us = t0.elapsed().as_micros() as u64`;
+  `let content_ok = verify_block(&self.rbuf, self.seq, Pattern::Random)`;
+  `Ok(ProbeOutcome { latency_us, content_ok })`.
+- **Dependências internas:** `ramshared-cuda`, `ramshared-integrity`.
+- **Padrão de referência:** `crates/ramshared-wsl2d/src/residency.rs` (lógica pura + testes).
+- **Testes requeridos** (`#[cfg(test)]` no próprio arquivo, sem GPU):
+  - `cadence_fires_every_n`: `Cadence::new(64)` → `tick()` retorna `true` exatamente no 64º.
+  - `cadence_resets`: após disparar, recomeça do zero.
+  - (round-trip real de `run()` é coberto por teste `--ignored` em `lib.rs`/composição — exige GPU.)
+
+## Arquivos a MODIFICAR
+
+### `crates/ramshared-wsl2d/Cargo.toml`
+
+- **O que muda:** adiciona dep de path `ramshared-integrity`.
+- **Requisitos:** DT-4.
+- **Antes:** deps = `ramshared-cuda`, `ramshared-block`, `ramshared-tier`.
+- **Depois:** + `ramshared-integrity = { path = "../ramshared-integrity" }`.
+- **Impacto:** nenhum (workspace path dep; sem dep externa).
+
+### `crates/ramshared-wsl2d/src/lib.rs`
+
+- **O que muda:** `pub mod canary_probe;` + re-export.
+- **Antes:** `pub mod backend; pub mod residency; pub mod state;` + re-exports.
+- **Depois:** + `pub mod canary_probe;` e `pub use canary_probe::{Cadence, CanaryProbe, ProbeOutcome, CANARY_BYTES, CANARY_EVERY};`.
+- **Impacto:** API de lib cresce (interna ao crate/bin); `forbid(unsafe_code)` mantido.
+
+### `crates/ramshared-wsl2d/src/residency.rs`
+
+- **O que muda:** `ResidencyConfig::default().free_floor_bytes` de `0` para `64 * 1024 * 1024` (DT-3).
+- **Requisitos:** RF-4.
+- **Antes:** `free_floor_bytes: 0,`
+- **Depois:** `free_floor_bytes: 64 * 1024 * 1024,`
+- **Impacto:** os testes existentes passam `free = u64::MAX` (não cruzam o floor) e o
+  `free_floor_demotes` fixa `1 << 30` explicitamente → **sem quebra**. Atualizar o
+  comentário do default.
+- **Testes requeridos:** os 5 existentes continuam verdes (rodar `cargo test -p ramshared-wsl2d`).
+
+### `crates/ramshared-wsl2d/src/main.rs`
+
+- **O que muda:** (a) alocar a região-canário; (b) construir `Cadence` + `CanaryProbe`;
+  (c) **substituir** o bloco de amostragem por latência de `serve()` pela sonda em
+  cadência, alimentando `(latency_us, content_ok, free)`; erro de sonda/`mem_info` ⇒
+  DEMOTE conservador (DT-5).
+- **Requisitos:** RF-3, RF-4, RF-5, RF-6, DT-5, DT-6.
+- **Função/bloco afetado:** `run()` — alocação após `let mut backend = ...` e o bloco do
+  serve loop que hoje faz `c.sample(lat_us, true, u64::MAX)`.
+- **Antes (resumo do estado atual):**
+  ```rust
+  // ... let mut backend = VramBackend::new(mem, BLOCK_SIZE);
+  // serve loop:
+  let touches_vram = matches!(req.cmd, Command::Read | Command::Write);
+  let t0 = std::time::Instant::now();
+  let out = serve(&req, &payload, &mut backend);
+  let lat_us = t0.elapsed().as_micros() as u64;
+  // ... escreve reply ... ; poll de demote_rx ...
+  if touches_vram && !demoted && demote_rx.is_none() {
+      match canary.as_mut() {
+          None => { baseline.push(lat_us); /* arma na 16ª */ }
+          Some(c) => { if let Verdict::Demote(reason) = c.sample(lat_us, true, u64::MAX) { /* spawn swapoff */ } }
+      }
+  }
+  ```
+- **Depois (decisões fechadas):**
+  - Após `backend`: `let canary_region = ctx.alloc(CANARY_BYTES)?;` e
+    `let mut probe = CanaryProbe::new(canary_region);` e `let mut cadence = Cadence::new(CANARY_EVERY);`.
+  - Remover a cronometragem de `serve()` como fonte do canário (o `serve()` continua,
+    sem `t0`/`lat_us` para o canário).
+  - O bloco de amostragem passa a:
+    ```rust
+    if touches_vram && !demoted && demote_rx.is_none() && cadence.tick() {
+        // DT-5: não conseguir medir residência ⇒ DEMOTE conservador.
+        let sample = match (probe.run(), ctx.mem_info()) {
+            (Ok(o), Ok((free, _total))) => Some((o.latency_us, o.content_ok, free as u64)),
+            _ => None, // erro CUDA ⇒ trata como Demote
+        };
+        let verdict = match (sample, canary.as_mut()) {
+            (Some((lat, ok, free)), None) => { /* baseline.push(lat); arma na 16ª */ Verdict::Ok }
+            (Some((lat, ok, free)), Some(c)) => c.sample(lat, ok, free),
+            (None, _) => Verdict::Demote(DemoteReason::Corruption), // conservador (DT-5)
+        };
+        if let Verdict::Demote(reason) = verdict {
+            // mesmo spawn de swapoff confirmado por canal já existente
+        }
+    }
+    ```
+    (A montagem exata do baseline e do `spawn` reusa o código atual; só a **fonte** da
+    amostra e o gate `cadence.tick()` mudam.)
+- **Por quê:** PRD RF-3/RF-4/RF-6 — ativa os 3 gatilhos a partir de uma sonda dedicada.
+- **Impacto:** sem uAPI/ABI; o `serve()` e o protocolo NBD não mudam; o caminho de
+  DEMOTE (swapoff + canal) é o mesmo.
+- **Testes requeridos:** `cargo test -p ramshared-wsl2d` (cadência + decisão);
+  `cargo clippy --workspace -D warnings`; re-rodar `cascade-validate.sh`/`cascade-demote.sh`
+  (sem regressão §14).
+  - **Disciplina Kahneman:** #5/#2 (DT-5 DEMOTE conservador) — ver Mapa acima.
+
+## Documentos a atualizar no mesmo commit do IMPL
+
+- `docs/008-vram-residency-canary/IMPL.md` (Passo 3).
+- `docs/vram-as-ram/SPECv3-WSL2.md` §9.4 → implementado.
+- `docs/vram-as-ram/IMPL.md`, `ARCHITECTURE.md` (limitação C1 resolvida), `MEMORY.md`.


### PR DESCRIPTION
## Resumo

Ataca o **C1** do #3 pela esteira **SSDV3**: gera o **PRD** (Passo 1) e o **SPEC** (Passo 2) do **canário de residência dedicado (§9.4)**. Hoje o canário inline alimenta `sample(lat, true, u64::MAX)` — os gatilhos `Demote(Corruption)`/`Demote(FreeFloor)` são código morto e a detecção repousa só num proxy de latência do `serve()`. O desenho fecha uma região-canário dedicada + sonda periódica (latência de round-trip fixo, conteúdo, free-floor), reusando `residency.rs` (decisão) e `ramshared-cuda`/`ramshared-integrity` (I/O+sentinela). **Sem implementação aqui** (Passo 3/IMPL é follow-up).

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `07f47ba` | PRD (14 seções + frontmatter, fato/proposta marcados) | Passo 1 do SSDV3 para a feature | <details><summary>detalhes</summary>**Arquivos:** docs/008-vram-residency-canary/PRD.md<br>**Validação:** segue estrutura do `ssdv3.md`; opção recomendada única; riscos R1–R4<br>**Risco/rollback:** nenhum (doc)</details> |
| `aa5a778` | SPEC cirúrgico (rastreabilidade RF→ITEM, DT-1..6, mapa Kahneman, arquivos a criar/modificar com assinaturas) | Passo 2 do SSDV3 a partir do PRD | <details><summary>detalhes</summary>**Arquivos:** docs/008-vram-residency-canary/SPEC.md<br>**Validação:** decisões fechadas (CANARY_BYTES/EVERY, free_floor default, sentinela via ramshared-integrity, DEMOTE conservador); fronteira de atomicidade + rollback app-only<br>**Risco/rollback:** nenhum (doc)</details> |

## Issue

Parte de #8 (Passo 1 PRD + Passo 2 SPEC). Relaciona #3 (C1). **Não fecha** #8 — o IMPL (Passo 3) é o próximo passo.

## Responsavel

@emersonbusson

## Labels

`type:docs`, `area:core`

## Validacao

- [x] PRD com as 14 seções do `ssdv3.md` + frontmatter (slug/title/issues)
- [x] SPEC com rastreabilidade por RF, DTs, mapa Kahneman e arquivos com assinaturas exatas
- [x] Reuso provado (residency.rs, ramshared-cuda, ramshared-integrity) — sem API nova desnecessária
- [ ] N/A: `checkpatch.pl`/`make modules`/`cargo` (sem código nesta PR)

## Rollback trigger

- Nenhum gatilho operacional (planejamento). Se o Passo 2.5 (auditoria) der `no-go`, gerar `SPECv2.md` preservando o `SPEC.md`.
