### PR TITLE
feat(mm): dedicated residency canary (§9.4) with hysteresis sampler (#8)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,7 +88,8 @@ Aceitação §14 no sistema vivo (cgroup-confined): spill de **511 MiB** para a 
 
 ## Limitações conhecidas (rastreadas)
 
-- Canário inline usa **só latência** (WDDM é data-safe). Conteúdo/free-floor exigem o
-  canário dedicado §9.4 — issue #3 (C1).
+- **Canário §9.4 dedicado** (conteúdo + free-floor com histerese, `ResidencySampler`):
+  **implementado** — issue #8 (C1 resolvido). Latência por-request segue como gatilho
+  primário; conteúdo demove imediato, free-floor/erro transiente exigem streak.
 - Serve loop **serial** (1 conexão = a vida do swap); o read-back do DEMOTE não tem
   leitor dedicado — issue #3 (H1).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,5 +32,6 @@ version = "0.1.0"
 dependencies = [
  "ramshared-block",
  "ramshared-cuda",
+ "ramshared-integrity",
  "ramshared-tier",
 ]

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -124,3 +124,25 @@ Atacando a issue #3 (follow-up da revisao adversarial) via PRs gated (CI + gover
   detecta pressao GPU-wide (indicador antecedente), nao a evicção da nossa regiao; DT-12
   zera a regiao-canario no teardown. SPEC.md/SPECv2.md preservados.
 - **Candidato ativo: SPECv3.md; re-auditoria = go.** Pendente: Passo 3 (IMPL). #8 aberta.
+
+---
+
+## 2026-06-05 — vram-as-ram: canario #8 — Passo 3 (IMPL do SPECv3)
+
+- **Passo 3 do SPECv3 implementado** (canário §9.4 dedicado). `ResidencySampler` puro
+  com histerese: corrupção de conteúdo (`Some(false)`) demove **imediato**; free-floor
+  e amostras degradadas (erro de sonda/`mem_info` = `None`) entram no `bad_streak`, só
+  demovem em `>= consecutive` (default 3). `free_floor_bytes` default 0 → 64 MiB (DT-3).
+- **Arquivos:** novo `crates/ramshared-wsl2d/src/canary_probe.rs` (`Cadence` +
+  `CanaryProbe::check_content` + `zero`); `residency.rs` (+`ResidencySampler`, 4 testes);
+  `main.rs` (aloca região-canário separada, bloco de cadência, `spawn_swapoff` unificado
+  DT-8, `probe.zero()` no teardown DT-12); `lib.rs`/`Cargo.toml`. Latência por-request
+  **intacta** (RF-3 não regrediu).
+- **Validação:** `fmt`/`clippy --workspace -D warnings` limpos; `cargo test --workspace`
+  verde (wsl2d lib 15 ok + 1 GPU ignorado: 2 cadência + 4 `ResidencySampler` novos + 5
+  `Canary` intactos). **Pendente no rig (GPU+root):** `cascade-validate.sh`/
+  `cascade-demote.sh` em `/home/emdev/fase0/` (§14 sem regressão).
+- **Desvio do SPEC (não-ADR):** `.ok()`/`.ok().map()` no lugar do `match Ok/Err`
+  (`clippy::manual_ok_err` sob `-D warnings`); semântica idêntica, DT-11 preservada.
+- **C1 resolvido** (ARCHITECTURE). Docs: `docs/008-vram-residency-canary/IMPL.md`,
+  SPECv3-WSL2 §9.4, `docs/vram-as-ram/IMPL.md`. **Commit/PR pendente** (não commitado).

--- a/crates/ramshared-wsl2d/Cargo.toml
+++ b/crates/ramshared-wsl2d/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 ramshared-cuda = { path = "../ramshared-cuda" }
 ramshared-block = { path = "../ramshared-block" }
 ramshared-tier = { path = "../ramshared-tier" }
+ramshared-integrity = { path = "../ramshared-integrity" }
 
 [lints.clippy]
 unwrap_used = "deny"

--- a/crates/ramshared-wsl2d/src/canary_probe.rs
+++ b/crates/ramshared-wsl2d/src/canary_probe.rs
@@ -1,0 +1,107 @@
+//! Canário de residência dedicado (§9.4): região-canário separada da swap +
+//! sonda de conteúdo em cadência. **Lógica de I/O pura sobre a VRAM**: a decisão
+//! de DEMOTE (streak/histerese) vive no [`crate::residency::ResidencySampler`];
+//! a cronometragem de DEMOTE por latência segue por-request no daemon.
+//!
+//! SPEC: `docs/008-vram-residency-canary/SPECv3.md` (DT-1, DT-2, DT-4, DT-12).
+//! A `Cadence` é testável sem GPU; o round-trip real de [`CanaryProbe`] exige
+//! VRAM (coberto por teste `--ignored` na composição do daemon).
+
+use ramshared_cuda::{CudaError, DeviceMem};
+use ramshared_integrity::{Pattern, fill_block, verify_block};
+
+/// Tamanho do round-trip da sonda: 1 página (alinhado ao `BLOCK_SIZE`). DT-1.
+pub const CANARY_BYTES: usize = 4096;
+/// Cadência da sonda de conteúdo/free: 1 a cada `CANARY_EVERY` requests. DT-2.
+pub const CANARY_EVERY: u32 = 64;
+
+/// Cadência pura: dispara a cada `every` ticks e recomeça do zero.
+pub struct Cadence {
+    every: u32,
+    counter: u32,
+}
+
+impl Cadence {
+    pub fn new(every: u32) -> Self {
+        Self { every, counter: 0 }
+    }
+
+    /// Conta um tick; retorna `true` (e zera) quando completa `every`.
+    pub fn tick(&mut self) -> bool {
+        self.counter += 1;
+        if self.counter >= self.every {
+            self.counter = 0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Sonda da região-canário. Empresta o [`DeviceMem`] da região dedicada
+/// (separada da swap, **não endereçável** por NBD). Reusa as sentinelas
+/// reprodutíveis do `ramshared-integrity` (DT-4).
+pub struct CanaryProbe<'c, 'a> {
+    region: DeviceMem<'c, 'a>,
+    wbuf: Vec<u8>,
+    rbuf: Vec<u8>,
+    seq: u64,
+}
+
+impl<'c, 'a> CanaryProbe<'c, 'a> {
+    pub fn new(region: DeviceMem<'c, 'a>) -> Self {
+        Self {
+            region,
+            wbuf: vec![0u8; CANARY_BYTES],
+            rbuf: vec![0u8; CANARY_BYTES],
+            seq: 0,
+        }
+    }
+
+    /// Um ciclo de conteúdo: `fill(seq)` → `write_at(0)` → `read_at(0)` →
+    /// `verify(seq)`. O `seq` por ciclo também pega leitura stale. Retorna
+    /// `content_ok`; erro de CUDA é propagado (tratado como amostra degradada
+    /// pelo sampler, DT-11). A latência da sonda **não** é exportada (a detecção
+    /// por latência segue por-request no daemon).
+    pub fn check_content(&mut self) -> Result<bool, CudaError> {
+        self.seq += 1;
+        fill_block(&mut self.wbuf, self.seq, Pattern::Random);
+        self.region.write_at(0, &self.wbuf)?;
+        self.region.read_at(0, &mut self.rbuf)?;
+        Ok(verify_block(&self.rbuf, self.seq, Pattern::Random))
+    }
+
+    /// Zera a região-canário (teardown §11, DT-12). A região fica encapsulada
+    /// aqui, então o daemon delega o zero por este método.
+    pub fn zero(&mut self) -> Result<(), CudaError> {
+        self.region.zero()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cadence_fires_every_n() {
+        let mut cad = Cadence::new(64);
+        for _ in 0..63 {
+            assert!(!cad.tick(), "não deve disparar antes do 64º");
+        }
+        assert!(cad.tick(), "deve disparar no 64º tick");
+    }
+
+    #[test]
+    fn cadence_resets() {
+        let mut cad = Cadence::new(4);
+        for _ in 0..3 {
+            assert!(!cad.tick());
+        }
+        assert!(cad.tick()); // 4º → dispara e reseta
+        // recomeça do zero: mais 3 falsos antes do próximo disparo
+        for _ in 0..3 {
+            assert!(!cad.tick());
+        }
+        assert!(cad.tick());
+    }
+}

--- a/crates/ramshared-wsl2d/src/lib.rs
+++ b/crates/ramshared-wsl2d/src/lib.rs
@@ -4,9 +4,11 @@
 #![forbid(unsafe_code)]
 
 pub mod backend;
+pub mod canary_probe;
 pub mod residency;
 pub mod state;
 
 pub use backend::VramBackend;
-pub use residency::{Canary, DemoteReason, ResidencyConfig, Verdict};
+pub use canary_probe::{CANARY_BYTES, CANARY_EVERY, Cadence, CanaryProbe};
+pub use residency::{Canary, DemoteReason, ResidencyConfig, ResidencySampler, Verdict};
 pub use state::State;

--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -250,8 +250,11 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // --- teardown: zera a VRAM (§11) e remove o socket ---
-    backend.zero()?;
-    let _ = probe.zero(); // DT-12: zera tambem a regiao-canario (§11)
+    // DT-12/§11: zera as DUAS regioes (swap + canario) incondicionalmente. Um erro no
+    // zero do backend NAO pode pular o scrub do canario; tenta ambos e so' entao propaga.
+    let backend_zero = backend.zero();
+    let _ = probe.zero();
+    backend_zero?;
     let _ = std::fs::remove_file(path);
     eprintln!("[wsl2d] encerrado (VRAM zerada)");
     Ok(())

--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -4,8 +4,10 @@
 //! faz a fiação do kernel (os ioctls). Assim o daemon fica **sem `unsafe`** — o
 //! único `unsafe` do projeto vive isolado no `ramshared-cuda`.
 //!
-//! MVP/smoke: aloca a VRAM, serve **uma** conexão e sai. Sequência completa
-//! (`mlockall`, `oom_score_adj`, backoff, canário §9) entra nos próximos passos.
+//! MVP/smoke: aloca a VRAM, serve **uma** conexão e sai com `mlockall` +
+//! `oom_score_adj` (Disciplina 3) e o canário de residência §9 (latência
+//! por-request) + §9.4 (sonda dedicada de conteúdo/free em cadência). Multi-conexão
+//! e backoff seguem como trabalho futuro.
 
 use std::io::{BufReader, Read, Write};
 use std::os::unix::net::UnixListener;
@@ -14,7 +16,10 @@ use std::path::Path;
 use ramshared_block::protocol::{NBD_FLAG_HAS_FLAGS, NBD_FLAG_SEND_FLUSH, REQUEST_LEN};
 use ramshared_block::{BlockBackend, Command, parse_request, serve, server_handshake};
 use ramshared_cuda::Cuda;
-use ramshared_wsl2d::{Canary, ResidencyConfig, Verdict, VramBackend};
+use ramshared_wsl2d::{
+    CANARY_BYTES, CANARY_EVERY, Cadence, Canary, CanaryProbe, ResidencyConfig, ResidencySampler,
+    Verdict, VramBackend,
+};
 
 // Disciplina 3 (anti-deadlock): o daemon serve o swap, logo nao pode ser swapado.
 unsafe extern "C" {
@@ -109,6 +114,14 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         BLOCK_SIZE
     );
 
+    // --- canário dedicado de residência (§9.4): região separada da swap, NÃO
+    // endereçável por NBD (o device anunciado segue = região de swap). Alimenta a
+    // sonda de conteúdo/free em cadência (SPECv3 DT-1/DT-9). ---
+    let canary_region = ctx.alloc(CANARY_BYTES)?;
+    let mut probe = CanaryProbe::new(canary_region);
+    let mut cadence = Cadence::new(CANARY_EVERY);
+    let mut sampler = ResidencySampler::new(ResidencyConfig::default());
+
     // --- socket Unix ---
     let path = Path::new(&sock);
     let _ = std::fs::remove_file(path);
@@ -184,10 +197,11 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         }
-        // Canario inline (§9): mede a latencia do I/O da VRAM e dispara DEMOTE sob spike.
-        // content_ok=true e free=u64::MAX sao DE PROPOSITO: a eviction WDDM e' data-safe
-        // (Fase 0), entao a latencia e' o gatilho vivo aqui. O canario dedicado de
-        // conteudo/free-floor (§9.4) exige uma regiao-canario propria (trabalho futuro).
+        // Canario de latencia por-request (§9, gatilho PRIMARIO): mede a latencia do
+        // I/O da VRAM e dispara DEMOTE sob spike. content_ok=true e free=u64::MAX sao DE
+        // PROPOSITO aqui: a eviction WDDM e' data-safe mas latency-unsafe (Fase 0), entao
+        // a latencia e' o sinal vivo. Conteudo e free-floor sao cobertos pela sonda
+        // dedicada §9.4 logo abaixo (cadencia), nao por este bloco.
         if touches_vram && !demoted && demote_rx.is_none() {
             match canary.as_mut() {
                 None => {
@@ -206,19 +220,27 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                         );
                         // Thread separada (nao bloqueia o serve); o resultado volta pelo
                         // canal e so' entao decidimos desarmar (ver poll acima).
-                        let dev = nbd_dev.clone();
-                        let (tx, rx) = std::sync::mpsc::channel();
-                        std::thread::spawn(move || {
-                            let ok = std::process::Command::new("swapoff")
-                                .arg(&dev)
-                                .status()
-                                .map(|s| s.success())
-                                .unwrap_or(false);
-                            let _ = tx.send(ok);
-                        });
-                        demote_rx = Some(rx);
+                        demote_rx = Some(spawn_swapoff(&nbd_dev));
                     }
                 }
+            }
+        }
+        // Canario dedicado §9.4 (SPECv3): sonda de conteudo/free em cadencia.
+        // Conteudo corrompido demove imediato; free-floor e erros transientes exigem
+        // `consecutive` amostras (histerese, DT-9/DT-11). E' independente do streak de
+        // latencia por-request acima e so' roda quando nao ha DEMOTE em curso.
+        if touches_vram && !demoted && demote_rx.is_none() && cadence.tick() {
+            // DT-11: erro de sonda/`mem_info` vira amostra degradada (None), nao DEMOTE
+            // imediato — entra no streak como free baixo.
+            let content = probe.check_content().ok();
+            let free = ctx.mem_info().ok().map(|(f, _)| f as u64);
+            if let Verdict::Demote(reason) = sampler.sample(content, free) {
+                // M4: loga os valores reais (None = erro de sonda/meminfo) e o streak.
+                eprintln!(
+                    "[wsl2d] DEMOTE ({reason:?}) content={content:?} free={free:?} streak={} -> swapoff {nbd_dev}",
+                    sampler.bad_streak()
+                );
+                demote_rx = Some(spawn_swapoff(&nbd_dev));
             }
         }
         if out.disconnect {
@@ -229,7 +251,25 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     // --- teardown: zera a VRAM (§11) e remove o socket ---
     backend.zero()?;
+    let _ = probe.zero(); // DT-12: zera tambem a regiao-canario (§11)
     let _ = std::fs::remove_file(path);
     eprintln!("[wsl2d] encerrado (VRAM zerada)");
     Ok(())
+}
+
+/// Dispara `swapoff <dev>` numa thread separada (nao bloqueia o serve loop) e
+/// devolve o canal que confirma o resultado. Caminho unico de DEMOTE (DT-8):
+/// usado tanto pela latencia por-request quanto pela sonda em cadencia.
+fn spawn_swapoff(dev: &str) -> std::sync::mpsc::Receiver<bool> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let dev = dev.to_string();
+    std::thread::spawn(move || {
+        let ok = std::process::Command::new("swapoff")
+            .arg(&dev)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        let _ = tx.send(ok);
+    });
+    rx
 }

--- a/crates/ramshared-wsl2d/src/residency.rs
+++ b/crates/ramshared-wsl2d/src/residency.rs
@@ -21,7 +21,9 @@ impl Default for ResidencyConfig {
         Self {
             latency_mult: 8,
             consecutive: 3,
-            free_floor_bytes: 0,
+            // DT-3: piso de "GPU criticamente cheia". Conservador e tunável; com a
+            // histerese do `ResidencySampler` (DT-9) o risco de falso-positivo cai.
+            free_floor_bytes: 64 * 1024 * 1024,
         }
     }
 }
@@ -83,6 +85,54 @@ impl Canary {
     }
 }
 
+/// Amostrador da sonda dedicada (§9.4) com histerese. Diferente do [`Canary`]
+/// (latência por-request), este recebe conteúdo + free e decide:
+/// - corrupção confirmada (`content = Some(false)`) ⇒ DEMOTE **imediato** (raro,
+///   inequívoco; DT-9);
+/// - free abaixo do piso **OU** amostra degradada (erro de sonda/`mem_info`) ⇒
+///   incrementa `bad_streak`; só demove em `bad_streak >= consecutive` (DT-9/DT-11);
+/// - amostra boa zera o streak.
+///
+/// SPEC: `docs/008-vram-residency-canary/SPECv3.md` DT-9/DT-10/DT-11.
+pub struct ResidencySampler {
+    cfg: ResidencyConfig,
+    bad_streak: u32,
+}
+
+impl ResidencySampler {
+    pub fn new(cfg: ResidencyConfig) -> Self {
+        Self { cfg, bad_streak: 0 }
+    }
+
+    /// Alimenta uma amostra da sonda em cadência.
+    /// - `content`: `Some(true)` = ok, `Some(false)` = corrupção (imediato),
+    ///   `None` = erro de sonda (degradada, DT-11).
+    /// - `free`: `Some(bytes)` ou `None` (erro de `mem_info`, degradada, DT-11).
+    pub fn sample(&mut self, content: Option<bool>, free: Option<u64>) -> Verdict {
+        // Corrupção é o único gatilho imediato: raro e inequívoco.
+        if content == Some(false) {
+            return Verdict::Demote(DemoteReason::Corruption);
+        }
+        // Sinal fraco/transiente: free baixo, erro de sonda ou erro de mem_info.
+        let degraded = content.is_none()
+            || free.is_none()
+            || free.is_some_and(|f| f < self.cfg.free_floor_bytes);
+        if degraded {
+            self.bad_streak += 1;
+            if self.bad_streak >= self.cfg.consecutive {
+                return Verdict::Demote(DemoteReason::FreeFloor);
+            }
+        } else {
+            self.bad_streak = 0; // amostra boa zera o streak (anti falso-positivo)
+        }
+        Verdict::Ok
+    }
+
+    pub fn bad_streak(&self) -> u32 {
+        self.bad_streak
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -141,5 +191,69 @@ mod tests {
         for _ in 0..100 {
             assert_eq!(c.sample(3500, true, u64::MAX), Verdict::Ok);
         }
+    }
+}
+
+#[cfg(test)]
+mod sampler_tests {
+    use super::*;
+
+    fn sampler() -> ResidencySampler {
+        // default: consecutive=3, free_floor_bytes=64 MiB (DT-3).
+        ResidencySampler::new(ResidencyConfig::default())
+    }
+
+    // Kahneman ITEM-5 (#13 ilusão de validade): corrupção devolve dado errado
+    // apesar de "data-safe" → guarda que demove na hora, sem streak.
+    #[test]
+    fn corruption_is_immediate() {
+        let mut s = sampler();
+        assert_eq!(
+            s.sample(Some(false), Some(u64::MAX)),
+            Verdict::Demote(DemoteReason::Corruption)
+        );
+        assert_eq!(s.bad_streak(), 0); // corrupção não passa pelo streak
+    }
+
+    // Kahneman ITEM-6 (#5 worst-case): 1 leitura de free baixa é ruído; só
+    // `consecutive` baixas configuram pressão GPU-wide (DT-10).
+    #[test]
+    fn free_floor_needs_consecutive() {
+        let mut s = sampler();
+        let low = Some(8 * 1024 * 1024); // abaixo do piso de 64 MiB
+        assert_eq!(s.sample(Some(true), low), Verdict::Ok); // 1
+        assert_eq!(s.sample(Some(true), low), Verdict::Ok); // 2
+        assert_eq!(
+            s.sample(Some(true), low),
+            Verdict::Demote(DemoteReason::FreeFloor)
+        ); // 3 consecutivas
+    }
+
+    // Kahneman ITEM-6 (#5 worst-case): um erro CUDA/`mem_info` isolado não é
+    // perda de residência (DT-11) — conta para o streak, não demove sozinho.
+    #[test]
+    fn transient_error_needs_consecutive() {
+        let mut s = sampler();
+        assert_eq!(s.sample(None, Some(u64::MAX)), Verdict::Ok); // 1 (erro de sonda)
+        assert_eq!(s.sample(Some(true), None), Verdict::Ok); // 2 (erro de mem_info)
+        assert_eq!(
+            s.sample(None, None),
+            Verdict::Demote(DemoteReason::FreeFloor)
+        ); // 3 degradadas
+    }
+
+    #[test]
+    fn good_sample_resets_streak() {
+        let mut s = sampler();
+        let low = Some(8 * 1024 * 1024);
+        s.sample(Some(true), low); // degradada (1)
+        s.sample(Some(true), low); // degradada (2)
+        assert_eq!(s.bad_streak(), 2);
+        assert_eq!(s.sample(Some(true), Some(u64::MAX)), Verdict::Ok); // boa → reseta
+        assert_eq!(s.bad_streak(), 0);
+        // recomeça do 1: 2 degradadas não bastam para demover
+        assert_eq!(s.sample(Some(true), low), Verdict::Ok); // 1
+        assert_eq!(s.sample(Some(true), low), Verdict::Ok); // 2
+        assert_eq!(s.bad_streak(), 2);
     }
 }

--- a/docs/008-vram-residency-canary/IMPL.md
+++ b/docs/008-vram-residency-canary/IMPL.md
@@ -1,0 +1,76 @@
+# IMPL — Issue #8 — Canário de residência dedicado (§9.4)
+
+SPEC ativo: [`SPECv3.md`](SPECv3.md) (Passo 2.5 = `go` sobre o SPECv2; histerese).
+Implementa **estritamente** o SPECv3. Zero criatividade fora do escopo (SSDV3 #3).
+
+## Escopo entregue
+
+Canário dedicado §9.4: região-canário separada (não endereçável por NBD) +
+`ResidencySampler` com **histerese** (streak). Corrupção de conteúdo demove
+imediato; free-floor e erros transientes exigem `consecutive` amostras. A
+detecção por **latência por-request** (§9, gatilho primário) fica **intacta**.
+
+## Arquivos
+
+| Ação | Arquivo | Conteúdo | SPEC |
+|---|---|---|---|
+| CRIAR | `crates/ramshared-wsl2d/src/canary_probe.rs` | `Cadence` (pura) + `CanaryProbe::check_content` (round-trip + sentinela) + `zero()` (teardown) + consts | DT-1, DT-2, DT-4, DT-12 |
+| MOD | `crates/ramshared-wsl2d/Cargo.toml` | + dep `ramshared-integrity` | DT-4 |
+| MOD | `crates/ramshared-wsl2d/src/lib.rs` | `pub mod canary_probe;` + re-exports (`Cadence`, `CanaryProbe`, consts, `ResidencySampler`) | — |
+| MOD | `crates/ramshared-wsl2d/src/residency.rs` | `free_floor_bytes` 0→64 MiB; `ResidencySampler` (streak) + 4 testes | DT-3, DT-9, DT-11 |
+| MOD | `crates/ramshared-wsl2d/src/main.rs` | aloca `canary_region`; `probe`/`cadence`/`sampler`; `spawn_swapoff` (unificado); bloco de cadência; `probe.zero()` no teardown; corrige 2 comentários "§9.4 = futuro" | DT-8, DT-9, DT-10, DT-11, DT-12, M4 |
+
+## Rastreabilidade RF → entrega
+
+- **RF-1** (região-canário): `ctx.alloc(CANARY_BYTES)` em `main.rs`; `CanaryProbe`. DT-1.
+- **RF-2** (corrupção): `ResidencySampler::sample(content=Some(false), _)` ⇒ `Demote(Corruption)` **imediato**. DT-9.
+- **RF-3** (latência por-request): **inalterado** — o bloco de latência segue por-request (não regride §14).
+- **RF-4** (free-floor): `free < floor` ou amostra degradada ⇒ `bad_streak`; `>= consecutive` ⇒ `Demote(FreeFloor)`. DT-9/DT-10.
+- **RF-5** (sentinela/cadência): `Cadence(64)`; `fill_block`/`verify_block`, `idx = seq`. DT-2/DT-4.
+- **RF-6** (DEMOTE unificado): `spawn_swapoff` único para latência **e** sonda. DT-8.
+
+## Disciplina Kahneman (itens críticos)
+
+- **ITEM-5 — corrupção imediata (#13 ilusão de validade).** Pergunta: "e se a VRAM
+  devolver dado corrompido apesar de data-safe?" Evidência: `corruption_is_immediate`
+  (`Some(false)` → `Demote(Corruption)`, `bad_streak` não usado). Round-trip real em
+  GPU = teste `--ignored` (rig). É guarda; não dispara em operação sã.
+- **ITEM-6 — free-floor/erro transiente (#5 worst-case + #2 counterfactual).**
+  Pergunta: "1 leitura de free baixa / 1 erro CUDA é evicção iminente ou ruído?"
+  Evidência: `free_floor_needs_consecutive`, `transient_error_needs_consecutive`,
+  `good_sample_resets_streak` (1 amostra ruim → `Ok`; `consecutive` → `Demote`; boa
+  zera). **Rollback trigger:** DEMOTE por free-floor em operação normal (sem `vramhog`)
+  → subir `free_floor_bytes`/`consecutive` e reverter os commits (app-only).
+
+## Decisões pequenas (não pediram nova ADR / SPEC)
+
+- `probe.check_content().ok()` e `ctx.mem_info().ok().map(|(f,_)| f as u64)` no lugar do
+  `match { Ok => Some, Err => None }` do SPEC: idêntico em semântica (DT-11 preservada),
+  mas `clippy::manual_ok_err` falha sob `-D warnings`. A forma `.ok()` é a idiomática.
+- `CanaryProbe::zero()` (delega a `region.zero()`): a região fica **encapsulada** no
+  probe, então o teardown DT-12 usa `probe.zero()` — opção explicitamente prevista no SPEC.
+- Testes do `ResidencySampler` em `mod sampler_tests` separado: evita colisão de nome com
+  `Canary::good_sample_resets_streak` (mesmo nome, módulos distintos).
+- Corrigidos 2 comentários em `main.rs` que descreviam o §9.4 como "trabalho futuro"
+  (agora falsos): Day-0 não deixa texto enganoso adjacente à mudança.
+
+## Validação
+
+- `cargo fmt --all -- --check` — limpo.
+- `cargo clippy --workspace --all-targets -- -D warnings` — limpo.
+- `cargo test --workspace` — verde. `ramshared-wsl2d` lib: **15 passou** (2 cadência + 4
+  `ResidencySampler` novos + 5 `Canary` intactos + estado), **1 ignorado** (round-trip GPU);
+  workspace ~54 testes, 2 ignorados (GPU). Sem regressão nos 5 testes de `Canary`.
+- **Pendente no rig (GPU + root):** `cascade-validate.sh` / `cascade-demote.sh`
+  (`/home/emdev/fase0/`) — confirmar **sem regressão §14** (spill + DEMOTE ao vivo).
+
+## Atomicidade & rollback
+
+Cada ciclo de sonda é independente; o estado novo é `bad_streak` (in-memory, no daemon).
+DEMOTE (`swapoff`) atômico no kernel (caminho existente). **Rollback: app-only** (revert
+dos commits); sem migration/dados.
+
+## uAPI/ABI
+
+Sem mudança: `serve()`/protocolo NBD inalterados; o device anunciado segue = região de swap;
+a região-canário é separada e não endereçável.

--- a/docs/008-vram-residency-canary/IMPL.md
+++ b/docs/008-vram-residency-canary/IMPL.md
@@ -54,6 +54,26 @@ detecção por **latência por-request** (§9, gatilho primário) fica **intacta
 - Corrigidos 2 comentários em `main.rs` que descreviam o §9.4 como "trabalho futuro"
   (agora falsos): Day-0 não deixa texto enganoso adjacente à mudança.
 
+## Revisão adversarial pré-merge (3 lentes)
+
+Revisão em 3 lentes paralelas (correção · concorrência/recursos · conformidade-SPEC/Day-0),
+framing adversarial (#12). Conformidade **GO**, correção **GO**; a lente de concorrência
+apontou findings, triados:
+
+- **#6a (HIGH, CORRIGIDO):** o teardown fazia `backend.zero()?` e pulava o `probe.zero()`
+  em erro → região-canário não-zerada (viola §11/DT-12). **Fix:** zera as duas regiões
+  incondicionalmente e só então propaga o erro do backend.
+- **#5 (alloc do canário após `mlockall`) — watch-item, NÃO corrigido:** daemon é root e o
+  `cuMemcpy` do canário usa o mesmo staging já validado sob `MCL_FUTURE` no §14; reordenar
+  desviaria do SPEC ("Após backend"). A abort trigger do ITEM-6 ("DEMOTE em operação
+  normal → reverter") já cobre o risco; o rig (`cascade-validate`) é o árbitro.
+- **Pré-existentes (fora do escopo → follow-up):** thread de `swapoff` detached + teardown
+  sob disconnect (#2a); `swapoff` via `$PATH` (#2c); teardown pulado em erro de I/O no loop
+  (#6c). Não introduzidos aqui (só extraí `spawn_swapoff`); o §14 já validou o DEMOTE.
+- **Por design / spec-matching (NÃO corrigido):** `bad_streak`/`over_count` não resetam após
+  swapoff falho (retry rápido sob pressão persistente é aceitável); cadência pausa durante
+  DEMOTE in-flight; `streak=` no log de Corruption — todos batem com o texto do SPEC.
+
 ## Validação
 
 - `cargo fmt --all -- --check` — limpo.

--- a/docs/vram-as-ram/IMPL.md
+++ b/docs/vram-as-ram/IMPL.md
@@ -64,12 +64,14 @@ Implementa **estritamente** o `SPECv3-WSL2.md`. Zero criatividade fora do escopo
      páginas íntegras**, 0 falso-positivo do canário.
    - §14.4 DEMOTE: **481 MiB vivos** migraram da VRAM p/ VHDX via `swapoff` em 6 s,
      **384.000 páginas íntegras, 0 corrupção**, daemon serviu o read-back.
+6. ✅ **Canário §9.4 dedicado** (issue #8, 2026-06-05): região-canário separada +
+   `ResidencySampler` com histerese — corrupção demove imediato; free-floor/erro
+   transiente exigem `consecutive` amostras; latência por-request intacta. 4 testes
+   novos + 5 de `Canary` intactos; `clippy -D warnings` limpo. Detalhe em
+   [`docs/008-vram-residency-canary/IMPL.md`](../008-vram-residency-canary/IMPL.md).
 
 ### Refinamentos futuros (não bloqueiam Day-0)
 
-- Canário §9.4 **dedicado** (região-canário + checagem de conteúdo/free-floor): hoje
-  o wiring inline cobre o gatilho de latência (o dominante na Fase 0); conteúdo e
-  free-floor têm a lógica testada (`residency.rs`) mas exigem o sampler dedicado.
 - Multi-conexão no daemon (hoje serve 1 conexão = exatamente a vida do swap).
 
 ### Fase 0 (evidência que fundou o SPECv3)

--- a/docs/vram-as-ram/SPECv3-WSL2.md
+++ b/docs/vram-as-ram/SPECv3-WSL2.md
@@ -280,6 +280,14 @@ de saída sem perda de dado.
 Dado sobrevive (hash ok); latência 4K → 1,18 s sob VRAM cheia. Confirma (a) como o
 gatilho relevante e justifica o DEMOTE em vez de confiar na VRAM sob pressão.
 
+### 9.4 Canário dedicado de conteúdo/free-floor — implementado (issue #8)
+Os gatilhos (b)/(c) do §9.1 são sondados por uma região-canário dedicada (separada da
+swap, **não endereçável** por NBD) + amostrador com histerese (`ResidencySampler`):
+corrupção de conteúdo demove imediato; free-floor e erros transientes exigem
+`consecutive` amostras (anti falso-positivo, DT-9/DT-11). A latência por-request (a)
+segue como gatilho primário. Spec/Impl:
+[`docs/008-vram-residency-canary/`](../008-vram-residency-canary/).
+
 ## 10. Tiers e backends
 
 - **zram:** `ramshared-tier/zram.rs` (criar, dimensionar, mkswap, swapon 200,


### PR DESCRIPTION
## Resumo

Passo 3 (SSDV3 IMPL) do **canário de residência dedicado §9.4** (issue #8), sobre o
daemon `ramshared-wsl2d`. Implementa o `SPECv3.md` (Passo 2.5 = `go`): adiciona um
amostrador com **histerese** (`ResidencySampler`) para os gatilhos de **conteúdo** e
**free-floor**, sem mexer na detecção por **latência por-request** (§9, gatilho
primário, validada no §14).

- **Conteúdo corrompido** (`Some(false)`) → DEMOTE **imediato** (raro, inequívoco).
- **Free abaixo do piso** (default 64 MiB) **ou amostra degradada** (erro de
  sonda/`mem_info` = `None`) → entra no `bad_streak`; só demove em `>= consecutive`
  (default 3). Corrige o no-go do SPECv2 (free-floor/erro transiente demoviam no
  single-sample, sem histerese).
- **DT-10:** no GPU-PV o free-floor é indicador *antecedente* de pressão GPU-wide, não a
  evicção direta da nossa região — sinal secundário; a latência segue primária.
- Região-canário **separada** (não endereçável por NBD), zerada no teardown (DT-12);
  DEMOTE unificado em `spawn_swapoff` (DT-8); log distingue gatilho real de erro (M4).

Rollback **app-only** (revert dos commits); sem migration/dados; sem uAPI/ABI.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `e808daa` | Canário §9.4 dedicado + `ResidencySampler` com histerese | Ativar os gatilhos de conteúdo/free-floor (§9.3 b/c) sem regredir a latência por-request (§14) | <details><summary>detalhes</summary>**Arquivos:** novo `crates/ramshared-wsl2d/src/canary_probe.rs` (Cadence + CanaryProbe::check_content + zero); `residency.rs` (+ResidencySampler, DT-3 default 64 MiB, 4 testes); `main.rs` (aloca região-canário, bloco de cadência, spawn_swapoff DT-8, probe.zero() DT-12, M4); `lib.rs`/`Cargo.toml` (+ramshared-integrity). Docs: `docs/008-vram-residency-canary/IMPL.md`, SPECv3-WSL2 §9.4, `docs/vram-as-ram/IMPL.md`, ARCHITECTURE (C1 resolvido), MEMORY.<br>**Rastreabilidade:** RF-1, RF-2, RF-4, RF-5, RF-6; DT-3, DT-8, DT-9, DT-10, DT-11, DT-12, M4.<br>**Validação:** fmt/clippy --workspace -D warnings limpos; cargo test --workspace verde (wsl2d lib 15 ok + 1 GPU ignorado: 2 cadência + 4 ResidencySampler + 5 Canary intactos).<br>**Desvio não-ADR:** `.ok()`/`.ok().map()` no lugar do `match Ok/Err` (clippy::manual_ok_err sob -D warnings); semântica idêntica, DT-11 preservada.<br>**Risco/rollback:** app-only (revert); sem uAPI/ABI; latência por-request intacta.</details> |
| `1beb0c7` | Teardown zera a região-canário mesmo se `backend.zero()` falhar | Fix da revisão adversarial pré-merge (#6a): o `?` pulava o scrub do canário em erro → violava §11/DT-12 | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-wsl2d/src/main.rs` (teardown), `docs/008-vram-residency-canary/IMPL.md` (triagem da revisão).<br>**O quê:** zera as duas regiões (swap + canário) incondicionalmente e só então propaga o erro do backend.<br>**Validação:** clippy -D warnings limpo; 15 testes verdes; sem mudança no caminho feliz.<br>**Rastreabilidade:** DT-12, §11.<br>**Risco/rollback:** fortalece um scrub existente; reverter = voltar ao early-return que pulava o canário.</details> |

## Issue

Closes #8

## Responsavel

@emersonbusson

## Labels

`type:feat`, `area:core`, `area:mm`

## Validacao

- [x] `cargo fmt --all -- --check` — limpo
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — limpo
- [x] `cargo test --workspace` — verde (wsl2d lib 15 ok / 1 GPU ignorado; workspace ~54 ok / 2 GPU ignorados)
- [x] **Revisão adversarial pré-merge** (3 lentes: correção / concorrência / conformidade-SPEC): conformidade GO, correção GO; 1 finding HIGH corrigido (#6a, teardown). Watch-item #5 (alloc do canário após `mlockall`) deferido ao rig; pré-existentes (#2a/#2c/#6c) → follow-up. Triagem em `IMPL.md`.
- [ ] **Rig (GPU + root):** `cascade-validate.sh` (§14.3 spill) + `cascade-demote.sh` (§14.4 DEMOTE) — sem regressão; **pendente** (gate de merge)
- [ ] (opcional) `cargo test -p ramshared-wsl2d -- --ignored` — round-trip da sonda em GPU real

## Rollback trigger

DEMOTE por **free-floor** disparando em operação normal (sem `vramhog`/pressão GPU real)
por `>= consecutive` amostras = falso-positivo: subir `free_floor_bytes` e/ou
`consecutive` (`ResidencyConfig`) e reverter os commits (app-only). O gatilho de
**corrupção** disparando em operação sã (não deve — é guarda) → investigar o driver CUDA
antes de relaxar limiares.
