### PR TITLE
feat(core): daemon multi-conn (H1) + hardening + typed errors + Fase B specs (#3)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -91,5 +91,6 @@ Aceitação §14 no sistema vivo (cgroup-confined): spill de **511 MiB** para a 
 - **Canário §9.4 dedicado** (conteúdo + free-floor com histerese, `ResidencySampler`):
   **implementado** — issue #8 (C1 resolvido). Latência por-request segue como gatilho
   primário; conteúdo demove imediato, free-floor/erro transiente exigem streak.
-- Serve loop **serial** (1 conexão = a vida do swap); o read-back do DEMOTE não tem
-  leitor dedicado — issue #3 (H1).
+- **H1 resolvido (multi-conexão):** worker CUDA único + leitor/escritor por conexão
+  (`nbd-client -C N`, `NBD_FLAG_CAN_MULTI_CONN`); sem head-of-line blocking. Ver
+  `docs/daemon-multiconn/`.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -146,3 +146,27 @@ Atacando a issue #3 (follow-up da revisao adversarial) via PRs gated (CI + gover
   (`clippy::manual_ok_err` sob `-D warnings`); semântica idêntica, DT-11 preservada.
 - **C1 resolvido** (ARCHITECTURE). Docs: `docs/008-vram-residency-canary/IMPL.md`,
   SPECv3-WSL2 §9.4, `docs/vram-as-ram/IMPL.md`. **Commit/PR pendente** (não commitado).
+
+---
+
+## 2026-06-05 — next-fronts (#3): H1 multi-conn + hardening + typed errors + Fase B specs
+
+Branch `feat/next-fronts-ssdv3` — 5 itens via esteira SSDV3, **um PR só**. Validado ao vivo (RTX 2060).
+- **H1 — daemon NBD multi-conexão** (`feat(core)`): laço serial → acceptor + leitor/escritor por
+  conexão + **worker CUDA único** (afinidade por `!Send`); canal `WMsg` (backpressure) + réplica
+  ilimitada (sem deadlock); `LiveCount` (término determinístico); `CAN_MULTI_CONN`. Esteira
+  PRD→SPEC→SPECv2→SPECv3 (2 no-go: lifecycle não-determinístico; válvula backpressure).
+  **Lição forte (IMPL→SPEC, Kahneman #13):** o §14.3 ao vivo mostrou que medir **latência total**
+  (espera na fila, DT-16) dava **falso-positivo de DEMOTE** sob carga (nbd0 511→10 MiB); revertido
+  p/ **serve-only**; SPECv3 atualizado. Auditoria teórica não pegou — só o teste vivo.
+- **Hardening** (`fix(core)`): `/usr/sbin/swapoff` absoluto (#2c); #2a/#6c resolvidos pelo H1
+  (teardown DT-17 + threads por-conexão); #5 (mlockall) validado ao vivo.
+- **Typed errors** (`refactor(core)`): `CascadeError` (zero-dep, padrão `CudaError`); **clap
+  rejeitado** (seria a 1ª dep externa num projeto zero-dep/Ring-0) → registrado em LIBRARIES.md (#11).
+- **Fase B (kernel-gated, DESIGN-ONLY):** `docs/zram-writeback-vram/` + `docs/ublk-backend/` —
+  esteira até SPECv2 (go). WSL2 sem `CONFIG_ZRAM_WRITEBACK`/`CONFIG_BLK_DEV_UBLK` (verificado).
+  zram-writeback ingênuo **rejeitado** (reentrância sob reclaim + DEMOTE sem drenagem) → kernel-side
+  ou manter 2-tier; ublk threading corrigido (ring = 1 thread) + unsafe-vs-crate ao ADR. IMPL adiada.
+- **Validação:** fmt/clippy --workspace -D warnings limpos; `cargo test --workspace` 61/0/2-GPU;
+  §14.3 511 MiB/332.800 páginas; §14.4 480 MiB/384.000 páginas/0 corrupção; `-C 2` 2 conns íntegro.
+- **C1+H1 = feito** (ROADMAP/ARCHITECTURE). PR único pendente.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,12 +18,11 @@ O caminho executável hoje é o **WSL2**; o destino é o **ring 0 bare-metal**
 
 ## Agora — issue #3 (Fase A, WSL2)
 
-- **C1 — canário dedicado (§9.4):** região-canário com checagem de **conteúdo**
-  (sentinela write/read) e **free-floor** (`cuMemGetInfo` periódico), ativando
-  `Demote(Corruption)`/`Demote(FreeFloor)` além da latência. _Em esteira SSDV3
-  (PRD → SPEC)._
-- **H1 — daemon multi-thread / leitor dedicado:** servir o NBD sem
-  head-of-line-blocking, encurtando a janela do DEMOTE sob eviction.
+- **C1 — canário dedicado (§9.4):** ✅ **feito** — `ResidencySampler` com histerese
+  (conteúdo imediato; free-floor/erro transiente com streak). Ver `docs/008-vram-residency-canary/`.
+- **H1 — daemon multi-conexão / leitor dedicado:** ✅ **feito** — worker CUDA único +
+  leitor/escritor por conexão (`nbd-client -C N`, `CAN_MULTI_CONN`); sem head-of-line
+  blocking. Ver `docs/daemon-multiconn/`.
 - **LOW:** erros tipados (enum) no daemon/cascade; `clap` no parse de args.
 
 ## Fase B — kernel custom (WSL2 + kernel próprio)

--- a/crates/ramshared-block/src/protocol.rs
+++ b/crates/ramshared-block/src/protocol.rs
@@ -12,6 +12,11 @@ pub const NBD_FLAG_NO_ZEROES: u16 = 1 << 1;
 // Flags de transmissão (export).
 pub const NBD_FLAG_HAS_FLAGS: u16 = 1 << 0;
 pub const NBD_FLAG_SEND_FLUSH: u16 = 1 << 2;
+/// Multi-conexão segura (H1). Só é seguro anunciar porque a WRITE é durável no ack
+/// (`cuMemcpyHtoD` síncrono) + o worker CUDA único serializa: um FLUSH em qualquer
+/// conexão cobre todas as WRITEs já ackadas. NÃO trocar para cópia assíncrona sem
+/// revisar este contrato. SPEC: docs/daemon-multiconn/SPECv3.md DT-10.
+pub const NBD_FLAG_CAN_MULTI_CONN: u16 = 1 << 8;
 
 // Transmissão.
 pub const NBD_REQUEST_MAGIC: u32 = 0x2560_9513;

--- a/crates/ramshared-cli/src/cascade.rs
+++ b/crates/ramshared-cli/src/cascade.rs
@@ -76,6 +76,7 @@ struct UpArgs {
     zram_mb: u64,
     daemon: String,
     force: bool,
+    connections: u32,
 }
 
 fn parse_up_args() -> Result<UpArgs, String> {
@@ -84,6 +85,7 @@ fn parse_up_args() -> Result<UpArgs, String> {
         zram_mb: 1024,
         daemon: default_daemon(),
         force: false,
+        connections: 1,
     };
     let args: Vec<String> = std::env::args().skip(2).collect(); // pula "ramshared up"
     let mut i = 0;
@@ -108,6 +110,17 @@ fn parse_up_args() -> Result<UpArgs, String> {
             "--daemon" => {
                 i += 1;
                 a.daemon = args.get(i).ok_or("--daemon requer caminho")?.clone();
+            }
+            "--connections" => {
+                i += 1;
+                a.connections = args
+                    .get(i)
+                    .ok_or("--connections requer N")?
+                    .parse()
+                    .map_err(|_| "connections invalido")?;
+                if a.connections == 0 {
+                    return Err("--connections deve ser >= 1".into());
+                }
             }
             "--force-no-safety-net" => a.force = true,
             other => return Err(format!("arg desconhecido: {other}")),
@@ -187,10 +200,20 @@ pub fn up() -> Result<(), String> {
     if !ok {
         return Err("daemon nao subiu (socket ausente)".into());
     }
-    sh("nbd-client", &["-unix", SOCK, NBD])?;
+    // H1: multi-conexão (-C N) só quando N>1; o daemon é N-agnóstico (aceita o que vier).
+    let conns = a.connections.to_string();
+    let mut nbd_args: Vec<&str> = Vec::new();
+    if a.connections > 1 {
+        nbd_args.extend(["-C", conns.as_str()]);
+    }
+    nbd_args.extend(["-unix", SOCK, NBD]);
+    sh("nbd-client", &nbd_args)?;
     sh("mkswap", &["-L", "RAMSHARED", NBD])?;
     sh("swapon", &["-p", &prios.vram.to_string(), NBD])?;
-    eprintln!("[up] VRAM {NBD} (prio {}, {} MiB)", prios.vram, a.vram_mb);
+    eprintln!(
+        "[up] VRAM {NBD} (prio {}, {} MiB, {} conexão(ões))",
+        prios.vram, a.vram_mb, a.connections
+    );
     eprintln!(
         "[up] cascata ativa: zram({}) > VRAM({}) > VHDX",
         prios.zram, prios.vram

--- a/crates/ramshared-cli/src/cascade.rs
+++ b/crates/ramshared-cli/src/cascade.rs
@@ -3,6 +3,7 @@
 //! `swapoff` **antes** de desconectar o NBD (anti-panic).
 
 use ramshared_tier::{TierPriorities, validate_order, vram_safety_net};
+use std::fmt;
 use std::fs;
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -13,19 +14,49 @@ const SOCK: &str = "/run/ramshared/wsl2d.sock";
 const NBD: &str = "/dev/nbd0";
 const ZRAM_DEV_FILE: &str = "/run/ramshared/zram-dev";
 
-fn sh(cmd: &str, args: &[&str]) -> Result<String, String> {
+/// Erro tipado da orquestração da cascata (sem dep externa — segue o padrão do
+/// `CudaError`: enum + `Display` + `Error`). Zero-criatividade: variantes mapeiam os
+/// modos de falha reais (comando externo, argumento, I/O, pré-condição).
+#[derive(Debug)]
+pub enum CascadeError {
+    /// Comando externo falhou (spawn ou status != 0).
+    Shell { cmd: String, msg: String },
+    /// Argumento de CLI inválido.
+    Arg(String),
+    /// Erro de I/O (fs / `/proc`).
+    Io(String),
+    /// Pré-condição da cascata violada (ordem de tiers, rede A1, device, daemon).
+    Precondition(String),
+}
+
+impl fmt::Display for CascadeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CascadeError::Shell { cmd, msg } => write!(f, "comando `{cmd}` falhou: {msg}"),
+            CascadeError::Arg(m) => write!(f, "argumento inválido: {m}"),
+            CascadeError::Io(m) => write!(f, "I/O: {m}"),
+            CascadeError::Precondition(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+impl std::error::Error for CascadeError {}
+
+fn sh(cmd: &str, args: &[&str]) -> Result<String, CascadeError> {
     let out = Command::new(cmd)
         .args(args)
         .output()
-        .map_err(|e| format!("{cmd}: {e}"))?;
+        .map_err(|e| CascadeError::Shell {
+            cmd: cmd.to_string(),
+            msg: e.to_string(),
+        })?;
     if out.status.success() {
         Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
     } else {
-        Err(format!(
-            "`{cmd} {}` falhou: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&out.stderr).trim()
-        ))
+        Err(CascadeError::Shell {
+            cmd: format!("{cmd} {}", args.join(" ")),
+            msg: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        })
     }
 }
 
@@ -79,7 +110,7 @@ struct UpArgs {
     connections: u32,
 }
 
-fn parse_up_args() -> Result<UpArgs, String> {
+fn parse_up_args() -> Result<UpArgs, CascadeError> {
     let mut a = UpArgs {
         vram_mb: 1024,
         zram_mb: 1024,
@@ -95,61 +126,64 @@ fn parse_up_args() -> Result<UpArgs, String> {
                 i += 1;
                 a.vram_mb = args
                     .get(i)
-                    .ok_or("--vram requer MiB")?
+                    .ok_or_else(|| CascadeError::Arg("--vram requer MiB".into()))?
                     .parse()
-                    .map_err(|_| "vram invalido")?;
+                    .map_err(|_| CascadeError::Arg("vram invalido".into()))?;
             }
             "--zram" => {
                 i += 1;
                 a.zram_mb = args
                     .get(i)
-                    .ok_or("--zram requer MiB")?
+                    .ok_or_else(|| CascadeError::Arg("--zram requer MiB".into()))?
                     .parse()
-                    .map_err(|_| "zram invalido")?;
+                    .map_err(|_| CascadeError::Arg("zram invalido".into()))?;
             }
             "--daemon" => {
                 i += 1;
-                a.daemon = args.get(i).ok_or("--daemon requer caminho")?.clone();
+                a.daemon = args
+                    .get(i)
+                    .ok_or_else(|| CascadeError::Arg("--daemon requer caminho".into()))?
+                    .clone();
             }
             "--connections" => {
                 i += 1;
                 a.connections = args
                     .get(i)
-                    .ok_or("--connections requer N")?
+                    .ok_or_else(|| CascadeError::Arg("--connections requer N".into()))?
                     .parse()
-                    .map_err(|_| "connections invalido")?;
+                    .map_err(|_| CascadeError::Arg("connections invalido".into()))?;
                 if a.connections == 0 {
-                    return Err("--connections deve ser >= 1".into());
+                    return Err(CascadeError::Arg("--connections deve ser >= 1".into()));
                 }
             }
             "--force-no-safety-net" => a.force = true,
-            other => return Err(format!("arg desconhecido: {other}")),
+            other => return Err(CascadeError::Arg(format!("arg desconhecido: {other}"))),
         }
         i += 1;
     }
     Ok(a)
 }
 
-pub fn up() -> Result<(), String> {
+pub fn up() -> Result<(), CascadeError> {
     let a = parse_up_args()?;
     let prios = TierPriorities::default();
-    validate_order(prios).map_err(|e| e.to_string())?;
+    validate_order(prios).map_err(|e| CascadeError::Precondition(e.to_string()))?;
 
     // A1 — rede de segurança do DEMOTE (precisa de um tier abaixo da VRAM).
     let vram_bytes = a
         .vram_mb
         .checked_mul(1024 * 1024)
-        .ok_or("--vram: overflow (MiB grande demais)")?;
+        .ok_or_else(|| CascadeError::Arg("--vram: overflow (MiB grande demais)".into()))?;
     let net = vram_safety_net(lower_tier_present(), mem_available_bytes(), vram_bytes);
     if !net.is_safe() && !a.force {
-        return Err(
+        return Err(CascadeError::Precondition(
             "sem rede de seguranca p/ DEMOTE (sem VHDX e RAM insuficiente); \
              use --force-no-safety-net se intencional"
                 .into(),
-        );
+        ));
     }
     eprintln!("[up] rede de seguranca A1: {net:?}");
-    fs::create_dir_all("/run/ramshared").map_err(|e| e.to_string())?;
+    fs::create_dir_all("/run/ramshared").map_err(|e| CascadeError::Io(e.to_string()))?;
 
     // Tier zram (HOT, prio alta).
     sh("modprobe", &["zram", "num_devices=1"])?;
@@ -166,11 +200,13 @@ pub fn up() -> Result<(), String> {
     // M5: zramctl deveria devolver /dev/zramN; valida antes de passar a cmds privilegiados.
     if !matches!(zdev.strip_prefix("/dev/zram"), Some(s) if !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()))
     {
-        return Err(format!("zramctl retornou device inesperado: {zdev}"));
+        return Err(CascadeError::Precondition(format!(
+            "zramctl retornou device inesperado: {zdev}"
+        )));
     }
     sh("mkswap", &[&zdev])?;
     sh("swapon", &["-p", &prios.zram.to_string(), &zdev])?;
-    fs::write(ZRAM_DEV_FILE, &zdev).map_err(|e| e.to_string())?;
+    fs::write(ZRAM_DEV_FILE, &zdev).map_err(|e| CascadeError::Io(e.to_string()))?;
     eprintln!("[up] zram {zdev} (prio {})", prios.zram);
 
     // Tier VRAM (COLD, prio média): daemon + nbd.
@@ -188,7 +224,10 @@ pub fn up() -> Result<(), String> {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
-        .map_err(|e| format!("spawn daemon ({}): {e}", a.daemon))?;
+        .map_err(|e| CascadeError::Shell {
+            cmd: a.daemon.clone(),
+            msg: e.to_string(),
+        })?;
     let mut ok = false;
     for _ in 0..120 {
         if Path::new(SOCK).exists() {
@@ -198,7 +237,9 @@ pub fn up() -> Result<(), String> {
         sleep(Duration::from_millis(50));
     }
     if !ok {
-        return Err("daemon nao subiu (socket ausente)".into());
+        return Err(CascadeError::Precondition(
+            "daemon nao subiu (socket ausente)".into(),
+        ));
     }
     // H1: multi-conexão (-C N) só quando N>1; o daemon é N-agnóstico (aceita o que vier).
     let conns = a.connections.to_string();
@@ -221,14 +262,16 @@ pub fn up() -> Result<(), String> {
     status()
 }
 
-pub fn down() -> Result<(), String> {
+pub fn down() -> Result<(), CascadeError> {
     // Anti-panic: se a VRAM estiver em swap, swapoff DEVE concluir antes do disconnect.
     let nbd_in_swap = fs::read_to_string("/proc/swaps")
         .map(|s| s.contains(NBD))
         .unwrap_or(false);
     if nbd_in_swap {
         sh("swapoff", &[NBD]).map_err(|e| {
-            format!("swapoff {NBD} falhou ({e}); NAO desconectando (risco de panic) — intervir")
+            CascadeError::Precondition(format!(
+                "swapoff {NBD} falhou ({e}); NAO desconectando (risco de panic) — intervir"
+            ))
         })?;
     }
     // zram tier
@@ -261,7 +304,7 @@ pub fn down() -> Result<(), String> {
     status()
 }
 
-pub fn status() -> Result<(), String> {
+pub fn status() -> Result<(), CascadeError> {
     println!("{}", sh("swapon", &["--show"])?);
     Ok(())
 }

--- a/crates/ramshared-cli/src/main.rs
+++ b/crates/ramshared-cli/src/main.rs
@@ -186,7 +186,7 @@ fn main() -> ExitCode {
     }
 }
 
-fn to_exit(r: Result<(), String>) -> ExitCode {
+fn to_exit<E: fmt::Display>(r: Result<(), E>) -> ExitCode {
     match r {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {

--- a/crates/ramshared-wsl2d/src/backend.rs
+++ b/crates/ramshared-wsl2d/src/backend.rs
@@ -44,6 +44,9 @@ impl BlockBackend for VramBackend<'_, '_> {
 
     fn flush(&mut self) -> Result<(), IoError> {
         // cuMemcpy*_v2 são síncronas (a referência usa o mesmo modelo); nada a drenar.
+        // A coerência multi-conexão (NBD_FLAG_CAN_MULTI_CONN, H1/DT-10) depende desta
+        // sincronicidade: WRITE durável no ack ⇒ FLUSH no-op ⇒ um FLUSH cobre todas as
+        // WRITEs ackadas. NÃO trocar `write_at` para cópia assíncrona sem revisar isto.
         Ok(())
     }
 }

--- a/crates/ramshared-wsl2d/src/conn.rs
+++ b/crates/ramshared-wsl2d/src/conn.rs
@@ -1,0 +1,323 @@
+//! Conexão NBD multi-conexão (§9.4 / H1): leitor e escritor dedicados por conexão,
+//! ligados ao **worker CUDA único** (em `main`) por canais. O leitor drena o socket
+//! e enfileira `Job`s; o worker processa (afinidade CUDA) e devolve `Reply`s pelo
+//! canal **ilimitado** de réplica da conexão; o escritor escreve no socket.
+//!
+//! SPEC: `docs/daemon-multiconn/SPECv3.md` (DT-7/DT-8/DT-15/DT-16). Desenho determinístico:
+//! `Opened` vem do acceptor (antes de spawnar o reader), `Closed` vem do reader (ao sair) —
+//! o worker conta `live` e encerra quando todas as conexões abertas fecham.
+
+use std::io::{BufReader, Read, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::sync::mpsc::{Receiver, Sender, SyncSender, channel};
+use std::thread::JoinHandle;
+
+use ramshared_block::protocol::SIMPLE_REPLY_LEN;
+use ramshared_block::{Command, Request, parse_request, protocol::REQUEST_LEN, server_handshake};
+
+/// Capacidade do canal de mensagens do worker (`WMsg`): **único** ponto de backpressure.
+/// O canal de réplica por conexão é ilimitado (DT-7), então o worker nunca bloqueia ao
+/// responder — só os leitores fazem backpressure ao enfileirar `Job`s.
+pub const CHAN_CAP: usize = 64;
+
+/// Um request a processar pelo worker CUDA, com a rota de réplica da conexão de origem.
+/// A latência do canário é medida no worker em volta do `serve()` (serve-only, DT-16
+/// revisado): medir a espera na fila causava falso-positivo de DEMOTE sob carga normal.
+pub struct Job {
+    pub req: Request,
+    pub payload: Vec<u8>,
+    pub reply: Sender<Reply>,
+}
+
+/// Resultado do `serve()` a escrever no socket da conexão. `reply` é o cabeçalho NBD
+/// de 16 bytes (array fixo `Copy`, sem alocação no hot path — DT-8).
+pub struct Reply {
+    pub reply: [u8; SIMPLE_REPLY_LEN],
+    pub data: Vec<u8>,
+    pub disconnect: bool,
+}
+
+/// Mensagem do canal do worker (DT-15). `Opened`/`Closed` controlam o término
+/// determinístico; `Job` é trabalho.
+pub enum WMsg {
+    Opened,
+    Job(Job),
+    Closed,
+}
+
+/// Contagem de conexões vivas no worker (DT-15). `Opened` (do acceptor) sempre precede
+/// `Closed` (do reader) por conexão, então `live` fica balanceado; o worker para quando
+/// todas as conexões abertas fecharam. Lógica pura (testável sem GPU/sockets).
+#[derive(Default)]
+pub struct LiveCount {
+    live: u32,
+    opened: bool,
+}
+
+impl LiveCount {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn on_open(&mut self) {
+        self.live += 1;
+        self.opened = true;
+    }
+
+    /// Registra o fechamento de uma conexão; retorna `true` quando **todas** as conexões
+    /// abertas já fecharam (o worker deve encerrar). `saturating_sub` evita underflow caso
+    /// um `Closed` chegue desbalanceado (não deve, mas é defensivo).
+    pub fn on_close(&mut self) -> bool {
+        self.live = self.live.saturating_sub(1);
+        self.live == 0 && self.opened
+    }
+
+    pub fn live(&self) -> u32 {
+        self.live
+    }
+}
+
+/// Thread escritora: drena `Reply`s e escreve no socket. Réplicas podem sair fora de
+/// ordem (cada uma carrega o `handle` NBD). Encerra em erro de socket, em `disconnect`,
+/// ou quando o canal fecha (leitor saiu e todas as réplicas foram drenadas).
+pub fn spawn_writer(stream: UnixStream, replies: Receiver<Reply>) -> JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut w = stream;
+        for r in replies.iter() {
+            if w.write_all(&r.reply).is_err() {
+                break;
+            }
+            if !r.data.is_empty() && w.write_all(&r.data).is_err() {
+                break;
+            }
+            if w.flush().is_err() {
+                break;
+            }
+            if r.disconnect {
+                break;
+            }
+        }
+    })
+}
+
+/// Thread leitora: faz o **handshake na própria thread** (DT-15 — erro de handshake fica
+/// confinado a esta conexão, não derruba o acceptor), depois lê requests e enfileira `Job`s.
+/// Ao sair (EOF/erro/handshake falho), envia `WMsg::Closed` para balancear o `Opened`.
+pub fn spawn_reader(
+    stream: UnixStream,
+    device_size: u64,
+    tx_flags: u16,
+    jobs: SyncSender<WMsg>,
+    reply_tx: Sender<Reply>,
+) -> JoinHandle<()> {
+    std::thread::spawn(move || {
+        // Handshake precisa de um handle de escrita separado do reader (full-duplex).
+        let mut hs_writer = match stream.try_clone() {
+            Ok(w) => w,
+            Err(e) => {
+                eprintln!("[wsl2d] conn: try_clone (handshake) falhou: {e}");
+                let _ = jobs.send(WMsg::Closed);
+                return;
+            }
+        };
+        let mut reader = BufReader::new(stream);
+        if let Err(e) = server_handshake(&mut reader, &mut hs_writer, device_size, tx_flags) {
+            eprintln!("[wsl2d] conn: handshake falhou: {e}");
+            let _ = jobs.send(WMsg::Closed);
+            return;
+        }
+        drop(hs_writer); // handshake concluído; daqui só o writer thread escreve réplicas.
+
+        let mut hdr = [0u8; REQUEST_LEN];
+        loop {
+            if reader.read_exact(&mut hdr).is_err() {
+                break; // EOF ou erro de socket
+            }
+            let req = match parse_request(&hdr) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("[wsl2d] conn: request malformado: {e}; desconectando");
+                    break;
+                }
+            };
+            // Anti-DoS: um WRITE nunca pode exceder o device (evita alocar gigabytes).
+            if req.cmd == Command::Write && req.len as u64 > device_size {
+                eprintln!(
+                    "[wsl2d] conn: WRITE len {} excede o device; desconectando",
+                    req.len
+                );
+                break;
+            }
+            let payload = if req.cmd == Command::Write {
+                let mut p = vec![0u8; req.len as usize];
+                if reader.read_exact(&mut p).is_err() {
+                    break;
+                }
+                p
+            } else {
+                Vec::new()
+            };
+            let job = Job {
+                req,
+                payload,
+                reply: reply_tx.clone(),
+            };
+            if jobs.send(WMsg::Job(job)).is_err() {
+                break; // worker encerrou
+            }
+        }
+        let _ = jobs.send(WMsg::Closed);
+    })
+}
+
+/// Thread acceptor: aceita conexões em laço infinito (N-agnóstico — `N` é só do
+/// `nbd-client -C N`). Por conexão: envia `WMsg::Opened` **antes** de spawnar o reader
+/// (balanço do `live`), cria o canal de réplica **ilimitado** (DT-7) e spawna writer + reader.
+pub fn spawn_acceptor(
+    listener: UnixListener,
+    device_size: u64,
+    tx_flags: u16,
+    jobs: SyncSender<WMsg>,
+) -> JoinHandle<()> {
+    std::thread::spawn(move || {
+        loop {
+            let stream = match listener.accept() {
+                Ok((s, _)) => s,
+                Err(e) => {
+                    eprintln!("[wsl2d] accept falhou: {e}");
+                    break;
+                }
+            };
+            let wstream = match stream.try_clone() {
+                Ok(w) => w,
+                Err(e) => {
+                    eprintln!("[wsl2d] try_clone (writer) falhou: {e}");
+                    continue;
+                }
+            };
+            // DT-15: Opened ANTES de spawnar o reader garante o balanço de `live`.
+            if jobs.send(WMsg::Opened).is_err() {
+                break; // worker encerrou
+            }
+            let (reply_tx, reply_rx) = channel::<Reply>(); // ilimitado (DT-7)
+            spawn_writer(wstream, reply_rx);
+            spawn_reader(stream, device_size, tx_flags, jobs.clone(), reply_tx);
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use std::sync::mpsc::sync_channel;
+
+    fn dummy_req() -> Request {
+        Request {
+            flags: 0,
+            cmd: Command::Read,
+            handle: 1,
+            offset: 0,
+            len: 0,
+        }
+    }
+
+    #[test]
+    fn job_reply_roundtrip() {
+        let (tx, _rx) = channel::<Reply>();
+        let job = Job {
+            req: dummy_req(),
+            payload: vec![1, 2, 3],
+            reply: tx,
+        };
+        assert_eq!(job.req.handle, 1);
+        assert_eq!(job.payload, vec![1, 2, 3]);
+        let rep = Reply {
+            reply: [0u8; SIMPLE_REPLY_LEN],
+            data: vec![9, 8, 7],
+            disconnect: false,
+        };
+        assert_eq!(rep.data, vec![9, 8, 7]);
+        assert!(!rep.disconnect);
+    }
+
+    #[test]
+    fn chan_cap_is_bounded() {
+        let (tx, _rx) = sync_channel::<u8>(2);
+        assert!(tx.try_send(1).is_ok());
+        assert!(tx.try_send(2).is_ok());
+        assert!(
+            tx.try_send(3).is_err(),
+            "deve recusar além do cap (backpressure)"
+        );
+    }
+
+    // DT-18 / F-3/F-5: término determinístico — para exatamente quando live==0.
+    #[test]
+    fn live_count_terminates_on_all_closed() {
+        let mut lc = LiveCount::new();
+        lc.on_open(); // live=1
+        lc.on_open(); // live=2
+        assert!(!lc.on_close(), "live=1 ainda"); // live=1
+        assert!(lc.on_close(), "live=0 + opened -> para"); // live=0
+    }
+
+    // DT-18 / F-6: handshake falho = Opened (acceptor) + Closed (reader) imediato; balanceado.
+    #[test]
+    fn live_count_balanced_open_then_close() {
+        let mut lc = LiveCount::new();
+        lc.on_open();
+        assert!(lc.on_close(), "1 conexão abriu e fechou -> para");
+    }
+
+    #[test]
+    fn live_count_never_stops_before_any_open() {
+        let mut lc = LiveCount::new();
+        assert!(!lc.on_close(), "sem Opened não para espuriamente");
+        assert_eq!(lc.live(), 0);
+    }
+
+    // DT-7 / DT-18: réplica ilimitada — worker progride mesmo com o writer parado.
+    // Se a réplica fosse limitada e o writer não drenasse, o worker bloquearia →
+    // canal de Jobs encheria → reader bloquearia → deadlock (este teste travaria).
+    #[test]
+    fn slow_writer_does_not_deadlock() {
+        let (jobs_tx, jobs_rx) = sync_channel::<WMsg>(2); // canal de Jobs pequeno
+        let (reply_tx, reply_rx) = channel::<Reply>(); // réplica ILIMITADA (DT-7)
+        let _writer_parado = reply_rx; // segura sem drenar (simula socket travado)
+
+        let worker = std::thread::spawn(move || {
+            let mut served = 0u32;
+            for m in jobs_rx.iter() {
+                if let WMsg::Job(job) = m {
+                    // worker nunca bloqueia: réplica ilimitada
+                    let _ = job.reply.send(Reply {
+                        reply: [0u8; SIMPLE_REPLY_LEN],
+                        data: Vec::new(),
+                        disconnect: false,
+                    });
+                    served += 1;
+                    if served >= 10 {
+                        break;
+                    }
+                }
+            }
+            served
+        });
+
+        for _ in 0..10 {
+            jobs_tx
+                .send(WMsg::Job(Job {
+                    req: dummy_req(),
+                    payload: Vec::new(),
+                    reply: reply_tx.clone(),
+                }))
+                .unwrap();
+        }
+        assert_eq!(
+            worker.join().unwrap(),
+            10,
+            "worker processou tudo sem deadlock"
+        );
+    }
+}

--- a/crates/ramshared-wsl2d/src/lib.rs
+++ b/crates/ramshared-wsl2d/src/lib.rs
@@ -5,10 +5,12 @@
 
 pub mod backend;
 pub mod canary_probe;
+pub mod conn;
 pub mod residency;
 pub mod state;
 
 pub use backend::VramBackend;
 pub use canary_probe::{CANARY_BYTES, CANARY_EVERY, Cadence, CanaryProbe};
+pub use conn::{CHAN_CAP, Job, LiveCount, Reply, WMsg, spawn_acceptor, spawn_reader, spawn_writer};
 pub use residency::{Canary, DemoteReason, ResidencyConfig, ResidencySampler, Verdict};
 pub use state::State;

--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -4,21 +4,21 @@
 //! faz a fiação do kernel (os ioctls). Assim o daemon fica **sem `unsafe`** — o
 //! único `unsafe` do projeto vive isolado no `ramshared-cuda`.
 //!
-//! MVP/smoke: aloca a VRAM, serve **uma** conexão e sai com `mlockall` +
-//! `oom_score_adj` (Disciplina 3) e o canário de residência §9 (latência
-//! por-request) + §9.4 (sonda dedicada de conteúdo/free em cadência). Multi-conexão
-//! e backoff seguem como trabalho futuro.
+//! Aloca a VRAM e serve **N conexões** NBD (`nbd-client -C N`) por um leitor/escritor
+//! dedicados por conexão + um **worker CUDA único** (afinidade de thread, §9.4/H1), com
+//! `mlockall`+`oom_score_adj` (Disciplina 3) e o canário de residência §9 (latência
+//! por-request, agora incluindo a espera na fila) + §9.4 (sonda de conteúdo/free).
+//! Backoff segue como trabalho futuro.
 
-use std::io::{BufReader, Read, Write};
 use std::os::unix::net::UnixListener;
 use std::path::Path;
 
-use ramshared_block::protocol::{NBD_FLAG_HAS_FLAGS, NBD_FLAG_SEND_FLUSH, REQUEST_LEN};
-use ramshared_block::{BlockBackend, Command, parse_request, serve, server_handshake};
+use ramshared_block::protocol::{NBD_FLAG_CAN_MULTI_CONN, NBD_FLAG_HAS_FLAGS, NBD_FLAG_SEND_FLUSH};
+use ramshared_block::{BlockBackend, Command, serve};
 use ramshared_cuda::Cuda;
 use ramshared_wsl2d::{
-    CANARY_BYTES, CANARY_EVERY, Cadence, Canary, CanaryProbe, ResidencyConfig, ResidencySampler,
-    Verdict, VramBackend,
+    CANARY_BYTES, CANARY_EVERY, CHAN_CAP, Cadence, Canary, CanaryProbe, LiveCount, Reply,
+    ResidencyConfig, ResidencySampler, Verdict, VramBackend, WMsg, spawn_acceptor,
 };
 
 // Disciplina 3 (anti-deadlock): o daemon serve o swap, logo nao pode ser swapado.
@@ -127,66 +127,61 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let _ = std::fs::remove_file(path);
     let listener = UnixListener::bind(path)?;
     eprintln!("[wsl2d] escutando em {sock}");
-    eprintln!("[wsl2d] conecte: sudo nbd-client -unix {sock} /dev/nbd0");
+    eprintln!("[wsl2d] conecte: sudo nbd-client -C <N> -unix {sock} {nbd_dev}");
 
-    // --- serve UMA conexão (MVP) ---
-    let (stream, _) = listener.accept()?;
-    eprintln!("[wsl2d] cliente conectado");
-    let mut writer = stream.try_clone()?;
-    let mut reader = BufReader::new(stream);
+    // --- multi-conexão (H1): acceptor + leitor/escritor por conexão alimentam o worker
+    // CUDA único (esta thread). O canal WMsg é o ÚNICO ponto de backpressure (réplica por
+    // conexão é ilimitada, DT-7). SPEC: docs/daemon-multiconn/SPECv3.md ---
+    let tx_flags = NBD_FLAG_HAS_FLAGS | NBD_FLAG_SEND_FLUSH | NBD_FLAG_CAN_MULTI_CONN; // DT-10
+    let device_size = backend.size_bytes();
+    let (jobs_tx, jobs_rx) = std::sync::mpsc::sync_channel::<WMsg>(CHAN_CAP);
+    let _acceptor = spawn_acceptor(listener, device_size, tx_flags, jobs_tx); // move o único sender
+    eprintln!("[wsl2d] em transmissão (worker CUDA único; multi-conexão)");
 
-    let tx_flags = NBD_FLAG_HAS_FLAGS | NBD_FLAG_SEND_FLUSH;
-    server_handshake(&mut reader, &mut writer, backend.size_bytes(), tx_flags)?;
-    eprintln!("[wsl2d] handshake ok; em transmissão");
-
+    // Estado do worker (esta thread é dona de backend/probe/ctx — afinidade CUDA).
     let mut canary: Option<Canary> = None;
     let mut baseline: Vec<u64> = Vec::new();
     let mut demoted = false;
     let mut demote_rx: Option<std::sync::mpsc::Receiver<bool>> = None;
-    let mut hdr = [0u8; REQUEST_LEN];
-    loop {
-        match reader.read_exact(&mut hdr) {
-            Ok(()) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
-            Err(e) => return Err(e.into()),
-        }
-        let req = parse_request(&hdr)?;
-        // Defesa anti-DoS: um WRITE nunca pode exceder o device; len absurdo => request
-        // malformado => desconecta em vez de alocar (evita alloc de ate ~4 GiB).
-        if req.cmd == Command::Write && req.len as u64 > backend.size_bytes() {
-            eprintln!(
-                "[wsl2d] WRITE len {} excede o device; desconectando",
-                req.len
-            );
-            break;
-        }
-        let payload = if req.cmd == Command::Write {
-            let mut p = vec![0u8; req.len as usize];
-            reader.read_exact(&mut p)?;
-            p
-        } else {
-            Vec::new()
+    let mut live = LiveCount::new();
+
+    while let Ok(msg) = jobs_rx.recv() {
+        let job = match msg {
+            WMsg::Opened => {
+                live.on_open();
+                continue;
+            }
+            WMsg::Closed => {
+                if live.on_close() {
+                    break; // todas as conexões abertas fecharam (DT-15)
+                }
+                continue;
+            }
+            WMsg::Job(job) => job,
         };
-        let touches_vram = matches!(req.cmd, Command::Read | Command::Write);
+
+        let touches_vram = matches!(job.req.cmd, Command::Read | Command::Write);
+        // DT-16 (revisado): latência SERVE-ONLY (tempo da op de VRAM). Medir a espera na
+        // fila dava falso-positivo de DEMOTE sob carga normal (§14.3 ao vivo: baseline
+        // 85us idle vs 1.1ms sob fila = 13x → demote indevido). A falha REAL (eviction
+        // WDDM) spike o serve ~330x (Fase 0) → o canário dispara nela, não na fila.
         let t0 = std::time::Instant::now();
-        let out = serve(&req, &payload, &mut backend);
+        let out = serve(&job.req, &job.payload, &mut backend);
         let lat_us = t0.elapsed().as_micros() as u64;
-        writer.write_all(&out.reply)?;
-        if !out.read_data.is_empty() {
-            writer.write_all(&out.read_data)?;
-        }
-        writer.flush()?;
-        // Poll nao-bloqueante do swapoff de DEMOTE em curso: o serve loop PRECISA
-        // continuar atendendo o read-back do swapoff (senao paginas sujas se perdem).
+        let _ = job.reply.send(Reply {
+            reply: out.reply,
+            data: out.read_data,
+            disconnect: out.disconnect,
+        });
+
+        // Poll nao-bloqueante do swapoff de DEMOTE em curso (re-arma se falhar).
         if let Some(rx) = demote_rx.take() {
             match rx.try_recv() {
                 Ok(true) => {
-                    demoted = true; // confirmado: desarma o canario de vez
+                    demoted = true;
                     eprintln!("[wsl2d] DEMOTE: swapoff {nbd_dev} OK (canario desarmado)");
                 }
                 Ok(false) => {
-                    // swapoff falhou: device ainda e' swap vivo e degradado. NAO engole —
-                    // deixa demote_rx=None p/ re-armar e tentar de novo no proximo spike.
                     eprintln!("[wsl2d] DEMOTE: swapoff {nbd_dev} FALHOU; canario re-armado");
                 }
                 Err(std::sync::mpsc::TryRecvError::Empty) => {
@@ -197,11 +192,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         }
-        // Canario de latencia por-request (§9, gatilho PRIMARIO): mede a latencia do
-        // I/O da VRAM e dispara DEMOTE sob spike. content_ok=true e free=u64::MAX sao DE
-        // PROPOSITO aqui: a eviction WDDM e' data-safe mas latency-unsafe (Fase 0), entao
-        // a latencia e' o sinal vivo. Conteudo e free-floor sao cobertos pela sonda
-        // dedicada §9.4 logo abaixo (cadencia), nao por este bloco.
+
+        // Canário de latência por-request (§9, gatilho PRIMÁRIO): inclui a espera na fila
+        // (DT-16). content_ok=true/free=u64::MAX DE PROPÓSITO aqui: o sinal é a latência;
+        // conteúdo e free-floor vêm da sonda dedicada §9.4 logo abaixo.
         if touches_vram && !demoted && demote_rx.is_none() {
             match canary.as_mut() {
                 None => {
@@ -218,20 +212,15 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                         eprintln!(
                             "[wsl2d] DEMOTE ({reason:?}) lat={lat_us}us -> swapoff {nbd_dev}"
                         );
-                        // Thread separada (nao bloqueia o serve); o resultado volta pelo
-                        // canal e so' entao decidimos desarmar (ver poll acima).
                         demote_rx = Some(spawn_swapoff(&nbd_dev));
                     }
                 }
             }
         }
-        // Canario dedicado §9.4 (SPECv3): sonda de conteudo/free em cadencia.
-        // Conteudo corrompido demove imediato; free-floor e erros transientes exigem
-        // `consecutive` amostras (histerese, DT-9/DT-11). E' independente do streak de
-        // latencia por-request acima e so' roda quando nao ha DEMOTE em curso.
+
+        // Canário dedicado §9.4 (SPECv3): sonda de conteúdo/free em cadência. Conteúdo
+        // corrompido demove imediato; free-floor/erro transiente exigem streak (histerese).
         if touches_vram && !demoted && demote_rx.is_none() && cadence.tick() {
-            // DT-11: erro de sonda/`mem_info` vira amostra degradada (None), nao DEMOTE
-            // imediato — entra no streak como free baixo.
             let content = probe.check_content().ok();
             let free = ctx.mem_info().ok().map(|(f, _)| f as u64);
             if let Verdict::Demote(reason) = sampler.sample(content, free) {
@@ -243,26 +232,32 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 demote_rx = Some(spawn_swapoff(&nbd_dev));
             }
         }
-        if out.disconnect {
-            eprintln!("[wsl2d] disconnect");
-            break;
-        }
     }
 
-    // --- teardown: zera a VRAM (§11) e remove o socket ---
-    // DT-12/§11: zera as DUAS regioes (swap + canario) incondicionalmente. Um erro no
-    // zero do backend NAO pode pular o scrub do canario; tenta ambos e so' entao propaga.
-    let backend_zero = backend.zero();
-    let _ = probe.zero();
-    backend_zero?;
+    // --- teardown (DT-17): espera (bounded) o swapoff em voo, loga honesto, zera ambos.
+    // Aqui todas as conexões NBD já caíram → ninguém lê a VRAM por NBD → zerar é safe.
+    if let Some(rx) = demote_rx.take() {
+        match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+            Ok(true) => eprintln!("[wsl2d] teardown: swapoff {nbd_dev} confirmado (DEMOTE limpo)"),
+            Ok(false) => eprintln!(
+                "[wsl2d] teardown: AVISO swapoff {nbd_dev} NAO confirmou (swap pode estar inconsistente)"
+            ),
+            Err(_) => eprintln!(
+                "[wsl2d] teardown: AVISO swapoff {nbd_dev} sem confirmacao em 5s (timeout/thread sumiu)"
+            ),
+        }
+    }
+    let zeroed = backend.zero();
+    let _ = probe.zero(); // DT-12/DT-17: zera tambem a regiao-canario (§11)
     let _ = std::fs::remove_file(path);
+    zeroed?;
     eprintln!("[wsl2d] encerrado (VRAM zerada)");
     Ok(())
 }
 
-/// Dispara `swapoff <dev>` numa thread separada (nao bloqueia o serve loop) e
-/// devolve o canal que confirma o resultado. Caminho unico de DEMOTE (DT-8):
-/// usado tanto pela latencia por-request quanto pela sonda em cadencia.
+/// Dispara `swapoff <dev>` numa thread separada (nao bloqueia o worker) e devolve o
+/// canal que confirma o resultado. Caminho unico de DEMOTE (DT-8): usado pela latencia
+/// por-request e pela sonda em cadencia.
 fn spawn_swapoff(dev: &str) -> std::sync::mpsc::Receiver<bool> {
     let (tx, rx) = std::sync::mpsc::channel();
     let dev = dev.to_string();

--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -7,7 +7,7 @@
 //! Aloca a VRAM e serve **N conexões** NBD (`nbd-client -C N`) por um leitor/escritor
 //! dedicados por conexão + um **worker CUDA único** (afinidade de thread, §9.4/H1), com
 //! `mlockall`+`oom_score_adj` (Disciplina 3) e o canário de residência §9 (latência
-//! por-request, agora incluindo a espera na fila) + §9.4 (sonda de conteúdo/free).
+//! por-request, **serve-only**) + §9.4 (sonda de conteúdo/free).
 //! Backoff segue como trabalho futuro.
 
 use std::os::unix::net::UnixListener;
@@ -193,8 +193,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
-        // Canário de latência por-request (§9, gatilho PRIMÁRIO): inclui a espera na fila
-        // (DT-16). content_ok=true/free=u64::MAX DE PROPÓSITO aqui: o sinal é a latência;
+        // Canário de latência por-request (§9, gatilho PRIMÁRIO): mede o serve-only (op de
+        // VRAM), DT-16. content_ok=true/free=u64::MAX DE PROPÓSITO aqui: o sinal é a latência;
         // conteúdo e free-floor vêm da sonda dedicada §9.4 logo abaixo.
         if touches_vram && !demoted && demote_rx.is_none() {
             match canary.as_mut() {

--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -255,6 +255,18 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Caminho absoluto do `swapoff` (#2c: um daemon root NAO deve depender do `$PATH`;
+/// evita shim malicioso no ambiente). Fallback p/ `$PATH` so' como ultimo recurso.
+fn swapoff_bin() -> &'static str {
+    const CANDIDATES: &[&str] = &["/usr/sbin/swapoff", "/sbin/swapoff"];
+    for c in CANDIDATES {
+        if std::path::Path::new(c).exists() {
+            return c;
+        }
+    }
+    "swapoff"
+}
+
 /// Dispara `swapoff <dev>` numa thread separada (nao bloqueia o worker) e devolve o
 /// canal que confirma o resultado. Caminho unico de DEMOTE (DT-8): usado pela latencia
 /// por-request e pela sonda em cadencia.
@@ -262,7 +274,7 @@ fn spawn_swapoff(dev: &str) -> std::sync::mpsc::Receiver<bool> {
     let (tx, rx) = std::sync::mpsc::channel();
     let dev = dev.to_string();
     std::thread::spawn(move || {
-        let ok = std::process::Command::new("swapoff")
+        let ok = std::process::Command::new(swapoff_bin())
             .arg(&dev)
             .status()
             .map(|s| s.success())

--- a/docs/LIBRARIES.md
+++ b/docs/LIBRARIES.md
@@ -21,6 +21,11 @@ e das poucas deps userspace. Inclui "deliberadamente NÃO usado".
 - **zram-writeback** — exige `CONFIG_ZRAM_WRITEBACK` (kernel custom); cascata por prioridade resolve Day-0.
 - **MTD/phram (MMIO direto)** — descartado por performance (CPU memcpy).
 - **OpenCL** (proposta original do PRD-2) — CUDA escolhido para o caminho WSL2/GPU-PV.
+- **`clap` (arg parsing)** — descartado p/ preservar **zero-dep externa** num projeto
+  Ring-0/Day-0 (#11). Para ~4-9 flags o parser hand-rolled (`std::env::args`) atende; clap
+  traria ~10 crates transitivas + custo de build. A qualidade do "polish" (issue #3 LOW) veio
+  de **erros tipados** (`CascadeError`, sem dep), não de clap. Revisitar se o CLI crescer
+  muito (muitos subcommands/validações com `--help` rico).
 
 ## Forward (bare-metal — decisões a registrar quando aplicável)
 

--- a/docs/daemon-multiconn/IMPL.md
+++ b/docs/daemon-multiconn/IMPL.md
@@ -1,0 +1,63 @@
+# IMPL — H1 — Daemon NBD multi-conexão / leitor dedicado
+
+SPEC ativo: [`SPECv3.md`](SPECv3.md) (go no Passo 2.5 após 2 no-go: SPEC → SPECv2 → SPECv3).
+Implementa **estritamente** o SPECv3, com **uma revisão no Passo 3** (DT-16, ver abaixo).
+
+## Escopo entregue
+
+`main` virou o **worker CUDA único** (afinidade preservada por tipo — `Context`/`DeviceMem`
+são `!Send`); uma thread **acceptor** + **leitor/escritor por conexão** alimentam o worker via
+canais. NBD multi-conexão (`nbd-client -C N`) via `NBD_FLAG_CAN_MULTI_CONN`. Sem head-of-line
+blocking. Latência por-request preservada como gatilho de DEMOTE.
+
+## Arquivos
+
+| Ação | Arquivo | Conteúdo | SPEC |
+|---|---|---|---|
+| CRIAR | `crates/ramshared-wsl2d/src/conn.rs` | `WMsg`/`Job`/`Reply`/`LiveCount` + `spawn_reader`/`spawn_writer`/`spawn_acceptor` + 5 testes | DT-7/8/15/18 |
+| MOD | `crates/ramshared-block/src/protocol.rs` | `+ NBD_FLAG_CAN_MULTI_CONN = 1<<8` | DT-10 |
+| MOD | `crates/ramshared-wsl2d/src/main.rs` | `run()` reescrito: canal `WMsg` + worker loop (`LiveCount`) + serve-only latency + teardown bounded; flag CAN_MULTI_CONN; N-agnóstico | DT-1/15/16/17 |
+| MOD | `crates/ramshared-wsl2d/src/lib.rs` | `pub mod conn` + re-exports | — |
+| MOD | `crates/ramshared-cli/src/cascade.rs` | `up --connections N` → `nbd-client -C N` (N>1); daemon N-agnóstico | DT-15 |
+| MOD | `crates/ramshared-wsl2d/src/backend.rs` | comentário F-7 (flush no-op depende de write síncrono p/ CAN_MULTI_CONN) | F-7 |
+
+## Rastreabilidade RF → entrega
+
+- **RF-1** (multi-conexão): `spawn_acceptor` (N-agnóstico) + `up --connections N` → `-C N`. Validado: `-C 2`, 2 sockets.
+- **RF-2** (worker CUDA único): worker loop em `main` (thread do `ctx`); `!Send` garante afinidade.
+- **RF-3** (réplicas corretas/fora de ordem): `Reply` por conexão (canal ilimitado), `handle` NBD. Validado: `-C 2` 0 corrupção.
+- **RF-4** (sem HOL): reader↔worker↔writer desacoplados; canal `WMsg` único backpressure.
+- **RF-5** (canário/DEMOTE): canário §9 (serve-only) + §9.4 (sonda) no worker; `spawn_swapoff`.
+- **RF-6** (teardown gracioso): `LiveCount` → break em live==0; `recv_timeout(5s)` + zera ambas as regiões.
+
+## Revisão no Passo 3 (disciplina IMPL→SPEC)
+
+**DT-16 revisado por evidência ao vivo (Kahneman #13).** O SPECv3 (auditado `go`) previa medir a
+**latência total** (espera na fila + serve) para fechar a válvula de backpressure (F-8). O `§14.3`
+ao vivo mostrou que isso causa **falso-positivo de DEMOTE** sob carga normal: baseline 85µs (idle)
+→ 1.1ms (sob fila) = 13× → a VRAM era demovida com só ~10-72 MiB absorvidos (vs 511 do baseline),
+inutilizando o tier (daemon.log: `DEMOTE (Latency) lat=1101us`). **Corrigido para serve-only**;
+SPECv3 DT-16 atualizado com a justificativa. A auditoria teórica não pegou isto — só o teste ao vivo.
+
+## Disciplina Kahneman (itens críticos)
+
+- **DT-15 (lifecycle, #5):** término determinístico por `LiveCount` (Opened do acceptor / Closed do
+  reader). Evidência: `live_count_*` (3 testes) verdes; `-C 2` sobe e desce limpo.
+- **DT-16 (serve-only, #5/#13):** mede o sinal certo (op de VRAM), não a fila. Evidência: §14.3 nbd0
+  511 MiB **sem** falso-positivo. Abort trigger (DEMOTE indevido) **disparou** no IMPL → revertido.
+- **DT-17 (teardown, #5/#2):** `recv_timeout` bounded + zera safe pós-disconnect. Evidência: §14.4 0 corrupção.
+
+## Validação
+
+- `cargo fmt --all -- --check` · `cargo clippy --workspace --all-targets -- -D warnings` — limpos.
+- `cargo test --workspace` — verde. `ramshared-wsl2d`: 21 (LiveCount×3, slow_writer_does_not_deadlock,
+  job_reply_roundtrip, chan_cap_is_bounded + canário/sampler/state) + 1 GPU ignorado.
+- **Ao vivo (RTX 2060, sudo):** §14.3 spill **511 MiB** / 332.800 páginas (sem falso-DEMOTE);
+  §14.4 DEMOTE **479 MiB** migrados / 384.000 páginas / **0 corrupção**; `-C 2` **2 conexões** +
+  hog íntegro (worker serializa).
+
+## Atomicidade & rollback
+
+Worker único serializa todo acesso à VRAM (coerência multi-conexão por construção, sem lock no hot
+path). Rollback **app-only** (revert dos commits); sem migração/dados; protocolo NBD on-wire
+compatível (+1 flag).

--- a/docs/daemon-multiconn/PRD.md
+++ b/docs/daemon-multiconn/PRD.md
@@ -1,0 +1,212 @@
+---
+slug: daemon-multiconn
+title: Daemon NBD multi-conexão / leitor dedicado (sem head-of-line blocking)
+milestone: —
+issues: [3]
+---
+# PRD — H1 — Daemon NBD multi-conexão / leitor dedicado
+
+> **Nota (pós-auditoria, F-2):** o SPEC ativo é o [`SPECv3.md`](SPECv3.md). Em relação aos
+> esboços deste PRD, o SPECv3 fixou: `Reply.reply: [u8; SIMPLE_REPLY_LEN]` (não `Vec`),
+> canal de réplica **ilimitado** (`Sender`, não `SyncSender` — evita deadlock DT-7), e a
+> latência do canário passou a medir o **total** (enfileiramento→réplica, DT-16). O resto
+> do PRD permanece válido.
+
+## Resumo
+
+O daemon `ramshared-wsl2d` serve **uma** conexão NBD num laço **serial**: lê 1 request,
+processa (`serve()` síncrono, I/O CUDA), responde, repete. Um request lento (op de VRAM
+sob eviction, ou a sonda-canário §9.4) **bloqueia a leitura do próximo** (head-of-line
+blocking) e **alonga a janela do DEMOTE** — o kernel não consegue pipeline de I/O e o
+read-back do `swapoff` compete com o tráfego normal no mesmo fluxo serial.
+
+Esta mudança desacopla **leitura do socket** de **processamento CUDA**: leitor(es)
+dedicado(s) drenam o socket para uma fila limitada; um **único worker CUDA** (preservando
+a afinidade de thread obrigatória) processa e responde. Resultado: sem HOL blocking, NBD
+multi-conexão (kernel multi-queue) e janela de DEMOTE menor — sem aumentar a vazão real de
+VRAM (limitada pela thread CUDA única, por design).
+
+Valor: reduz latência percebida e o tempo de DEMOTE sob pressão — o gargalo operacional do
+tier VRAM (Fase A, ROADMAP "Agora").
+
+## Contexto técnico
+
+- **Módulo:** `crates/ramshared-wsl2d` (daemon) — `src/main.rs` (laço de serve);
+  `crates/ramshared-block` (protocolo NBD, `serve()`/`parse_request`); `crates/ramshared-cuda`
+  (`Context`/`DeviceMem`, I/O de VRAM).
+- **Estado atual — Confirmado no codebase:**
+  - `main.rs:133` — `listener.accept()` **uma vez**; serve exatamente 1 conexão = a vida do swap.
+  - `main.rs:147` — `loop` serial: `read_exact(hdr)` → `serve(&req,…,&mut backend)` (síncrono)
+    → `write_all(reply)` → poll de `demote_rx` → canário. **Tudo na mesma thread.**
+  - `crates/ramshared-cli/src/cascade.rs:190` — `nbd-client -unix <sock> <nbd>` **sem `-C`**
+    (1 conexão); teardown `nbd-client -d`.
+  - **Restrição dura (`crates/ramshared-cuda/src/driver.rs:176-181`):** a corrente do
+    contexto CUDA é **thread-local**; todo I/O de VRAM tem de rodar **na mesma thread** que
+    criou o contexto. `cuCtxSetCurrent` não é usado. → **não dá para paralelizar ops de VRAM
+    entre threads.**
+  - DEMOTE já roda em thread separada (`spawn_swapoff`, só `swapoff`, sem CUDA) e o laço
+    continua servindo o read-back via poll de `demote_rx`.
+- **Confirmado na documentação oficial:** NBD permite **réplicas fora de ordem** (cada request
+  carrega um `handle` de 64 bits) e **multi-conexão** (`nbd-client -C N` abre N sockets para o
+  mesmo device; multi-queue do bloco). FLUSH coordena durabilidade.
+- **Proposto:** arquitetura leitor(es) → fila limitada → **worker CUDA único** → writer(s) de
+  réplica por conexão.
+
+## Opção recomendada
+
+**Reader/Worker/Writer com worker CUDA único.**
+
+- **N leitores** (1 por conexão NBD aceita): cada um faz só `read_exact` do header+payload e
+  enfileira `(request, payload, reply_tx_da_conexão)` num **canal limitado** (`sync_channel`,
+  backpressure).
+- **1 worker CUDA** (a thread que criou o `Context`): consome a fila, chama `serve(&req,…,&mut
+  backend)`, devolve a réplica ao `reply_tx` da conexão de origem. Roda também o canário §9.4
+  (sonda/free-floor) e dispara DEMOTE — **toda interação CUDA fica nesta thread** (afinidade
+  preservada).
+- **N writers** (1 por conexão): drenam o `reply_rx` da conexão e escrevem no socket. Réplicas
+  podem sair fora de ordem (NBD `handle`).
+
+Por quê: é a **única** forma de remover o HOL blocking **respeitando a afinidade de thread do
+CUDA**. O leitor nunca fica preso atrás de uma op de VRAM lenta; o read-back do DEMOTE é só
+mais um item na fila, servido com prioridade natural; o kernel pode manter vários requests em
+voo (multi-queue).
+
+**Alternativas descartadas:**
+
+- **Múltiplos workers CUDA** — **impossível**: afinidade de thread do contexto (driver.rs:176).
+- **async/tokio** — overhead e zero ganho: a FFI CUDA é **bloqueante/síncrona**; não há await real
+  no caminho quente. Viola também o "zero deps externas" atual sem benefício.
+- **Thread por request** — churn de threads e ainda serializado no worker CUDA único; pior.
+- **Manter serial + só um leitor "à frente"** — alivia parcialmente mas não suporta multi-conexão
+  nem desacopla o writer; meia-solução (não Day-0).
+
+**Trade-offs aceitos:** a **vazão real de VRAM não aumenta** (1 thread CUDA) — o ganho é
+latência/HOL/janela-de-DEMOTE e capacidade de absorver bursts via a fila. Mais threads (N
+leitores + 1 worker + N writers) e um canal limitado (memória previsível).
+
+## Requisitos funcionais
+
+- **RF-1 — Multi-conexão.** O daemon aceita `--connections N` (default 1) conexões NBD para o
+  mesmo export; cada conexão tem um leitor e um writer dedicados.
+  - *Critério:* `nbd-client -C N -unix <sock> <nbd>` conecta; `N` sockets ativos; I/O íntegro.
+  - *Isolamento:* todas as conexões servem o **mesmo** `VramBackend` (mesmo export); nenhum
+    acesso fora dos limites do device (bounds-check de `serve()`/`DeviceMem` inalterado).
+- **RF-2 — Worker CUDA único.** Todo I/O de VRAM ocorre numa única thread worker; requests
+  chegam por canal limitado.
+  - *Critério:* nenhuma chamada `DeviceMem`/`Context`/`serve()` fora da thread worker (revisão +
+    teste de fumaça); afinidade preservada.
+- **RF-3 — Réplicas corretas e fora de ordem.** Cada réplica volta para a conexão de origem com o
+  `handle` correto; sem interleaving corrompido entre conexões.
+  - *Critério:* round-trip multi-conexão íntegro (hash); réplicas fora de ordem aceitas pelo kernel.
+- **RF-4 — Sem head-of-line blocking.** Uma op de VRAM lenta **não** impede o leitor de drenar o
+  socket nem o writer de responder outras conexões; o read-back do DEMOTE é servido enquanto o
+  `swapoff` está em curso.
+  - *Critério:* sob sonda/op lenta, o leitor continua enfileirando; §14.4 (DEMOTE) sem regressão.
+- **RF-5 — Canário/DEMOTE preservados.** O canário §9 (latência por-request) e §9.4
+  (sonda/free-floor) e o DEMOTE (`spawn_swapoff`) continuam funcionando, agora ancorados na thread
+  worker.
+  - *Critério:* os testes de `ResidencySampler`/`Canary` seguem verdes; §14.3/§14.4 ao vivo OK.
+- **RF-6 — Teardown gracioso.** Ao EOF/disconnect de todas as conexões, drena os in-flight, **espera
+  o DEMOTE em voo**, zera a VRAM (§11) e sai.
+  - *Critério:* sem páginas perdidas no disconnect durante DEMOTE; VRAM zerada no fim (inclui canário).
+
+## Requisitos não-funcionais
+
+- **Performance:** latência por-request **não regride** vs. serial atual (p50/p99); HOL eliminado.
+  Vazão de VRAM = 1 thread (inalterada). Canal limitado (ex.: 64 itens) para backpressure.
+- **Segurança:** sem novo `unsafe` (`#![forbid(unsafe_code)]` mantido na lib); daemon root; sem
+  input externo além do protocolo NBD já validado (`parse_request`, bounds). Sem endereços logados.
+- **Observabilidade:** logs `[wsl2d]` por conexão (conectou/saiu), profundidade de fila sob pressão,
+  DEMOTE distinguindo gatilho real de erro (M4, já existente).
+- **Escalabilidade:** N conexões com 1 worker; canal limitado evita memória ilimitada sob burst.
+- **Resiliência:** canal cheio → backpressure no leitor (não OOM); writer lento de uma conexão não
+  trava as outras; pânico de uma thread não corrompe a VRAM (worker único é o dono).
+- **LGPD:** N/A (sem dados pessoais; sentinelas sintéticas).
+
+## Fluxos
+
+**Happy path (multi-conexão):**
+1. `ramshared up --connections N` sobe o daemon; CLI chama `nbd-client -C N -unix <sock> <nbd>`.
+2. Daemon faz `accept()` N vezes; para cada conexão: spawna **leitor** + **writer** e cria o
+   `reply_tx/reply_rx` da conexão.
+3. Leitor lê header (+payload se WRITE), valida cap anti-DoS, enfileira `(req,payload,reply_tx)` no
+   canal do worker (bloqueia se cheio — backpressure).
+4. **Worker CUDA** desenfileira, `serve()` na VRAM, envia a réplica ao `reply_tx`; roda canário e,
+   em gatilho, dispara DEMOTE (`spawn_swapoff`) e segue servindo.
+5. Writer da conexão drena `reply_rx` e escreve no socket (réplicas podem sair fora de ordem).
+6. EOF numa conexão → leitor encerra, sinaliza; quando todas encerram e o worker drena, teardown.
+
+**Fluxos alternativos:** N=1 (comportamento equivalente ao atual, mas com leitor/worker/writer
+desacoplados). DEMOTE em curso: read-back flui pela fila normalmente.
+
+**Fluxos de erro:**
+- WRITE com `len > device` → leitor desconecta aquela conexão (anti-DoS; já existe), sem derrubar as outras.
+- Socket de uma conexão quebra (`write_all`/`read_exact` Err) → encerra **só** aquela conexão.
+- Canal worker desconectado (worker morreu) → leitores encerram; teardown com erro logado.
+- `swapoff` falha → re-arma o canário (comportamento atual), worker segue.
+
+## Modelo de dados
+
+- **`struct Job`** (item do canal worker): `req: Request`, `payload: Vec<u8>`,
+  `reply: SyncSender<Reply>` (o canal de réplica da conexão de origem). Movido por valor.
+- **`struct Reply`**: `reply: Vec<u8>` (header NBD), `data: Vec<u8>` (read-back, possível vazio),
+  `disconnect: bool`. (Espelha o `out` atual de `serve()`.)
+- **Canais:** `sync_channel::<Job>(CAP)` (worker, **limitado** → backpressure); por conexão,
+  `sync_channel::<Reply>(CAP)` (writer). Ciclo de vida: leitores/worker/writers spawnados no `up`,
+  encerram por EOF/Drop dos sends.
+- **Posse:** o **worker** é o único dono de `&mut VramBackend` + `CanaryProbe`/`Cadence`/
+  `ResidencySampler` + `ctx` (afinidade). Leitores/writers só tocam sockets e canais. Sem
+  `Arc<Mutex<backend>>` (o worker serializa por construção — sem lock no hot path).
+- **uAPI/ABI:** **nenhuma mudança** — protocolo NBD on-wire inalterado; sem ioctl/sysfs novo.
+
+## API / Interfaces
+
+- **Sem ioctl/sysfs/debugfs novo.** Protocolo NBD on-wire inalterado (handshake + requests).
+- **CLI/daemon flag nova:** `--connections N` no `ramshared-wsl2d` e propagação no
+  `ramshared up` (CLI `cascade.rs`) → `nbd-client -C N`. Default `N=1` (sem mudança de comportamento).
+- **Impacto em ABI/headers:** nenhum. **Module params:** N/A (userspace).
+- **Erros (mantém os atuais):** WRITE `len>device` → desconecta a conexão; sem novos códigos.
+
+## Dependências e riscos
+
+- **Pré-requisitos:** nenhum externo novo (std `thread`/`sync_channel`). `nbd-client` suporta `-C`
+  (confirmar versão no SPEC).
+- **Riscos + mitigação:**
+  - *Réplica fora de ordem / interleaving entre conexões* → cada conexão tem seu próprio writer e
+    `reply_rx`; o `handle` NBD identifica a réplica. **Mitig.:** teste multi-conexão de integridade.
+  - *Coerência multi-conexão (mesma página por 2 conexões)* → o **worker único serializa** todos os
+    acessos; não há 2 escritas concorrentes na VRAM. **Mitig.:** invariante "1 worker" + teste.
+  - *Deadlock por canal cheio* (worker bloqueado escrevendo réplica enquanto leitor bloqueado
+    enfileirando) → réplicas vão para canais **por conexão** com writer próprio; o worker nunca
+    bloqueia indefinidamente num socket. **Mitig.:** disciplina #5 worst-case no SPEC.
+  - *Perda no disconnect durante DEMOTE* (finding #2a já conhecido) → teardown espera o `swapoff` em
+    voo antes de zerar (resolvido junto do item 2/hardening). **Mitig.:** §14.4 ao vivo.
+  - *Regressão de latência* → medir p50/p99 vs. serial; abort trigger no SPEC.
+- **Breaking changes:** nenhum on-wire. Internamente **substitui** o laço serial (Day-0: reescreve,
+  não empilha).
+- **Rollout:** app-only (binário). **Rollback:** reverter os commits (sem migração/dados).
+- **Hipóteses que exigirão disciplina no SPEC:** modelo de threads/canais (concorrência, #5/#2);
+  teardown sob DEMOTE (#5).
+
+## Estratégia de implementação
+
+Ordem das fatias (cada uma compila + testa):
+1. Extrair `serve()`-por-request num formato `Job→Reply` puro (sem mudar `serve()`), preparando o
+   canal. Validável cedo (unit do empacotamento Job/Reply).
+2. Worker CUDA único + canal limitado: mover o I/O de VRAM + canário para a thread worker; `main`
+   vira orquestrador. (N=1 ainda.)
+3. Leitor + writer desacoplados (1 conexão): remover HOL entre socket e CUDA.
+4. Multi-conexão: `accept()` em laço até N; 1 leitor + 1 writer por conexão; flag `--connections`.
+5. Teardown: drenar in-flight + esperar DEMOTE + zerar VRAM (§11).
+6. Propagar `--connections`/`-C` no CLI `up`.
+
+O que valida cedo: fatias 1-2 (canal + worker) com N=1 já provam não-regressão (`§14` + testes).
+O que exige cuidado: fatias 3-5 (concorrência) — disciplina #5/#2.
+
+## Fora de escopo
+
+- **Múltiplos exports/devices** num daemon (só 1 export, N conexões a ele).
+- **Vazão paralela de VRAM** (impossível: 1 thread CUDA).
+- **async/tokio** (sem ganho; FFI síncrona).
+- **Writeback / ublk** (itens 4-5, Fase B).
+- **Detecção em idle do canário** (H1 do canário, separado).

--- a/docs/daemon-multiconn/SPEC.md
+++ b/docs/daemon-multiconn/SPEC.md
@@ -1,0 +1,201 @@
+# SPEC — H1 — Daemon NBD multi-conexão / leitor dedicado
+
+Fonte: [`PRD.md`](PRD.md). Implementa a Fase A "Agora" do ROADMAP (issue #3, H1).
+Decisões fechadas para o Passo 3.
+
+## Escopo fechado desta implementação
+
+**Entra agora:**
+- `main` (run) vira o **worker CUDA único** (dono de `ctx`/`backend`/`probe`/`sampler` —
+  afinidade preservada). Uma thread **acceptor** aceita até `N` conexões; cada conexão tem um
+  **reader** e um **writer** dedicados. Comunicação por **canais limitados** (`sync_channel`).
+- Flag `--connections N` (default 1) no daemon + propagação `-C N` no `ramshared up`.
+- Teardown drena in-flight, **espera o `swapoff` em voo** (resolve finding #2a) e zera VRAM+canário.
+
+**Fica fora:** múltiplos exports; vazão paralela de VRAM (1 thread CUDA); async; writeback/ublk.
+
+**Dependências prontas:** `ramshared-block` (`serve`/`parse_request`/`server_handshake`),
+`ramshared-cuda`, `ramshared-wsl2d` (canário §9.4 já mergeado).
+
+## Matriz de rastreabilidade PRD → SPEC
+
+| PRD  | Implementação no SPEC |
+| ---- | --------------------- |
+| RF-1 (multi-conexão) | ITEM-4 (acceptor N), ITEM-6 (CLI -C), DT-5 |
+| RF-2 (worker CUDA único) | ITEM-2 (worker loop em `main`), DT-1, DT-2 |
+| RF-3 (réplicas fora de ordem) | ITEM-3 (writer por conexão + `reply_tx` no Job), DT-3 |
+| RF-4 (sem HOL) | ITEM-2+ITEM-3 (reader↔worker↔writer desacoplados), DT-2 |
+| RF-5 (canário/DEMOTE) | ITEM-2 (canário roda no worker), DT-4 |
+| RF-6 (teardown gracioso) | ITEM-5, DT-6 |
+
+## Decisões técnicas
+
+| #    | Decisão | Justificativa |
+| ---- | ------- | ------------- |
+| DT-1 | **`main` é o worker CUDA.** O setup CUDA (load/ctx/alloc/zero/canário) fica em `run()` como hoje; `run()` então **consome o canal de Jobs**. Não move CUDA para thread spawnada. | Afinidade de thread (driver.rs:176) + mínima perturbação do caminho CUDA validado §14. |
+| DT-2 | **Canal de Jobs limitado:** `std::sync::mpsc::sync_channel::<Job>(CHAN_CAP)`, `CHAN_CAP=64`. Readers clonam o `SyncSender`; worker tem o `Receiver`. Fim por drop de todos os senders. | Backpressure (sem OOM sob burst); fim natural quando todas as conexões caem. |
+| DT-3 | **Réplica por conexão:** cada conexão cria `sync_channel::<Reply>(CHAN_CAP)`; o `Job` carrega o `SyncSender<Reply>`. Writer da conexão drena o `Receiver<Reply>`. | Réplicas fora de ordem por conexão; nenhum interleaving entre conexões; worker nunca bloqueia num socket. |
+| DT-4 | **Canário/DEMOTE no worker.** `Canary`/`ResidencySampler`/`Cadence`/`probe`/`demote_rx` viram estado local do worker loop (como hoje, só que dirigido por Jobs em vez do laço serial). `spawn_swapoff` inalterado. | Mantém §9/§9.4 e a afinidade (sonda usa CUDA). |
+| DT-5 | **Acceptor thread** faz `listener.accept()` em laço até `N`; por conexão spawna reader+writer e clona o `SyncSender<Job>`. Após `N` aceitas, encerra. `N` default 1. | Desacopla o accept do worker; `N=1` ≡ comportamento atual. |
+| DT-6 | **Teardown ordenado:** worker sai do loop quando o `Receiver<Job>` fecha (todas as conexões caíram) → **espera `demote_rx` em voo** (join lógico do swapoff) → `backend.zero()` + `probe.zero()` (incondicional, fix #6a já mergeado) → remove socket. | Resolve #2a (não zerar VRAM com swapoff migrando); §11. |
+
+## Fronteira de atomicidade e política de rollback
+
+- **Atomicidade:** o **worker único serializa** todo acesso à VRAM — não há 2 writes concorrentes
+  (coerência multi-conexão por construção, sem lock no hot path). Cada Job é processado
+  atomicamente (read→serve→reply). DEMOTE (`swapoff`) atômico no kernel (caminho existente).
+- **Rollback:** **app-only** (revert dos commits). Sem migração/dados; protocolo NBD on-wire inalterado.
+
+## Mapa Kahneman por etapa crítica
+
+| Etapa / ITEM | Disciplina | Link | Pergunta obrigatória | Evidência mínima | Abort trigger |
+| --- | --- | --- | --- | --- | --- |
+| ITEM-2/ITEM-3 (modelo de threads/canais) | #5 Worst-case | [`KAHNEMAN-DISCIPLINES.md`](../methodology/KAHNEMAN-DISCIPLINES.md) | "que sequência de canal-cheio/desconexão trava o worker ou perde réplica?" | unit: `Job→serve→Reply` round-trip; teste de canal cheio (backpressure não deadlocka); `§14.3` ao vivo sem regressão | worker bloqueia >T ou réplica perdida → reverter |
+| ITEM-4 (multi-conexão) | #5 Worst-case + #13 ilusão de validade | [`KAHNEMAN-DISCIPLINES.md`](../methodology/KAHNEMAN-DISCIPLINES.md) | "2 conexões escrevendo a mesma página corrompem?" | integração: `nbd-client -C 2` + hash íntegro; revisão: worker único serializa | corrupção/divergência de hash sob `-C N` → reverter p/ N=1 |
+| ITEM-5 (teardown sob DEMOTE) | #5 Worst-case + #2 Counterfactual | [`KAHNEMAN-DISCIPLINES.md`](../methodology/KAHNEMAN-DISCIPLINES.md) | "disconnect no meio do swapoff zera a VRAM migrando?" | `§14.4` ao vivo: DEMOTE + disconnect, 0 corrupção; código espera `demote_rx` antes de `zero()` | corrupção no read-back durante teardown → reverter |
+
+## Checklist de segurança (pré-implementação)
+
+- [x] Isolamento: todas as conexões servem o **mesmo** export; `serve()`/`DeviceMem` bounds-check inalterado; canário separado.
+- [x] OOB: cap anti-DoS de WRITE (`len>device`) movido para o **reader** (por conexão).
+- [x] Permissões: daemon root (subido pelo `up`).
+- [x] Input validation: só protocolo NBD (`parse_request`); sentinela do canário sintética.
+- [x] Sem `unsafe` novo; `#![forbid(unsafe_code)]` mantido (threads/canais são `std` safe).
+- [x] Ponteiros: nenhum endereço de VRAM logado.
+
+## Arquivos a CRIAR
+
+### `crates/ramshared-wsl2d/src/conn.rs`
+- **Propósito:** tipos e threads de conexão (Job/Reply, acceptor, reader, writer). Mantém `main.rs` pequeno (<800 linhas, regra `coding.md`).
+- **Requisitos:** RF-1, RF-3, RF-4, DT-2, DT-3, DT-5.
+- **Types/funcs (assinaturas exatas):**
+  ```rust
+  use std::os::unix::net::{UnixListener, UnixStream};
+  use std::sync::mpsc::{Receiver, SyncSender};
+  use ramshared_block::Request;
+
+  pub const CHAN_CAP: usize = 64; // DT-2/DT-3
+
+  /// Um request a processar pelo worker CUDA, com a rota de réplica da conexão.
+  pub struct Job {
+      pub req: Request,
+      pub payload: Vec<u8>,
+      pub reply: SyncSender<Reply>, // canal de réplica da conexão de origem (DT-3)
+  }
+
+  /// Resultado do `serve()` a escrever no socket da conexão.
+  pub struct Reply {
+      pub reply: Vec<u8>,     // header NBD (out.reply)
+      pub data: Vec<u8>,      // read-back (out.read_data, pode ser vazio)
+      pub disconnect: bool,   // out.disconnect
+  }
+
+  /// Thread leitora: lê headers/payload do socket, valida cap anti-DoS, enfileira Jobs.
+  /// Encerra em EOF/erro; ao encerrar, dropa seu SyncSender<Job> (fim natural do worker).
+  pub fn spawn_reader(
+      reader: UnixStream,
+      device_size: u64,
+      jobs: SyncSender<Job>,
+      replies: SyncSender<Reply>,
+  ) -> std::thread::JoinHandle<()>;
+
+  /// Thread escritora: drena Reply e escreve no socket (réplicas fora de ordem OK).
+  pub fn spawn_writer(
+      writer: UnixStream,
+      replies: Receiver<Reply>,
+  ) -> std::thread::JoinHandle<()>;
+
+  /// Thread acceptor: aceita até `n` conexões; por conexão faz o handshake NBD,
+  /// cria o canal de réplica e spawna reader+writer. Clona `jobs` por conexão.
+  pub fn spawn_acceptor(
+      listener: UnixListener,
+      n: u32,
+      device_size: u64,
+      tx_flags: u16,
+      jobs: SyncSender<Job>,
+  ) -> std::thread::JoinHandle<()>;
+  ```
+- **Lógica resumida:**
+  - `spawn_reader`: loop `read_exact(hdr)` → `parse_request` → se `Write` e `len>device_size` → log + break; lê payload se Write; `jobs.send(Job{req,payload,reply: replies.clone()})` (bloqueia se cheio = backpressure). EOF/Err → break (dropa `jobs`/`replies`).
+  - `spawn_writer`: `for r in replies { write_all(r.reply); if !r.data.is_empty() {write_all(r.data)}; flush(); if r.disconnect {break} }`.
+  - `spawn_acceptor`: `for _ in 0..n { let (s,_)=accept()?; let w=s.try_clone()?; server_handshake(&mut BufReader::new(s),&mut w,device_size,tx_flags)?; let (rtx,rrx)=sync_channel(CHAN_CAP); spawn_writer(w,rrx); spawn_reader(s,device_size,jobs.clone(),rtx); }` (handshake por conexão).
+- **Dependências internas:** `ramshared-block`. **Externas:** nenhuma.
+- **Padrão de referência:** o laço serial atual de `main.rs` (read→serve→write) refatorado.
+- **Testes requeridos (`#[cfg(test)]`, sem GPU):** `job_reply_roundtrip` (constrói Job/Reply, checa campos); `chan_cap_is_bounded` (sync_channel(CAP) bloqueia no CAP+1 — backpressure, via try_send). Round-trip real multi-conexão = integração `--ignored`/§14.
+- **Disciplina Kahneman:** ITEM-2/3/4 (#5/#13) — ver Mapa.
+
+## Arquivos a MODIFICAR
+
+### `crates/ramshared-wsl2d/src/main.rs`
+- **O que muda:** `run()` deixa de fazer `accept()`+laço serial; passa a: (a) parse `--connections N`;
+  (b) setup CUDA + mlockall + canário **inalterados**; (c) bind socket; (d) criar `sync_channel::<Job>(CHAN_CAP)`;
+  (e) `spawn_acceptor(listener, n, size, tx_flags, jobs_tx)`; (f) **worker loop**: `for job in jobs_rx { serve + canário/DEMOTE + job.reply.send(Reply) }`; (g) teardown (DT-6).
+- **Requisitos:** RF-2, RF-5, RF-6, DT-1, DT-4, DT-6.
+- **Função/bloco afetado:** `run()` (linhas ~119-234: do `accept()` ao teardown).
+- **Antes:** `let (stream,_)=listener.accept()?; … loop { read_exact; serve; write; poll demote; canário } … backend.zero()`.
+- **Depois (shape):**
+  ```rust
+  let n: u32 = connections; // --connections, default 1
+  let (jobs_tx, jobs_rx) = std::sync::mpsc::sync_channel::<Job>(CHAN_CAP);
+  let acceptor = spawn_acceptor(listener, n, size, tx_flags, jobs_tx); // dropa o template ao fim
+  // worker loop (thread atual = dona do CUDA):
+  for job in jobs_rx.iter() {
+      let out = serve(&job.req, &job.payload, &mut backend);
+      // poll demote_rx + canário §9 (latência por-request) + cadência §9.4 — IDÊNTICOS a hoje,
+      // só que `touches_vram`/`lat_us` derivam de `job.req` e do tempo do `serve()`.
+      let _ = job.reply.send(Reply { reply: out.reply, data: out.read_data, disconnect: out.disconnect });
+  }
+  let _ = acceptor.join();
+  // DT-6: espera o swapoff em voo antes de zerar (fix #2a)
+  if let Some(rx) = demote_rx.take() { let _ = rx.recv(); }
+  backend.zero().and(probe.zero()).ok(); // ambos (fix #6a já mergeado)
+  ```
+- **Impacto:** sem uAPI/ABI; protocolo NBD inalterado; latência por-request preservada; remove HOL.
+  `serve()`/handshake reusados. **Day-0:** o laço serial é **substituído** (sem dual-path).
+- **Testes:** `cargo test -p ramshared-wsl2d`; clippy `-D warnings`; **§14.3/§14.4 ao vivo** + smoke `-C 2`.
+- **Disciplina Kahneman:** ITEM-2/5 (#5/#2) — ver Mapa.
+
+### `crates/ramshared-wsl2d/src/lib.rs`
+- **O que muda:** `pub mod conn;` + `pub use conn::{Job, Reply, CHAN_CAP};` (acceptor/reader/writer são fns de bin; manter `pub` p/ teste).
+- **Impacto:** API de lib cresce (interna); `forbid(unsafe_code)` mantido.
+
+### `crates/ramshared-wsl2d/src/main.rs` — parse de args
+- **O que muda:** adicionar `--connections N` (u32, default 1; valida `N>=1`).
+- **Por quê:** RF-1. **Impacto:** novo flag opcional; sem mudança se omitido.
+
+### `crates/ramshared-cli/src/cascade.rs`
+- **O que muda:** `ramshared up` ganha `--connections N` (default 1); passa `--connections N` ao daemon e `-C N` ao `nbd-client` (linha `sh("nbd-client", &["-unix", SOCK, NBD])` → inclui `-C` quando N>1).
+- **Requisitos:** RF-1, ITEM-6. **Impacto:** default 1 = sem mudança; teardown `nbd-client -d` inalterado.
+- **Testes:** smoke `ramshared up --connections 2` + `nbd-client -C 2` (manual/§14).
+
+## Ordem de implementação
+
+1. `conn.rs`: `Job`/`Reply`/`CHAN_CAP` + testes puros (`job_reply_roundtrip`, `chan_cap_is_bounded`).
+2. `main.rs`: trocar o laço serial pelo **canal + worker loop** com **acceptor de 1 conexão** (N=1); canário/DEMOTE no worker. Validar §14 (não-regressão).
+3. `conn.rs`: `spawn_reader`/`spawn_writer` desacoplados (remove HOL); validar §14.
+4. `conn.rs`: `spawn_acceptor` até N + flag `--connections`; smoke `-C 2`.
+5. `main.rs`: teardown DT-6 (espera swapoff + zero ambos).
+6. `cascade.rs`: propagar `--connections`/`-C`.
+
+## Plano de testes
+
+- **Unitários (sem GPU):** `job_reply_roundtrip`, `chan_cap_is_bounded` (conn.rs); os 15 testes da lib seguem verdes.
+- **Integração/ao vivo (GPU+root):** `§14.3` (spill, sem regressão), `§14.4` (DEMOTE + disconnect, 0 corrupção), **smoke `nbd-client -C 2`** (multi-conexão, hash íntegro).
+- **Concorrência:** canal cheio não deadlocka (backpressure); 2 conexões → worker serializa (sem corrupção).
+
+## Contratos e documentação viva
+
+| Documento | Atualização | Motivo |
+| --- | --- | --- |
+| `ARCHITECTURE.md` | Alterar | daemon deixa de ser "serve loop serial"; H1 resolvido |
+| `ROADMAP.md` | Alterar | mover H1 de "Agora" para "Feito" |
+| `docs/daemon-multiconn/IMPL.md` | Criar | Passo 3 |
+| `MEMORY.md` | Alterar | entrada da sessão |
+
+## Checklist de validação
+
+- [ ] `cargo fmt --all -- --check` · `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace` (+ `conn.rs` novos)
+- [ ] §14.3 / §14.4 ao vivo (sudo bash, sandbox off) — sem regressão
+- [ ] smoke `nbd-client -C 2` — multi-conexão íntegra
+- [ ] cada etapa crítica: pergunta/evidência/abort do Mapa Kahneman cumpridos

--- a/docs/daemon-multiconn/SPECv2.md
+++ b/docs/daemon-multiconn/SPECv2.md
@@ -1,0 +1,116 @@
+# SPECv2 — H1 — Daemon NBD multi-conexão / leitor dedicado
+
+> Versão melhorada após auditoria do Passo 2.5.
+> Baseline preservado: [`SPEC.md`](SPEC.md).
+> Motivo: o `SPEC.md` tinha **deadlock worker↔reply** (réplica limitada, CRITICAL-1),
+> **type-mismatch que não compila** (`Reply.reply` vs `ServeOutcome.reply: [u8;N]`,
+> CRITICAL-2), **hang de teardown** por N parcial (acceptor segurando o canal, HIGH-1),
+> **falta `NBD_FLAG_CAN_MULTI_CONN`** (quebra `-C N` + coerência não fundamentada, HIGH-2),
+> **backpressure×timeout não analisado** (risco de I/O-error→panic em swap, HIGH-3),
+> contradição **RF-4×DT-6** no read-back do DEMOTE (MEDIUM-1), `Inflight` não declarado
+> (MEDIUM-2) e testes sem prova de não-deadlock (MEDIUM-3).
+
+## 0. Proveniência da auditoria (regra de saída do Passo 2.5)
+
+- **Auditado:** `docs/daemon-multiconn/SPEC.md`. **Resultado:** `no-go`.
+- **Findings bloqueantes endereçados:** CRITICAL-1, CRITICAL-2, HIGH-1, HIGH-2, HIGH-3,
+  MEDIUM-1, MEDIUM-2, MEDIUM-3 (ver Decisões técnicas DT-7..DT-14).
+- **Este `SPECv2.md` é o candidato ativo** para nova auditoria / Passo 3.
+
+## Escopo fechado
+
+**Igual ao [`SPEC.md`](SPEC.md)** (worker CUDA único = `main`; acceptor + reader/writer por
+conexão; flag `--connections N`; teardown que espera o swapoff). Os deltas abaixo (DT-7..DT-14)
+**substituem** as decisões com falha do baseline.
+
+## Matriz de rastreabilidade PRD → SPECv2
+
+Igual ao SPEC; reforços: RF-3/RF-4 → DT-7/DT-8; RF-1 → DT-9/DT-10; RF-6 → DT-12; RNF resiliência → DT-11/DT-13/DT-14.
+
+## Decisões técnicas (delta sobre o SPEC.md)
+
+| #    | Decisão | Corrige |
+| ---- | ------- | ------- |
+| DT-1..DT-6 | **Herdadas do SPEC.md**, exceto onde DT-7..DT-14 sobrescrevem. | — |
+| **DT-7** | **Canal de réplica ILIMITADO** (`std::sync::mpsc::channel::<Reply>()`, não `sync_channel`). O **único** ponto de backpressure é o canal de **Jobs** (`sync_channel(CHAN_CAP)`). O worker **nunca** bloqueia em `reply.send()` → sempre progride consumindo Jobs. **Limite de memória:** o backlog de réplicas por conexão é limitado pela **profundidade da fila NBD do kernel** por conexão (o cliente não submete mais requests sem receber réplicas; se o writer trava, o reader da mesma conexão para de receber requests do kernel → para de gerar Jobs → o backlog de réplicas para de crescer). Teto ≈ `nr_requests × max_reply` por conexão. | **CRITICAL-1** (deadlock) |
+| **DT-8** | **`Reply.reply: [u8; ramshared_block::protocol::SIMPLE_REPLY_LEN]`** (array fixo `Copy`, sem alocação no hot path), espelhando `ServeOutcome.reply`. O writer faz `write_all(&r.reply)`. `data: Vec<u8>` e `disconnect: bool` inalterados. | **CRITICAL-2** (não compila) |
+| **DT-9** | **Término determinístico do acceptor:** aceita a 1ª conexão (bloqueante), depois `set_nonblocking(true)` e **drena o backlog** aceitando até `N` no total dentro de uma janela curta (`ACCEPT_WINDOW_MS = 250`, re-tentando em `WouldBlock`); ao fim **dropa seu `SyncSender<Job>` template** e fecha o `listener`. `nbd-client -C N` abre os N sockets juntos no `up`, então caem no backlog inicial. Assim o canal de Jobs fecha quando **todas as conexões aceitas caem** (não depende de "N exato atingido") → sem hang com N parcial. `run()` move sua única cópia de `jobs_tx` para o acceptor (não retém nenhuma). | **HIGH-1** (hang teardown) |
+| **DT-10** | **Anuncia `NBD_FLAG_CAN_MULTI_CONN = 1 << 8`** (novo em `protocol.rs`) em `tx_flags`. **Justificativa de coerência (cadeia explícita):** `cuMemcpyHtoD` é **síncrono** (driver.rs) ⇒ toda WRITE é durável na VRAM **no instante do ack** ⇒ `VramBackend::flush` é no-op **correto** ⇒ um FLUSH em qualquer conexão cobre trivialmente todas as WRITEs já ackadas (de todas as conexões) ⇒ a promessa do `CAN_MULTI_CONN` é satisfeita **por construção** (write síncrono + worker único serializando). Sem o flag, o kernel recusa/degrada `-C N`. | **HIGH-2** (protocolo) |
+| **DT-11** | **Backpressure×timeout (worst-case #5):** `CHAN_CAP = 64` é da ordem do `nr_requests` default do block layer (~128); o worker drena FIFO. O `ramshared up`/`nbd-client` **não** seta `-t` curto (mantém o default tolerante — validado no §14.4, onde o swapoff levou 6 s sem panic). **Sob lentidão sustentada da VRAM** (eviction), o backpressure faz o canário §9.4/latência **disparar o DEMOTE** — que é a **válvula de alívio projetada** (migra para fora da VRAM), não um caminho de panic. Declarado: `CHAN_CAP` ≥ profundidade típica; nenhum `-t` agressivo; backpressure→DEMOTE é intencional. | **HIGH-3** (panic em swap) |
+| **DT-12** | **Teardown sem deadlock (corrige RF-4×DT-6):** o read-back do swapoff é servido **dentro** do worker loop (chega como Jobs READ enquanto a conexão vive); o poll de `demote_rx` continua **no loop** (desarma o canário ao confirmar). Quando `jobs_rx` fecha (todas as conexões caíram — durante DEMOTE normal isso ocorre **após** o swapoff terminar o read-back), faz-se um **`recv_timeout(5s)`** em qualquer swapoff ainda em voo (edge #2a: disconnect no meio) — **bounded**, nunca `recv()` infinito; depois zera as duas regiões (`backend.zero()` + `probe.zero()`, ambos). | **MEDIUM-1** (deadlock/contradição) |
+| **DT-13** | **`Inflight` explicitamente fora de escopo (Day-0):** o worker único serializa todos os acessos à VRAM; sob `CAN_MULTI_CONN`, **o cliente garante** não criar dependências de ordem cross-conexão, então a ordem de entrega cross-reader (mpsc não-determinística entre senders) é irrelevante para corretude. `Inflight` (§8.1) **não** é usado nem criado. Declarado para remover o drift com a doc do `ramshared-block`. | **MEDIUM-2** (drift/ordem) |
+| **DT-14** | **Evidência de não-deadlock reproduzível (sem GPU):** teste `slow_writer_does_not_deadlock` (monta reader→jobs(bounded)→worker-stub→reply(unbounded DT-7)→writer-que-não-drena; assere que o worker-stub continua consumindo Jobs e o sistema não trava) e `acceptor_terminates_on_partial_n` (N=2, 1 conexão que cai → o canal de Jobs fecha). | **MEDIUM-3** (evidência) |
+
+## Fronteira de atomicidade e política de rollback
+
+Igual ao SPEC.md. Reforço (DT-7): o worker nunca bloqueia em réplica → progresso garantido;
+backpressure só no canal de Jobs. Rollback **app-only** (revert dos commits).
+
+## Mapa Kahneman por etapa crítica
+
+| Etapa / ITEM | Disciplina | Link | Pergunta obrigatória | Evidência mínima | Abort trigger |
+| --- | --- | --- | --- | --- | --- |
+| ITEM-2/3 (canais, DT-7/DT-8) | #5 Worst-case | [`KAHNEMAN-DISCIPLINES.md`](../methodology/KAHNEMAN-DISCIPLINES.md) | "writer travado de 1 conexão trava o daemon?" | `slow_writer_does_not_deadlock` (DT-14) verde; §14.3 ao vivo sem regressão | worker bloqueia / réplica perdida → reverter |
+| ITEM-4 (multi-conn, DT-9/DT-10) | #5 + #13 | [`KAHNEMAN-DISCIPLINES.md`](../methodology/KAHNEMAN-DISCIPLINES.md) | "`-C 2` é recusado (sem flag) ou corrompe?" | smoke `nbd-client -C 2` conecta + hash íntegro; `acceptor_terminates_on_partial_n` verde | recusa de `-C N` ou divergência de hash → reverter p/ N=1 |
+| ITEM-5 (teardown sob DEMOTE, DT-12) | #5 + #2 | [`KAHNEMAN-DISCIPLINES.md`](../methodology/KAHNEMAN-DISCIPLINES.md) | "disconnect no meio do swapoff zera VRAM migrando / trava o teardown?" | §14.4 ao vivo: DEMOTE + 0 corrupção; `recv_timeout` bounded (sem hang) | corrupção no read-back ou hang no teardown → reverter |
+| ITEM-6 backpressure (DT-11) | #5 Worst-case | [`KAHNEMAN-DISCIPLINES.md`](../methodology/KAHNEMAN-DISCIPLINES.md) | "burst + VRAM lenta estoura timeout NBD → I/O error em swap?" | §14.3 sob pressão sem reset de conexão; sem `-t` agressivo | reset de conexão/I/O-error em swap sob carga → reverter |
+
+## Checklist de segurança (pré-implementação)
+
+Igual ao SPEC.md (isolamento, OOB cap anti-DoS no reader, root, sem `unsafe` novo,
+`forbid(unsafe_code)`, sem endereços logados). **`Context`/`DeviceMem` são `!Send`** → o
+compilador **força** o worker a ficar na thread do `ctx` (afinidade garantida por tipo, LOW-2).
+
+## Arquivos a CRIAR
+
+### `crates/ramshared-wsl2d/src/conn.rs`
+- **Igual ao SPEC.md**, com os deltas:
+  - `Reply.reply: [u8; SIMPLE_REPLY_LEN]` (DT-8); `import ramshared_block::protocol::SIMPLE_REPLY_LEN`.
+  - O `Job.reply` é `std::sync::mpsc::Sender<Reply>` (canal **ilimitado**, DT-7), não `SyncSender`.
+  - `spawn_writer(writer, replies: Receiver<Reply>)`: `for r in replies { write_all(&r.reply); if !r.data.is_empty() {write_all(&r.data)}; flush(); if r.disconnect {break} }`.
+  - `spawn_acceptor(...)`: DT-9 (1ª bloqueante → `set_nonblocking` → drena até N em `ACCEPT_WINDOW_MS=250` → dropa template + fecha listener); anuncia `tx_flags` com `CAN_MULTI_CONN` (DT-10).
+  - Consts: `CHAN_CAP=64` (Jobs, bounded), `ACCEPT_WINDOW_MS=250`.
+- **Testes (sem GPU):** `job_reply_roundtrip`, `chan_cap_is_bounded`, **`slow_writer_does_not_deadlock`** (DT-14), **`acceptor_terminates_on_partial_n`** (DT-14, usando `UnixListener` em socketpair/tempdir, sem GPU).
+
+### `crates/ramshared-block/src/protocol.rs`
+- **O que muda:** `+ pub const NBD_FLAG_CAN_MULTI_CONN: u16 = 1 << 8;` (DT-10). Sem outra mudança no protocolo.
+- **Impacto:** novo flag exportado; `server_handshake` inalterado (recebe `tx_flags` pronto).
+- **Teste:** o handshake já é testado; adicionar asserção de que o flag pode compor `tx_flags`.
+
+## Arquivos a MODIFICAR
+
+### `crates/ramshared-wsl2d/src/main.rs`
+- **Igual ao SPEC.md** (run = setup CUDA + mlockall + canário inalterados; cria canal de Jobs;
+  `spawn_acceptor`; worker loop; teardown), com os deltas:
+  - `tx_flags = NBD_FLAG_HAS_FLAGS | NBD_FLAG_SEND_FLUSH | NBD_FLAG_CAN_MULTI_CONN` (DT-10).
+  - Worker loop: `let out = serve(...); /* poll demote_rx + canário §9/§9.4 (no loop, DT-12) */ let _ = job.reply.send(Reply { reply: out.reply, data: out.read_data, disconnect: out.disconnect });` — `out.reply` é `[u8;N]`, casa com `Reply.reply` (DT-8), **sem `.to_vec()`**.
+  - Teardown (DT-12): após `jobs_rx` fechar e `acceptor.join()`, `if let Some(rx)=demote_rx.take() { let _ = rx.recv_timeout(std::time::Duration::from_secs(5)); }`; depois `let r1=backend.zero(); let _=probe.zero(); r1?;`.
+  - **Doc-comment do módulo** (LOW-1): reescrever "serve **uma** conexão... multi-conexão futuro" → reflete N conexões + worker único.
+- **Impacto:** sem uAPI/ABI on-wire (só um flag a mais, compatível); latência por-request preservada; HOL removido.
+
+### `crates/ramshared-wsl2d/src/lib.rs`
+- Igual ao SPEC.md: `pub mod conn;` + `pub use conn::{Job, Reply, CHAN_CAP};`.
+
+### `crates/ramshared-cli/src/cascade.rs`
+- Igual ao SPEC.md: `--connections N` no `up` → `--connections N` ao daemon e `-C N` ao `nbd-client` (só quando N>1). **Não** adiciona `-t` curto (DT-11). Default N=1.
+
+## Ordem de implementação
+
+Igual ao SPEC.md (1→6), com: na fatia 1, `Reply.reply` array fixo + canal de réplica ilimitado;
+fatia 4 inclui `CAN_MULTI_CONN` + término DT-9; fatia 5 = teardown DT-12. Os 2 testes de
+concorrência (DT-14) entram nas fatias 1 e 4.
+
+## Plano de testes
+
+- **Unit (sem GPU):** `job_reply_roundtrip`, `chan_cap_is_bounded`, `slow_writer_does_not_deadlock`,
+  `acceptor_terminates_on_partial_n` (conn.rs) + os 15 da lib seguem verdes.
+- **Ao vivo (GPU+root):** §14.3 (spill, sem regressão + sem reset de conexão sob pressão, DT-11),
+  §14.4 (DEMOTE + disconnect, 0 corrupção, teardown bounded DT-12), **smoke `nbd-client -C 2`** (DT-9/DT-10).
+
+## Contratos e documentação viva
+
+Igual ao SPEC.md + `crates/ramshared-block` (novo flag `CAN_MULTI_CONN` — comentário no `protocol.rs`).
+
+## Checklist de validação
+
+Igual ao SPEC.md.

--- a/docs/daemon-multiconn/SPECv3.md
+++ b/docs/daemon-multiconn/SPECv3.md
@@ -1,0 +1,131 @@
+# SPECv3 — H1 — Daemon NBD multi-conexão / leitor dedicado
+
+> Versão melhorada após 2ª auditoria do Passo 2.5.
+> Baselines preservados: [`SPEC.md`](SPEC.md), [`SPECv2.md`](SPECv2.md).
+> Motivo: o `SPECv2.md` consertou CRITICAL-1/2 + HIGH-2 (DT-7/DT-8/DT-10 **verificados OK**),
+> mas 3 fixes falharam: DT-9 (acceptor com janela temporal não-determinística — F-3/F-4/F-5/F-6),
+> DT-11 (**a válvula backpressure→DEMOTE não existia** — F-8), DT-12 (teardown trocava hang por
+> corrupção no edge #2a — F-9). O SPECv3 substitui essas 3 por desenhos determinísticos
+> (DT-15/DT-16/DT-17) + testes que de fato as exercem (DT-18).
+
+## 0. Proveniência da auditoria
+
+- **Auditado:** `docs/daemon-multiconn/SPECv2.md`. **Resultado:** `no-go`.
+- **Verificados OK (mantidos):** DT-7 (réplica ilimitada → sem deadlock), DT-8 (`Reply.reply:[u8;SIMPLE_REPLY_LEN]`), DT-10 (`CAN_MULTI_CONN` + coerência via write síncrono), DT-13 (`Inflight` fora de escopo).
+- **Bloqueantes endereçados:** F-3/F-4/F-5/F-6 → **DT-15**; F-8 → **DT-16**; F-9 → **DT-17**;
+  F-1/F-10 → **DT-16/DT-18**; F-2/F-7 → docs.
+- **Este `SPECv3.md` é o candidato ativo.**
+- **Revisão no Passo 3 (IMPL):** o `§14.3` ao vivo revelou que **DT-16 (latência total)
+  causava falso-positivo de DEMOTE** sob carga normal (baseline 85µs idle → 1.1ms sob fila
+  = 13× → VRAM demovida cedo, tier inutilizado). DT-16 foi **revisado para serve-only** (ver
+  tabela). Evidência empírica acima da auditoria teórica (Kahneman #13: validar contra a realidade).
+
+## Escopo fechado
+
+Igual ao [`SPECv2.md`](SPECv2.md). Deltas: ciclo de vida acceptor/worker **por mensagens**
+(determinístico, sem timer); latência do canário passa a medir **latência total** (enfileiramento
+→ réplica), fechando a válvula de backpressure; teardown honesto e bounded. **Daemon vira
+N-agnóstico** (aceita qualquer nº de conexões; `N` é só do `nbd-client -C N`).
+
+## Decisões técnicas (delta sobre o SPECv2)
+
+| #    | Decisão | Corrige |
+| ---- | ------- | ------- |
+| DT-7, DT-8, DT-10, DT-13 | **Mantidas do SPECv2** (verificadas OK). | — |
+| DT-1..DT-6 | Herdadas, exceto onde DT-15/16/17 sobrescrevem. | — |
+| **DT-9** | **SUPERSEDED por DT-15.** | F-3/4/5/6 |
+| **DT-11** | **SUPERSEDED por DT-16.** | F-8 |
+| **DT-12** | **SUPERSEDED por DT-17.** | F-9 |
+| **DT-15** | **Ciclo de vida determinístico por mensagens (sem janela temporal).** O canal worker carrega `enum WMsg { Opened, Job(Job), Closed }`. **Acceptor:** loop `accept()` **bloqueante infinito** (sem N, sem timer); por conexão aceita, envia `WMsg::Opened` e spawna **reader** (que faz o **handshake dentro da própria thread** — não no acceptor) + **writer**. **Reader:** se o handshake falhar → loga e sai enviando `WMsg::Closed` (erro confinado à conexão, **não** derruba o acceptor — F-6); senão entra no read-loop e, ao EOF/erro, sai enviando `WMsg::Closed`. **Worker:** `live=0; opened=false;` `for m in rx { Opened⇒{live+=1;opened=true} Closed⇒{live-=1; if live==0 && opened {break}} Job(j)⇒{processa} }`. Término = **todas as conexões abertas fecharam** (determinístico, sem race de template nem janela de 250ms). O acceptor segue bloqueado em `accept()`; o worker quebra explícito → `main` zera e retorna → o processo sai (mata o acceptor). **Daemon N-agnóstico:** sem flag `--connections` no daemon; aceita o que vier. Handshake no reader resolve F-4 (acceptor nunca bloqueia em handshake lento). | **F-3/4/5/6** |
+| **DT-16** | **REVISADO no Passo 3 (§14.3 ao vivo):** a latência do canário mede **serve-only** (tempo da op de VRAM em volta do `serve()`), **NÃO** a latência total. A tentativa de medir a espera na fila (`enqueued.elapsed()`) deu **falso-positivo de DEMOTE sob carga normal** — baseline 85µs (idle) vs ~1.1ms (sob fila) = 13× → VRAM demovida com só ~10-72 MiB absorvidos (vs 511 MiB do baseline), inutilizando o tier. **F-8 mitigado sem trigger por fila:** (a) a falha REAL (eviction WDDM) spike o serve ~330× (Fase 0) → o canário serve-only dispara nela; (b) timeout NBD generoso (sem `-t`) → backpressure degrada a swap-lento, não I/O-error (§14.4: swapoff 6 s sem panic); (c) o regime "moderadamente lento que enche a fila sem spike de serve" não é observado no WDDM (eviction é binário: ok ou 330×) → trigger por profundidade-de-fila é YAGNI; adicionar só se observado. | **F-8** (revisado) |
+| **DT-17** | **Teardown honesto e bounded (liveness + safety):** o read-back do swapoff é servido **no loop** (Jobs READ, enquanto a conexão vive); poll de `demote_rx` **no loop** (desarma o canário). Ao sair do loop (todas as conexões caíram): `match demote_rx.take()` → se `Some(rx)`, `rx.recv_timeout(5s)` (**bounded**, sem hang). **Loga o resultado com honestidade**: `Ok(true)`=DEMOTE limpo; `Ok(false)`/`Err`/timeout=swapoff **não confirmado** (loga `WARN`, não finge sucesso). Zera as duas regiões (`backend.zero()`+`probe.zero()`, ambos): no caminho de teardown **a conexão NBD já caiu** → ninguém lê a VRAM por NBD → zerar é **safe** (o cenário "page-in lê zeros" de F-9 exige conexão viva, que não existe aqui). Edge #2a documentado: disconnect não-ordenado ⇒ swap já quebrado pelo transporte; o daemon loga e zera (lesser evil), não corrompe um swap vivo. | **F-9** |
+| **DT-18** | **Testes que exercem os findings (sem GPU):** `live_count_terminates_on_all_closed` + `live_count_balanced_open_then_close` + `live_count_never_stops_before_any_open` (DT-15: lifecycle determinístico via `LiveCount`); `slow_writer_does_not_deadlock` (DT-7: réplica ilimitada, sem deadlock); `job_reply_roundtrip`/`chan_cap_is_bounded`. O gatilho serve-latency→DEMOTE (DT-16 revisado) é coberto por `latency_demote_needs_consecutive` (residency). A não-regressão do DEMOTE indevido é provada **ao vivo** (§14.3: nbd0 volta a absorver ~500 MiB sem falso-positivo). | **F-10** |
+| DT-19 | **Teto de memória do canal de réplica (corrige F-1):** backlog por conexão ≤ `nr_requests` (profundidade da fila NBD do kernel; o cliente não submete além sem ler réplicas) × `(SIMPLE_REPLY_LEN + max_read_len)`. Para READs grandes são dezenas de MiB/conexão — **limitado**, não ilimitado; declarado explicitamente (não é a conta subdimensionada da DT-7). | F-1 |
+
+## Fronteira de atomicidade e política de rollback
+
+Igual ao SPECv2. Reforço (DT-15): término determinístico por contagem `live` no worker — não
+depende de drop de sender nem de timer. Rollback **app-only**.
+
+## Mapa Kahneman por etapa crítica
+
+| Etapa / ITEM | Disciplina | Link | Pergunta obrigatória | Evidência mínima | Abort trigger |
+| --- | --- | --- | --- | --- | --- |
+| DT-15 (lifecycle) | #5 Worst-case | [`KAHNEMAN`](../methodology/KAHNEMAN-DISCIPLINES.md) | "N parcial / handshake falho / última conexão cai cedo travam o término?" | `acceptor_terminates_on_all_closed` + `handshake_error_isolated` verdes; smoke `-C 2` | worker não termina ou termina cedo → reverter |
+| DT-16 (canário serve-only) | #5 Worst-case + #13 ilusão de validade | [`KAHNEMAN`](../methodology/KAHNEMAN-DISCIPLINES.md) | "medir latência total causa DEMOTE indevido sob carga? a falha real é pega?" | §14.3 ao vivo: nbd0 absorve ~500 MiB SEM falso-positivo (serve-only); falha real = serve 330× (Fase 0) | DEMOTE indevido sob carga normal (nbd0 mal usado) → reverter p/ serve-only |
+| DT-17 (teardown) | #5 + #2 | [`KAHNEMAN`](../methodology/KAHNEMAN-DISCIPLINES.md) | "disconnect no meio do swapoff trava ou corrompe?" | §14.4 ao vivo: DEMOTE 0 corrupção; `recv_timeout` bounded; log honesto | hang no teardown ou corrupção de swap vivo → reverter |
+
+## Checklist de segurança
+
+Igual ao SPECv2. `Context`/`DeviceMem` `!Send` → worker preso à thread do `ctx` por tipo (garantia do compilador).
+
+## Arquivos a CRIAR
+
+### `crates/ramshared-wsl2d/src/conn.rs`
+- **Igual ao SPECv2**, com deltas DT-15/DT-16:
+  - `enum WMsg { Opened, Job(Job), Closed }`; `Job { req: Request, payload: Vec<u8>, reply: std::sync::mpsc::Sender<Reply>, enqueued: std::time::Instant }` (DT-16).
+  - `Reply { reply: [u8; SIMPLE_REPLY_LEN], data: Vec<u8>, disconnect: bool }` (DT-8).
+  - `spawn_reader`: faz `server_handshake` **na thread**; em erro → loga + envia `WMsg::Closed` + retorna. Loop: `read_exact`→`parse_request`→cap anti-DoS→`jobs.send(WMsg::Job(Job{...,enqueued:Instant::now()}))`. EOF/erro→`jobs.send(WMsg::Closed)`.
+  - `spawn_writer`: `for r in replies { write_all(&r.reply); if !r.data.is_empty(){write_all(&r.data)}; flush(); if r.disconnect {break} }`.
+  - `spawn_acceptor`: loop `accept()` bloqueante; por conexão `jobs.send(WMsg::Opened)` + cria canal de réplica ilimitado + spawna writer + reader. (Sem janela, sem N, sem handshake inline.)
+  - Consts: `CHAN_CAP=64` (canal worker de `WMsg`, bounded). Sem `ACCEPT_WINDOW_MS`.
+- **Testes (DT-18, sem GPU):** `job_reply_roundtrip`, `chan_cap_is_bounded`, `slow_writer_does_not_deadlock`, `acceptor_terminates_on_all_closed`, `handshake_error_isolated`.
+
+### `crates/ramshared-block/src/protocol.rs`
+- Igual ao SPECv2: `+ pub const NBD_FLAG_CAN_MULTI_CONN: u16 = 1 << 8;` (DT-10).
+
+## Arquivos a MODIFICAR
+
+### `crates/ramshared-wsl2d/src/main.rs`
+- **Igual ao SPECv2**, com deltas:
+  - `tx_flags |= NBD_FLAG_CAN_MULTI_CONN` (DT-10).
+  - Canal worker: `sync_channel::<WMsg>(CHAN_CAP)`. Worker loop = `match m { Opened/Closed/Job }` (DT-15) com `live`/`opened`.
+  - Em `Job`: `let lat_us = job.enqueued.elapsed().as_micros() as u64;` (DT-16, latência TOTAL); alimenta o `Canary` existente; poll de `demote_rx` + cadência §9.4 **no loop**; `job.reply.send(Reply{ reply: out.reply, data: out.read_data, disconnect: out.disconnect })` (DT-8).
+  - Sem flag `--connections` no daemon (N-agnóstico, DT-15).
+  - Teardown DT-17: `recv_timeout(5s)` + log honesto + zera ambos.
+  - Doc-comment do módulo reescrito (multi-conexão + worker único; sem "futuro").
+- **Impacto:** sem uAPI/ABI on-wire além do flag compatível; latência por-request preservada; HOL removido; válvula de backpressure ativa.
+
+### `crates/ramshared-wsl2d/src/lib.rs`
+- `pub mod conn;` + `pub use conn::{Job, Reply, WMsg, CHAN_CAP};`.
+
+### `crates/ramshared-cli/src/cascade.rs`
+- `up --connections N` (default 1) → `-C N` ao `nbd-client` quando N>1. **Sem `-t` agressivo** (DT-16). Daemon spawnado **sem** `--connections` (N-agnóstico).
+
+### `crates/ramshared-cuda/src/driver.rs` e `crates/ramshared-wsl2d/src/backend.rs`
+- **F-7 (LOW):** comentário no `write_at`/`flush`: "NÃO trocar `cuMemcpyHtoD` para Async sem revisar `CAN_MULTI_CONN` (a coerência cross-conn depende do write síncrono)". Sem mudança de código.
+
+### `docs/daemon-multiconn/PRD.md`
+- **F-2 (LOW):** nota de que o SPEC ativo usa `Reply.reply:[u8;N]` + canal de réplica ilimitado + latência total (PRD descrevia `Vec`/`SyncSender`/serve-latency).
+
+## Ordem de implementação
+
+1. `conn.rs`: `WMsg`/`Job`(+enqueued)/`Reply`([u8;N]) + canal de réplica ilimitado + testes puros (DT-7/DT-18: `slow_writer_does_not_deadlock`, `job_reply_roundtrip`, `chan_cap_is_bounded`).
+2. `protocol.rs`: `NBD_FLAG_CAN_MULTI_CONN`.
+3. `main.rs`: canal `WMsg` + worker loop (`live`/`opened`) + latência total (DT-16) + canário/DEMOTE no loop. Validar §14 (não-regressão).
+4. `conn.rs`: `spawn_reader`(handshake na thread)/`spawn_writer`/`spawn_acceptor` + testes `acceptor_terminates_on_all_closed`, `handshake_error_isolated`. Remove HOL.
+5. `main.rs`: teardown DT-17 (recv_timeout + log honesto + zera ambos).
+6. `cascade.rs`: `up --connections N` → `-C N`. Smoke `-C 2`.
+7. `residency.rs` teste `backpressure_inflates_latency_demotes` (DT-18, prova a válvula).
+
+## Plano de testes
+
+- **Unit (sem GPU):** os 5 de `conn.rs` (DT-18) + `backpressure_inflates_latency_demotes` (residency) + os 15 da lib seguem verdes.
+- **Ao vivo (GPU+root):** §14.3 (spill, sem regressão + sem reset de conexão sob pressão, DT-16), §14.4 (DEMOTE + 0 corrupção + teardown bounded DT-17), **smoke `nbd-client -C 2`** (DT-10/DT-15).
+
+## Contratos e documentação viva
+
+| Documento | Atualização | Motivo |
+| --- | --- | --- |
+| `ARCHITECTURE.md` | Alterar | daemon = worker único + N conexões (não serial) |
+| `ROADMAP.md` | Alterar | H1 → Feito |
+| `docs/daemon-multiconn/IMPL.md` | Criar | Passo 3 |
+| `MEMORY.md` | Alterar | entrada da sessão |
+
+## Checklist de validação
+
+- [ ] `cargo fmt --all -- --check` · `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace` (+ `conn.rs` + `backpressure_inflates_latency_demotes`)
+- [ ] §14.3 / §14.4 ao vivo (sudo bash, sandbox off) — sem regressão, sem reset de conexão
+- [ ] smoke `nbd-client -C 2` — multi-conexão íntegra
+- [ ] cada etapa crítica do Mapa Kahneman: pergunta/evidência/abort cumpridos

--- a/docs/ublk-backend/PRD.md
+++ b/docs/ublk-backend/PRD.md
@@ -1,0 +1,114 @@
+---
+slug: ublk-backend
+title: ublk no lugar do NBD para o tier VRAM (Fase B)
+milestone: —
+issues: [3]
+---
+# PRD — Fase B — ublk no lugar do NBD para o tier VRAM
+
+> **Status: DESIGN-ONLY (Fase B, kernel-gated).** Verificado: este kernel WSL2 **não tem**
+> `CONFIG_BLK_DEV_UBLK` e o módulo `ublk_drv` não existe. IMPL/validação exigem **kernel
+> custom**. Este PRD fecha o desenho e — importante — registra uma **tensão de política**
+> (io_uring vs zero-dep/`forbid(unsafe_code)`) que precisa de decisão antes do Passo 3.
+> Itens **Inferência** não puderam ser testados.
+
+## Resumo
+
+A VRAM é exposta como block device via **NBD** (socket Unix + protocolo on-wire; o
+`ramshared-wsl2d` serve cada request com round-trips de socket). O **ublk** (`ublk_drv` +
+servidor userspace sobre **io_uring**) elimina o round-trip de socket e cópias: o kernel e o
+servidor compartilham buffers via io_uring, com menos context-switches. Objetivo: **latência
+menor** no caminho quente do tier VRAM (Confirmado em docs: ROADMAP Fase B; LIBRARIES.md "ublk:
+latência menor (io_uring), sem round-trip socket").
+
+## Contexto técnico
+
+- **Confirmado no codebase:**
+  - Transporte atual = NBD: `crates/ramshared-block` (protocolo) + `crates/ramshared-wsl2d`
+    (daemon, worker CUDA único H1). `LIBRARIES.md`: "Block backend: ublk (Fase B) — exige
+    kernel custom; só após Fase B".
+  - O daemon é **`#![forbid(unsafe_code)]`**; o único `unsafe` do projeto vive isolado em
+    `ramshared-cuda` (FFI da libcuda). **Zero deps externas** (Cargo.lock confirma).
+- **Confirmado na documentação oficial (kernel `Documentation/block/ublk.rst`):**
+  - `ublk_drv` cria `/dev/ublkbN`; o servidor userspace usa **io_uring** + a uAPI ublk
+    (`UBLK_IO_FETCH_REQ`/`COMMIT_AND_FETCH`) para receber/completar I/O. Buffers compartilhados.
+  - Requer `CONFIG_BLK_DEV_UBLK`. Implementação de referência: `ubdsrv` (C, liburing).
+- **Proposto / Inferência:**
+  - Servir o tier VRAM via ublk: o **worker CUDA único** (H1) processa os requests vindos do
+    io_uring em vez do socket NBD. **Inferência:** o reader/acceptor do H1 (sockets) é
+    substituído por um loop io_uring; o worker CUDA e o canário §9/§9.4 permanecem.
+
+## Opção recomendada
+
+**Servidor ublk reusando o worker CUDA único do H1; transporte NBD→io_uring; FFI mínima para
+io_uring isolada (como `ramshared-cuda`).**
+
+- O daemon ganha um modo ublk: loop io_uring (submit/complete) alimenta o **mesmo** canal
+  `WMsg`/worker do H1; o worker serve a VRAM e completa via io_uring.
+- **Tensão de política (decisão obrigatória antes do Passo 3):** io_uring em Rust exige **ou**
+  (a) uma **crate externa** (`io-uring`) — quebra o zero-dep (LIBRARIES.md #11), **ou** (b)
+  **FFI/`unsafe` hand-rolled** sobre `liburing`/syscalls — quebra o `forbid(unsafe_code)` do
+  daemon. **Recomendação:** isolar a FFI io_uring num **crate novo `ramshared-uring`** com
+  `unsafe` contido + `// SAFETY:` (espelhando o modelo do `ramshared-cuda`), mantendo o daemon
+  e a lib `forbid(unsafe_code)`. Decisão a registrar em `LIBRARIES.md` + ADR.
+- **Alternativas descartadas:**
+  - **crate `io-uring` externa** — viola o zero-dep num projeto Ring-0/Day-0; supply chain.
+  - **manter NBD (Day-0)** — funciona (validado §14/H1); ublk é otimização Fase B, não correção.
+  - **NBD + ublk dual-path permanente** — viola Day-0 (dois transportes); ublk **substitui** o
+    NBD quando maduro (ou fica atrás de feature-flag de build até a paridade).
+- **Trade-offs:** ganho de latência (Inferência — medir) ao custo de uma área `unsafe` nova
+  (io_uring FFI) e complexidade da uAPI ublk; depende de kernel custom.
+
+## Requisitos funcionais
+
+- **RF-1 — Device ublk servido pela VRAM.** O daemon cria/serve `/dev/ublkbN` respaldado pela
+  VRAM. *Aceite:* `mkswap`/`swapon` do ublk device; round-trip íntegro. **(kernel-gated)**
+- **RF-2 — Worker CUDA único preservado.** O loop io_uring alimenta o worker H1 (afinidade
+  CUDA); a VRAM segue serializada por 1 thread. *Aceite:* sem corrupção; 0 `unsafe` no worker.
+- **RF-3 — Canário/DEMOTE preservados.** §9 (latência serve-only) e §9.4 + DEMOTE funcionam
+  sobre ublk. *Aceite:* §14 adaptado verde. **(kernel-gated)**
+- **RF-4 — Isolamento do `unsafe`.** A FFI io_uring fica num crate dedicado; daemon/lib seguem
+  `forbid(unsafe_code)`. *Aceite:* `grep unsafe` só no crate novo + `ramshared-cuda`.
+
+## Requisitos não-funcionais
+
+- **Performance:** latência < NBD (Inferência — medir p50/p99 no kernel).
+- **Segurança:** `unsafe` só no crate io_uring, com `// SAFETY:` por bloco (regra rust/security);
+  sem dep externa nova.
+- **Resiliência:** falha de io_uring → DEMOTE (como hoje); worst-case #5 no SPEC.
+
+## Fluxos
+
+**Happy path (Fase B):** daemon modo ublk → io_uring fetch req → enfileira no worker → CUDA
+serve → completa via io_uring. Canário/DEMOTE iguais ao H1. **Erro:** io_uring/CUDA falha →
+DEMOTE; device removal → teardown zera a VRAM.
+
+## Modelo de dados
+
+- `ramshared-uring` (novo crate): wrappers RAII sobre io_uring (`unsafe` isolado), espelhando o
+  `ramshared-cuda`. Sem struct uAPI exposta a userspace (ublk uAPI é do kernel).
+
+## API / Interfaces
+
+- **Kconfig:** `CONFIG_BLK_DEV_UBLK=y` (kernel custom). **CLI:** `up --transport ublk` (default
+  nbd até paridade). Sem ioctl próprio (usa a uAPI ublk do kernel).
+
+## Dependências e riscos
+
+- **Pré-requisito duro:** kernel com `CONFIG_BLK_DEV_UBLK` + `ublk_drv` (ausente — verificado).
+- **Riscos:** (a) **io_uring + afinidade CUDA** — o thread que faz `io_uring_enter` vs o worker
+  CUDA: a completion não pode rodar CUDA fora da thread do ctx (worst-case #5, fechar no SPEC);
+  (b) **`unsafe` novo** (io_uring FFI) — mitigado por crate isolado; (c) complexidade da uAPI
+  ublk (FETCH/COMMIT) — Inferência, validar contra `ublk.rst`/`ubdsrv`.
+- **Rollout/rollback:** app-only + `--transport` (default nbd). ublk substitui NBD só na paridade.
+
+## Estratégia de implementação (quando houver kernel)
+
+1. ADR + LIBRARIES.md: decidir crate `ramshared-uring` (unsafe isolado) vs crate externa. 2.
+`ramshared-uring` (FFI io_uring RAII). 3. Daemon modo ublk reusando worker H1. 4. `--transport`
+no CLI. 5. §14 adaptado + bench de latência vs NBD.
+
+## Fora de escopo
+
+- IMPL/validação agora (kernel-gated). Trocar o modelo de worker único. Manter NBD+ublk dual
+  permanente (Day-0). zram-writeback (item 4, separado, mas combinável depois).

--- a/docs/ublk-backend/SPEC.md
+++ b/docs/ublk-backend/SPEC.md
@@ -1,0 +1,74 @@
+# SPEC — Fase B — ublk no lugar do NBD para o tier VRAM
+
+Fonte: [`PRD.md`](PRD.md). **DESIGN-ONLY / kernel-gated** (sem `CONFIG_BLK_DEV_UBLK` no WSL2 —
+verificado). Fecha o desenho + a **decisão de política** (io_uring vs zero-dep/`forbid(unsafe)`).
+Passo 3 fica para kernel custom. Itens não-testáveis = **(kernel-gated)**.
+
+## Escopo fechado
+
+**Entra (quando houver kernel):** crate `ramshared-uring` (FFI io_uring com `unsafe` isolado);
+daemon modo ublk reusando o worker CUDA único (H1); `up --transport ublk` (default `nbd`).
+**Fica fora:** IMPL/validação agora; crate io_uring externa; dual NBD+ublk permanente; trocar o
+worker único; zram-writeback (item 4).
+
+## Matriz de rastreabilidade PRD → SPEC
+
+| PRD | SPEC |
+| --- | --- |
+| RF-1 (device ublk) | DT-2, ITEM-2 |
+| RF-2 (worker único) | DT-3, ITEM-2 |
+| RF-3 (canário/DEMOTE) | DT-3, ITEM-2 |
+| RF-4 (unsafe isolado) | DT-1, ITEM-1 |
+
+## Decisões técnicas
+
+| # | Decisão | Justificativa |
+| --- | --- | --- |
+| DT-1 | **Crate novo `ramshared-uring`** encapsula a FFI io_uring/liburing com `unsafe` contido + `// SAFETY:` por bloco (espelha `ramshared-cuda`). O daemon e a lib `ramshared-wsl2d` seguem `#![forbid(unsafe_code)]`; **zero dep externa** (FFI hand-rolled, não a crate `io-uring`). Registrar em `LIBRARIES.md` + ADR. | resolve a tensão io_uring×política sem quebrar zero-dep nem espalhar `unsafe`. |
+| DT-2 | O daemon ganha **modo ublk**: loop io_uring (`UBLK_IO_FETCH_REQ`/`COMMIT_AND_FETCH`) traduz cada request da uAPI ublk num `Job` do **mesmo** canal `WMsg` do H1. NBD permanece como `--transport nbd` (default) até paridade; ublk = `--transport ublk`. | reusa toda a máquina H1 (worker, canário, DEMOTE); só troca o transporte. |
+| DT-3 | **Afinidade CUDA preservada:** a thread do io_uring (`io_uring_enter`/completion) **não** roda CUDA — ela só enfileira `Job`s e completa I/O; o **worker CUDA único** (thread do `ctx`) serve a VRAM, como no H1. Completar via io_uring a partir do worker exige passar o handle do request pelo `Reply` (análogo ao `Sender<Reply>` por conexão). **(kernel-gated — confirmar a thread-safety do io_uring CQE cross-thread no SPEC do IMPL.)** | mantém a garantia `!Send` do `Context`; não regride H1. |
+| DT-4 | **DEMOTE/canário:** latência serve-only (DT-16 do H1) medida no worker; gatilho e `spawn_swapoff` iguais; teardown zera a VRAM. ublk device removal = EOF equivalente. | reuso direto do H1. |
+
+## Fronteira de atomicidade e rollback
+
+- Atomicidade: worker único serializa a VRAM (igual H1). io_uring SQ/CQ por request.
+- Rollback: **app-only** + `--transport` default `nbd` (fallback Day-0 validado). ublk substitui
+  NBD só na paridade (sem dual-path permanente).
+
+## Mapa Kahneman por etapa crítica
+
+| Etapa / ITEM | Disciplina | Link | Pergunta obrigatória | Evidência mínima | Abort trigger |
+| --- | --- | --- | --- | --- | --- |
+| ITEM-1 (`ramshared-uring`, unsafe) | #11 halo + rust/security | [`KAHNEMAN`](../methodology/KAHNEMAN-DISCIPLINES.md) | "io_uring justifica `unsafe` novo vs manter NBD?" | bench (kernel) latência ublk < NBD por ≥X%; `unsafe` só no crate; `// SAFETY:` por bloco | sem ganho de latência medível → manter NBD |
+| ITEM-2 (io_uring × afinidade CUDA) | #5 Worst-case | [`KAHNEMAN`](../methodology/KAHNEMAN-DISCIPLINES.md) | "completar CQE de outra thread roda CUDA fora do ctx?" | (kernel) worker é o único a tocar CUDA; lockdep/asan limpos | CUDA chamado fora da thread do ctx → reverter |
+
+## Arquivos a CRIAR / MODIFICAR (quando houver kernel)
+
+### `crates/ramshared-uring/` (CRIAR — kernel-gated)
+- FFI io_uring (RAII, `unsafe` isolado, `// SAFETY:` por bloco), espelhando `ramshared-cuda`.
+  ADR + `LIBRARIES.md` registram a decisão (#11).
+
+### `crates/ramshared-wsl2d/src/` (MODIFICAR — kernel-gated)
+- Modo ublk: loop io_uring → `WMsg`/worker H1; `Reply` carrega o handle do request ublk p/
+  completar. `--transport {nbd,ublk}`. Mantém `forbid(unsafe_code)` (o `unsafe` vive no crate novo).
+
+### `crates/ramshared-cli/src/cascade.rs` (MODIFICAR — kernel-gated)
+- `up --transport ublk` → daemon em modo ublk; `swapon /dev/ublkbN` no lugar do nbd.
+
+## Plano de testes (quando houver kernel)
+
+- §14 adaptado sobre ublk (spill/DEMOTE/integridade); **bench de latência ublk vs NBD** (a
+  justificativa da feature — sem ganho, não adota). `grep unsafe` confina ao crate novo + cuda.
+- **Hoje (sem kernel):** N/A — só o desenho/política é auditável.
+
+## Checklist de validação
+
+- [ ] (kernel) `CONFIG_BLK_DEV_UBLK=y`; `/dev/ublkbN` servido; round-trip íntegro.
+- [ ] (kernel) latência ublk < NBD (bench, número) — senão **não adota** (mantém NBD).
+- [ ] (kernel) `unsafe` só em `ramshared-uring` + `ramshared-cuda`; daemon `forbid(unsafe_code)`.
+- [x] Desenho + decisão de política (crate `ramshared-uring`) + riscos (afinidade CUDA) fechados.
+
+## Documentos a atualizar (no IMPL futuro)
+
+`docs/ublk-backend/IMPL.md`; ADR-novo (crate `ramshared-uring`/io_uring); `LIBRARIES.md`
+(ublk: NÃO usado → ativo; io_uring FFI); `ARCHITECTURE.md`; `ROADMAP.md` (Fase B).

--- a/docs/ublk-backend/SPECv2.md
+++ b/docs/ublk-backend/SPECv2.md
@@ -1,0 +1,50 @@
+# SPECv2 — Fase B — ublk no lugar do NBD
+
+> Versão após auditoria do Passo 2.5. Baseline: [`SPEC.md`](SPEC.md). **DESIGN-ONLY / kernel-gated.**
+> Motivo (no-go do SPEC): (H5-1) DT-3 mandava **completar o CQE a partir do worker** = submissão
+> cross-thread no mesmo io_uring (modelo de threading inválido); (M5-1) custo do `unsafe` de
+> io_uring hand-rolled subestimado (barreiras de memória, ring compartilhado ≠ FFI dlopen do CUDA);
+> (M5-2) gate só no Kconfig do ublk, faltando `io_uring`/`ublk-control`; (M5-3) `nbd_dev` hardcoded
+> no DEMOTE.
+
+## 0. Proveniência da auditoria
+
+- **Auditado:** `SPEC.md`. **Resultado:** `no-go` (1 HIGH de design + 3 MEDIUM). Day-0, política e
+  rastreabilidade do SPEC foram aprovados; o furo era localizado (threading do ring).
+- **Este SPECv2 é o design ativo** (kernel-gated; IMPL no Passo 3 futuro).
+
+## Decisões técnicas (delta sobre o SPEC)
+
+| # | Decisão | Corrige |
+| --- | --- | --- |
+| DT-3 | **A thread io_uring é a ÚNICA dona do ring** (submit + complete). Fluxo: thread io_uring colhe `UBLK_IO_FETCH_REQ` → enfileira `Job` no canal `WMsg` (worker H1) → worker CUDA processa → devolve `Reply` (com o handle do request) por um canal **de volta à thread io_uring** → a thread io_uring submete o `UBLK_IO_COMMIT_AND_FETCH_REQ`. O worker **nunca** toca o ring (espelha exatamente o writer do H1: o worker manda `Reply`, outra thread faz o I/O de saída). Resolve a submissão cross-thread. | H5-1 |
+| DT-1 | **Calibração honesta do `unsafe` (M5-1):** io_uring hand-rolled exige `mmap` das filas SQ/CQ + **barreiras de memória** (`acquire`/`release` nos índices) + protocolo de ring — `unsafe` **qualitativamente mais perigoso** que o `dlopen`+chamadas síncronas do `ramshared-cuda`. Por isso o ADR deve pesar **duas** opções de verdade: (a) crate `ramshared-uring` hand-rolled (zero-dep, mas barreiras em `unsafe` = risco de correção alto); (b) crate **`io-uring` externa auditada** (quebra zero-dep, mas a unsafe de baixo nível fica numa lib madura). **Recomendação revisada:** dado o risco de correção de barreiras de memória, a crate auditada pode ser a escolha **mais segura** apesar do zero-dep — decisão para o ADR com critério (LoC unsafe, histórico de CVEs da crate, bench). Não pré-decidir hand-rolled. | M5-1 |
+| DT-5 | **Gate completo (M5-2):** exigir `CONFIG_BLK_DEV_UBLK` **e** `io_uring` funcional + `/dev/ublk-control` (o `check` do projeto já sabe checar io_uring). Nota factual: `CONFIG_IO_URING=y` **já existe** no WSL2 atual — falta só o `ublk_drv`. | M5-2 |
+| DT-6 | **Generalizar o device de swap (M5-3):** o DEMOTE/`spawn_swapoff` e o arg `--nbd` viram **`--swap-dev`/`swap_dev`** genérico (`/dev/nbd0` ou `/dev/ublkbN`). Sob ublk a VRAM **continua em swap** (só muda o transporte), então o `swapoff <swap_dev>` do DEMOTE permanece seguro (kernel drena) — diferente do item 4. | M5-3 |
+| DT-2 | **Mantida:** daemon modo ublk reusa o worker H1; `--transport {nbd,ublk}` default `nbd`; ublk substitui NBD na paridade (sem dual-path permanente). | — |
+
+## Fronteira de atomicidade e rollback
+
+- Atomicidade: worker único serializa a VRAM (H1); ring possuído por 1 thread (DT-3). DEMOTE =
+  `swapoff <swap_dev>` (seguro, kernel drena — a VRAM segue swap sob ublk).
+- Rollback: app-only + `--transport` default `nbd` (fallback Day-0 validado §14).
+
+## Mapa Kahneman (corrigido)
+
+| Etapa / ITEM | Disciplina | Link | Pergunta | Evidência mínima | Abort trigger |
+| --- | --- | --- | --- | --- | --- |
+| ITEM-1 (`ramshared-uring` vs crate) | #11 halo + rust/security | [`KAHNEMAN`](../methodology/KAHNEMAN-DISCIPLINES.md) | "hand-roll barreiras de io_uring (risco de correção) vs crate auditada (quebra zero-dep)?" | ADR com LoC unsafe + CVEs da crate + bench; latência ublk < NBD por ≥X% | sem ganho de latência → manter NBD |
+| ITEM-2 (ring threading, DT-3) | #5 Worst-case | [`KAHNEMAN`](../methodology/KAHNEMAN-DISCIPLINES.md) | "quem toca o ring? CUDA fora do ctx?" | thread io_uring é única dona do ring; worker é única a tocar CUDA; asan/lockdep limpos | submissão cross-thread no ring / CUDA fora do ctx → reverter |
+
+## Recomendação final (design ativo)
+
+Desenho **sólido e pronto como spec de design** (kernel-gated). Diferente do item 4, o ublk
+**mantém o DEMOTE seguro** (VRAM segue swap) e o furo de threading foi fechado (DT-3). A única
+decisão aberta — e deliberadamente roteada ao **ADR** — é hand-rolled vs crate `io-uring` (DT-1),
+a ser fechada com números quando o kernel custom existir. Passo 3 abre com `CONFIG_BLK_DEV_UBLK`.
+
+## Validação
+
+- **Hoje:** N/A (design-only). Entregue: desenho de threading correto + decisão de política roteada.
+- **Futuro (kernel):** §14 sobre ublk + bench latência ublk vs NBD (justificativa) + `grep unsafe`
+  confinado a `ramshared-uring`/`ramshared-cuda`.

--- a/docs/zram-writeback-vram/PRD.md
+++ b/docs/zram-writeback-vram/PRD.md
@@ -1,0 +1,129 @@
+---
+slug: zram-writeback-vram
+title: zram writeback do frio direto na VRAM (Fase B)
+milestone: —
+issues: [3]
+---
+# PRD — Fase B — zram writeback do frio direto na VRAM
+
+> **Status: DESIGN-ONLY (Fase B, kernel-gated).** Verificado: este kernel WSL2
+> (`6.6.114.1-microsoft-standard-WSL2`) **não tem** `CONFIG_ZRAM_WRITEBACK` (`# ... is not set`).
+> IMPL e validação exigem **kernel custom**. Este PRD fecha o desenho; o Passo 3 fica para
+> quando houver kernel com o config. Itens marcados **Inferência** não puderam ser testados.
+
+## Resumo
+
+Hoje a cascata trata zram e VRAM como **tiers de swap separados** (`zram 200 > nbd 100 >
+VHDX -2`): uma página fria desce de zram para a VRAM **re-swapando** por outro device NBD —
+caminho que passa por userspace (daemon) a cada página fria. A feature usa o **writeback
+nativo do zram** (`CONFIG_ZRAM_WRITEBACK`): zram escreve as páginas **idle/incompressíveis**
+direto para um `backing_dev` — apontado para a **VRAM** — sem o page-in/page-out extra por um
+2º device de swap. Reduz cópias no caminho frio e libera RAM do zram mais cedo.
+
+Valor: menos amplificação de I/O no caminho frio (Confirmado em docs: ROADMAP Fase B) e RAM do
+zram liberada sob pressão; mantém a VRAM como destino frio (alinhado ao SPECv3-WSL2).
+
+## Contexto técnico
+
+- **Confirmado no codebase:**
+  - Cascata atual: `crates/ramshared-cli/src/cascade.rs` monta `zram` (lzo-rle, prio 200) e
+    `nbd0` (VRAM, prio 100) como **swaps independentes**. Sem `backing_dev`.
+  - `docs/LIBRARIES.md` lista **zram-writeback** em "deliberadamente NÃO usado — exige
+    `CONFIG_ZRAM_WRITEBACK` (kernel custom); cascata por prioridade resolve Day-0".
+  - VRAM exposta como block device via `ramshared-wsl2d` (NBD) ou (Fase B) ublk.
+- **Confirmado na documentação oficial (kernel `Documentation/admin-guide/blockdev/zram.rst`):**
+  - zram aceita `backing_dev` (`echo /dev/X > /sys/block/zramN/backing_dev`) **antes** do
+    `disksize`. Writeback via `echo idle|huge|huge_idle > /sys/block/zramN/writeback`.
+  - `mem_limit`/`idle` marcam páginas; só páginas **incompressíveis (huge)** ou **idle** vão ao
+    backing_dev. `writeback_limit` controla o volume.
+  - O `backing_dev` deve ser um **block device** (não arquivo).
+- **Proposto / Inferência:**
+  - Apontar `backing_dev` do zram para o **device de VRAM** (o `/dev/nbdX` do daemon, ou um
+    device ublk na Fase B). **Inferência:** o zram writeback emite BIOs ao backing_dev como I/O
+    de bloco normal — o daemon serve via o caminho NBD existente (mesma VRAM, mesmo worker único).
+  - Substituir o **2º swap tier (nbd0 prio 100)** pelo `backing_dev` do zram: a VRAM deixa de
+    ser swap independente e vira o **store de writeback do zram**. **Inferência** (muda a
+    arquitetura da cascata; precisa do kernel p/ validar a semântica de pressão).
+
+## Opção recomendada
+
+**`backing_dev` do zram = device de VRAM; VRAM deixa de ser swap tier separado.**
+
+- `up` (Fase B): `modprobe zram` → `echo <vram_blockdev> > /sys/block/zram0/backing_dev` →
+  `disksize` → `mkswap`/`swapon` só do **zram** → política `echo idle > .../writeback` em
+  cadência (ou `huge` para incompressíveis na hora). VHDX permanece como tier final (`swapon`
+  prio menor) para overflow do próprio backing_dev/zram.
+- Por quê: elimina o page-out por um 2º swap device (o frio sai do zram direto pro backing);
+  o kernel gerencia idle/huge nativamente (menos lógica userspace); reusa o device de VRAM já
+  validado (H1).
+- **Alternativas descartadas:**
+  - **Manter 2 tiers separados (Day-0 atual)** — funciona, mas dobra o I/O no caminho frio
+    (zram→swapout→nbd). É o baseline; a Fase B existe para superá-lo.
+  - **`backing_dev` = arquivo no VHDX** — zram writeback aceita só block device; e mandaria o
+    frio pro disco, não pra VRAM (perde o ganho).
+- **Trade-offs:** muda a forma da cascata (VRAM vira backing, não swap); a observabilidade
+  passa a ser via `/sys/block/zram0/bd_stat` em vez de `/proc/swaps` do nbd0; depende de
+  kernel custom.
+
+## Requisitos funcionais
+
+- **RF-1 — Backing dev na VRAM.** `up --writeback` aponta `backing_dev` do zram para o device de
+  VRAM antes do `disksize`. *Aceite:* `/sys/block/zram0/backing_dev` ecoa o device; `bd_stat`
+  evolui sob writeback. **Inferência (precisa de kernel).**
+- **RF-2 — Política de writeback.** Disparar `writeback` por `idle` (cadência) e/ou `huge`
+  (incompressíveis na hora), com `writeback_limit` para não saturar a VRAM. *Aceite:* páginas
+  idle migram pro backing; RAM do zram cai. **Inferência.**
+- **RF-3 — VHDX como overflow final.** Quando a VRAM (backing) enche, o excedente vai ao VHDX.
+  *Aceite:* sob pressão > VRAM, VHDX cresce; sem OOM. **Inferência.**
+- **RF-4 — DEMOTE coerente.** O canário §9/§9.4 e o DEMOTE continuam protegendo a VRAM; com a
+  VRAM como backing, o "DEMOTE" passa a ser **desabilitar o backing_dev** (não `swapoff` do
+  nbd). *Aceite:* sob eviction, o backing é drenado/desligado sem perda. **Inferência (decisão
+  de design a fechar no SPEC).**
+
+## Requisitos não-funcionais
+
+- **Performance:** menos uma cópia no caminho frio vs baseline (Inferência — medir no kernel).
+- **Segurança:** sem novo input externo; root; a VRAM segue não endereçável fora do device.
+- **Resiliência:** writeback_limit evita saturar a VRAM; VHDX como rede final.
+- **Observabilidade:** `/sys/block/zram0/{bd_stat,mm_stat}`; substituir a linha "Tiers" do
+  `check` para refletir backing em vez de 2º swap.
+
+## Fluxos
+
+**Happy path (Fase B):** `up --writeback` → zram com `backing_dev`=VRAM → carga enche o zram →
+páginas idle/huge → writeback pra VRAM → RAM do zram liberada; overflow → VHDX. `down` →
+`writeback_limit 0` + drena + `swapoff zram` + solta o backing + daemon zera a VRAM.
+
+**Erro:** backing_dev cheio → writeback falha → páginas ficam no zram (RAM) → pressão sobe →
+canário/VHDX. backing_dev some (DEMOTE) → desabilita writeback, mantém zram em RAM.
+
+## Modelo de dados
+
+- Sem struct uAPI nova (usa sysfs do zram). Estado novo: o `backing_dev` (block device de VRAM)
+  + `writeback_limit`. Ciclo de vida: setar backing **antes** do disksize; soltar no teardown.
+
+## API / Interfaces
+
+- **Sem ioctl novo.** Usa sysfs do zram (`backing_dev`, `writeback`, `writeback_limit`,
+  `idle`, `bd_stat`). CLI: `ramshared up --writeback [--wb-limit N]`.
+- **Kconfig:** exige `CONFIG_ZRAM_WRITEBACK=y` (kernel custom — Fase B).
+
+## Dependências e riscos
+
+- **Pré-requisito duro:** kernel com `CONFIG_ZRAM_WRITEBACK` (ausente no WSL2 atual — verificado).
+- **Riscos:** (a) o zram writeback a um backing NBD/ublk pode ter latência/reentrância não óbvia
+  (BIO do kernel → daemon userspace → CUDA) — **Inferência**, medir; (b) semântica de DEMOTE
+  muda (backing vs swap) — decisão de design; (c) deadlock se o backing_dev (VRAM via daemon)
+  depender de RAM que o zram está liberando — **worst-case #5**, analisar no SPEC.
+- **Rollout/rollback:** app-only + flag `--writeback` (default off → mantém o Day-0 de 2 tiers).
+
+## Estratégia de implementação (quando houver kernel)
+
+1. CLI `up --writeback`: setar backing_dev + disksize + política. 2. `check`/`status` refletir
+backing. 3. Política de writeback (idle cadência). 4. DEMOTE adaptado (desligar backing). 5.
+Aceitação §14 adaptada (bd_stat).
+
+## Fora de escopo
+
+- IMPL/validação agora (kernel-gated). Writeback a arquivo. Mudar o worker único do daemon.
+- Substituir NBD por ublk (item 5, separado).

--- a/docs/zram-writeback-vram/SPEC.md
+++ b/docs/zram-writeback-vram/SPEC.md
@@ -1,0 +1,79 @@
+# SPEC — Fase B — zram writeback do frio direto na VRAM
+
+Fonte: [`PRD.md`](PRD.md). **DESIGN-ONLY / kernel-gated** (sem `CONFIG_ZRAM_WRITEBACK` no WSL2
+atual — verificado). Fecha as decisões de design; o Passo 3 (IMPL) fica para quando houver
+kernel custom. Itens não-testáveis agora estão marcados **(kernel-gated)**.
+
+## Escopo fechado
+
+**Entra (quando houver kernel):** `backing_dev` do zram = device de VRAM; política de
+writeback por `idle`/`huge` com `writeback_limit`; VHDX como overflow final; DEMOTE adaptado.
+Flag `up --writeback` (default off → mantém o Day-0 de 2 tiers).
+**Fica fora:** IMPL/validação agora; writeback a arquivo; trocar o worker único; ublk (item 5).
+
+## Matriz de rastreabilidade PRD → SPEC
+
+| PRD | SPEC |
+| --- | --- |
+| RF-1 (backing na VRAM) | DT-1, ITEM-1 |
+| RF-2 (política writeback) | DT-2, ITEM-2 |
+| RF-3 (VHDX overflow) | DT-3, ITEM-1 |
+| RF-4 (DEMOTE coerente) | DT-4, ITEM-3 |
+
+## Decisões técnicas
+
+| # | Decisão | Justificativa |
+| --- | --- | --- |
+| DT-1 | `backing_dev` = o device de VRAM já existente (`/dev/nbdX` do daemon H1, ou ublk na Fase B). Setado **antes** do `disksize` (exigência do zram). A VRAM **deixa** de ser `swapon` separado; vira store de writeback do zram. | reusa o device validado (H1); elimina o 2º swap-out do caminho frio. |
+| DT-2 | Writeback por **`idle`** (cadência, ex.: a cada T) + **`huge`** (incompressíveis na hora); `writeback_limit` = função do tamanho da VRAM (não saturar). | nativo do kernel; controla volume; idle = frio de verdade. |
+| DT-3 | VHDX permanece `swapon` com prio menor que o zram, como overflow quando a VRAM (backing) enche. | rede final; sem OOM. |
+| DT-4 | **DEMOTE adaptado:** com a VRAM como backing (não swap), o gatilho do canário passa a **desabilitar o writeback** (`writeback_limit 0`) + drenar o backing, em vez de `swapoff`. As páginas já no backing precisam ser lidas de volta para o zram/VHDX antes de soltar a VRAM. **(kernel-gated — decisão a confirmar na semântica real do zram.)** | mantém a proteção §9 sob a nova arquitetura. |
+
+## Fronteira de atomicidade e rollback
+
+- Atomicidade: cada writeback é I/O de bloco do kernel ao backing (atômico por página). DEMOTE
+  drena o backing antes de soltar.
+- Rollback: **app-only** + flag `--writeback` default off (o Day-0 de 2 tiers é o fallback).
+
+## Mapa Kahneman por etapa crítica
+
+| Etapa / ITEM | Disciplina | Link | Pergunta obrigatória | Evidência mínima | Abort trigger |
+| --- | --- | --- | --- | --- | --- |
+| ITEM-1 (backing=VRAM via daemon) | #5 Worst-case | [`KAHNEMAN`](../methodology/KAHNEMAN-DISCIPLINES.md) | "o writeback do zram ao backing (NBD→daemon→CUDA) reentra na RAM que o zram está liberando → deadlock?" | (kernel) `bd_stat` evolui sob carga sem stall; sem deadlock em lockdep | stall de I/O / deadlock no writeback → reverter p/ 2 tiers |
+| ITEM-3 (DEMOTE adaptado) | #2 Counterfactual | [`KAHNEMAN`](../methodology/KAHNEMAN-DISCIPLINES.md) | "soltar a VRAM-backing com páginas vivas nela perde dado?" | (kernel) DEMOTE drena backing→VHDX 0 corrupção | corrupção ao soltar o backing → reverter |
+
+## Arquivos a MODIFICAR (quando houver kernel)
+
+### `crates/ramshared-cli/src/cascade.rs`
+- **O que muda:** `up --writeback [--wb-limit N]`: após `modprobe zram`, `echo <vram_dev> >
+  /sys/block/zramN/backing_dev` **antes** do `disksize`; **não** fazer `swapon` do nbd0 (a VRAM
+  vira backing, não swap); setar `writeback_limit`; iniciar política `idle` em cadência. `down`:
+  `writeback_limit 0` + drenar + `swapoff zram` + soltar backing + daemon zera a VRAM.
+- **Requisitos:** RF-1, RF-2, RF-3, DT-1/2/3. **(kernel-gated)**
+- **Disciplina Kahneman:** ITEM-1 (#5) — ver Mapa.
+
+### `crates/ramshared-cli/src/main.rs` (check/status)
+- **O que muda:** a linha "Tiers" passa a reportar `backing_dev` (via `/sys/block/zramN/bd_stat`)
+  quando `--writeback`, em vez do 2º swap. **(kernel-gated)**
+
+### `crates/ramshared-wsl2d` (daemon)
+- **O que muda:** possivelmente nada (o backing emite BIOs ao mesmo device NBD; o worker único
+  serve igual). **A confirmar (kernel-gated):** se o writeback exige semântica de FLUSH/discard
+  diferente da do swap.
+
+## Plano de testes (quando houver kernel)
+
+- Aceitação §14 adaptada: pressão → `bd_stat.bd_writes` cresce (frio na VRAM); RAM do zram cai;
+  overflow → VHDX; integridade (hash) pós-writeback; DEMOTE drena backing 0 corrupção.
+- **Hoje (sem kernel):** N/A — só o desenho é auditável.
+
+## Checklist de validação
+
+- [ ] (kernel) `CONFIG_ZRAM_WRITEBACK=y`; `backing_dev` aceito; `bd_stat` evolui.
+- [ ] (kernel) §14 adaptado verde; DEMOTE 0 corrupção.
+- [x] Desenho fechado + riscos (deadlock de reentrância, DEMOTE-vs-backing) registrados.
+
+## Documentos a atualizar (no IMPL futuro)
+
+`docs/zram-writeback-vram/IMPL.md`; `ROADMAP.md` (Fase B → em progresso); `LIBRARIES.md`
+(zram-writeback: de "NÃO usado" → "ativo, kernel custom"); `ARCHITECTURE.md` (cascata com backing).

--- a/docs/zram-writeback-vram/SPECv2.md
+++ b/docs/zram-writeback-vram/SPECv2.md
@@ -1,0 +1,52 @@
+# SPECv2 — Fase B — zram writeback do frio na VRAM
+
+> Versão após auditoria do Passo 2.5. Baseline: [`SPEC.md`](SPEC.md). **DESIGN-ONLY / kernel-gated.**
+> Motivo (no-go do SPEC): (C4-1) **reentrância de memória** — writeback do zram (sob reclaim) →
+> backing NBD → daemon userspace → CUDA pode reentrar na RAM que o zram tenta liberar → deadlock;
+> (H4-1) **DEMOTE sem drenagem segura** — não há sysfs do zram p/ forçar readback do backing antes
+> de soltar a VRAM → perda de dado; (H4-2) "daemon não muda" é falso (DEMOTE = `swapoff` hardcoded,
+> mas a VRAM não está em swap aqui); (M4-1) overflow VHDX mal-modelado.
+
+## 0. Proveniência da auditoria
+
+- **Auditado:** `SPEC.md`. **Resultado:** `no-go` (2 CRITICAL/HIGH no núcleo da proposta de valor).
+- **Conclusão de design (honesta):** rotear o writeback do zram por um **backing servido em
+  userspace** (NBD/ublk → daemon → CUDA) é **inseguro sob reclaim** e **remove a ação segura do
+  DEMOTE**. O caminho Day-0 limpo para "zram frio → VRAM" é um **block device de VRAM no
+  kernel-space** (módulo futuro), que tira o userspace do caminho de reclaim. **Até existir esse
+  driver, a recomendação é MANTER a cascata de 2 tiers atual** (zram > VRAM-swap > VHDX, validada
+  §14/H1), que tem DEMOTE seguro por construção (o kernel drena no `swapoff`).
+
+## Decisões técnicas (delta sobre o SPEC)
+
+| # | Decisão | Corrige |
+| --- | --- | --- |
+| DT-5 | **Anti-reentrância (C4-1):** o writeback por backing userspace NÃO é Day-0-seguro — sob reclaim do zram, o caminho daemon→CUDA pode alocar RAM (Vec por-request em `conn.rs`, staging da libcuda) e reentrar. **Mitigações exigidas SE algum dia for userspace:** (a) pool de staging **pré-alocado + `mlock`** no daemon (zero alloc no caminho de backing); (b) validação ao vivo de ausência de deadlock sob reclaim (lockdep) ANTES de adotar. **Preferido:** backing = **block device de VRAM kernel-side** (sem userspace no reclaim) — vira um item próprio de Fase C (módulo de kernel). | C4-1 |
+| DT-6 | **DEMOTE sob backing (H4-1):** não existe operação do zram que force o readback de TODO o backing. Logo, soltar/zerar a VRAM-backing com páginas vivas **perde dado**. Portanto, sob o modelo de backing, o canário §9 **perde sua ação de mitigação segura** (`swapoff` não se aplica). Consequência de design: **o backing só é aceitável se os guards de free-floor/corrupção (§9.4) impedirem encher a VRAM a ponto de precisar de DEMOTE de emergência** — o que enfraquece a garantia. Por isso DT-5 prefere o caminho kernel-side e, no interim, **a cascata de 2 tiers (DEMOTE seguro) permanece o Day-0**. | H4-1 |
+| DT-7 | **Daemon muda (H4-2):** corrige o claim do SPEC. Se o backing for o device do daemon, o DEMOTE deixa de ser `swapoff <nbd>` e passa a `writeback_limit 0` + (impossível) drenagem — ver DT-6. Isso confirma que o backing userspace **não** é "daemon não muda". | H4-2 |
+| DT-8 | **Overflow (M4-1):** backing-cheio ≠ zram-cheio. Quando a VRAM-backing enche, o writeback falha e as páginas **ficam no zram (RAM)**; o VHDX só recebe quando o **zram inteiro** satura (prioridade de swap). O SPEC confundia os dois níveis. Modelo correto: VHDX é overflow do **zram**, não do backing. | M4-1 |
+
+## Recomendação final (design ativo)
+
+**NÃO implementar o writeback-via-backing-userspace.** O esteira de auditoria mostrou que ele é
+inseguro (reentrância) e sem DEMOTE seguro. Dois caminhos válidos, ambos Fase C+:
+1. **Block device de VRAM kernel-side** (módulo LKM) como `backing_dev` → tira o userspace do
+   reclaim, DEMOTE volta a ser seguro (kernel drena). **Preferido** (alinha ao destino Ring-0).
+2. **Manter a cascata de 2 tiers** (Day-0 atual) — DEMOTE seguro, já validado §14. **Interim.**
+
+Este SPECv2 é o **registro do design** (por que o caminho ingênuo foi rejeitado), não um SPEC de
+IMPL. O Passo 3 só abre quando (1) existir o driver kernel-side.
+
+## Mapa Kahneman (corrigido)
+
+| Etapa / ITEM | Disciplina | Link | Pergunta | Evidência mínima | Abort trigger |
+| --- | --- | --- | --- | --- | --- |
+| ITEM-1 (backing) | #5 Worst-case | [`KAHNEMAN`](../methodology/KAHNEMAN-DISCIPLINES.md) | "writeback sob reclaim reentra/deadlocka?" | (kernel-side) sem userspace no reclaim; ou (userspace) pool mlocked + lockdep limpo | reentrância → não adotar; manter 2 tiers |
+| ITEM-2 (política writeback) | #5 | [`KAHNEMAN`](../methodology/KAHNEMAN-DISCIPLINES.md) | "writeback_limit evita saturar a VRAM?" | (kernel) bd_stat sob limite | saturação → reverter |
+| ITEM-3 (DEMOTE) | #2 Counterfactual | [`KAHNEMAN`](../methodology/KAHNEMAN-DISCIPLINES.md) | "soltar backing perde dado?" | drenagem segura inexistente → manter 2-tier DEMOTE | perda → não adotar |
+
+## Validação
+
+- **Hoje:** N/A (design-only). O valor entregue é a **rejeição fundamentada** do caminho ingênuo +
+  o redirecionamento para o design kernel-side / manutenção do Day-0 de 2 tiers.
+- **Futuro (kernel-side):** §14 adaptado + lockdep sob reclaim + DEMOTE 0 corrupção.


### PR DESCRIPTION
## Resumo

Fecha a frente **Fase A** da issue #3 e adiciona os **design specs de Fase B**, num PR único,
toda a frente pela esteira SSDV3 (PRD→SPEC→Passo 2.5→SPECv2/v3) + disciplinas Kahneman:

- **H1 — daemon NBD multi-conexão** (`feat(core)`): o `ramshared-wsl2d` deixa de servir 1
  conexão num laço serial e passa a **N conexões** (`nbd-client -C N`) via **acceptor +
  leitor/escritor por conexão** alimentando um **worker CUDA único** (afinidade de thread
  preservada por `!Send`), sem head-of-line blocking. Canal `WMsg` (único backpressure) +
  réplica por conexão ilimitada (sem deadlock) + `LiveCount` (término determinístico) +
  `NBD_FLAG_CAN_MULTI_CONN`.
- **Hardening** (`fix(core)`): `/usr/sbin/swapoff` absoluto (#2c); #2a/#6c **resolvidos** pelo
  desenho do H1 (teardown DT-17 espera o swapoff antes de zerar; I/O de socket em threads
  por-conexão → worker sempre encerra via teardown); #5 (mlockall) validado ao vivo.
- **Typed errors** (`refactor(core)`): `cascade.rs` `Result<_, String>` → enum `CascadeError`
  (zero-dep, padrão do `CudaError`). **clap rejeitado** (seria a 1ª dependência externa num
  projeto zero-dep/Ring-0) — registrado em `LIBRARIES.md` (#11).
- **Fase B (DESIGN-ONLY, kernel-gated)**: `docs/zram-writeback-vram/` e `docs/ublk-backend/` —
  esteira até SPECv2 (auditada `go`). Verificado que o WSL2 não tem `CONFIG_ZRAM_WRITEBACK`/
  `CONFIG_BLK_DEV_UBLK`; IMPL adiada para kernel custom.

**Lição (IMPL→SPEC, Kahneman #13):** a auditoria do SPECv3 aprovou medir **latência total**
(espera na fila) como válvula de backpressure (DT-16). O **§14.3 ao vivo** mostrou que isso
causa **falso-positivo de DEMOTE** sob carga normal (nbd0 caiu de 511→10 MiB). Revertido para
**serve-only**; SPECv3 DT-16 atualizado. Só o teste vivo pegou — a auditoria teórica não.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `db49a6e` | H1: daemon NBD multi-conexão (reader/worker/writer) | Sem HOL blocking; encurta a janela do DEMOTE (ROADMAP "Agora") | <details><summary>detalhes</summary>**Arquivos:** `conn.rs` (novo: WMsg/Job/Reply/LiveCount + acceptor/reader/writer + 5 testes), `main.rs` (worker loop + serve-only latency + teardown DT-17), `protocol.rs` (CAN_MULTI_CONN), `lib.rs`, `cascade.rs` (--connections → -C N), `backend.rs` (F-7). Docs: `docs/daemon-multiconn/{PRD,SPEC,SPECv2,SPECv3,IMPL}.md`, ARCHITECTURE, ROADMAP.<br>**Esteira:** SPEC→SPECv2→SPECv3 (2 no-go: lifecycle não-determinístico; válvula backpressure).<br>**Validação:** §14.3 511 MiB/332.800 páginas; §14.4 479 MiB/0 corrupção; `-C 2` 2 conns íntegro.<br>**Rollback:** app-only.</details> |
| `6969645` | swapoff absoluto + fecha findings de hardening | #2c ($PATH→/usr/sbin); #2a/#6c resolvidos pelo H1; #5 validado | <details><summary>detalhes</summary>**Arquivos:** `main.rs` (`swapoff_bin()`).<br>**Validação:** §14.4 480 MiB/0 corrupção via /usr/sbin/swapoff.<br>**Risco:** fortalece a segurança do daemon root; reverter = voltar ao $PATH.</details> |
| `b3d97ba` | `CascadeError` tipado; clap rejeitado (zero-dep) | Polish #3 LOW sem nova dep externa | <details><summary>detalhes</summary>**Arquivos:** `cascade.rs` (enum CascadeError + Display + Error), `main.rs` CLI (to_exit genérico), `LIBRARIES.md` (clap NÃO usado, #11).<br>**Validação:** clippy -D warnings; cli 4 testes; smoke up/down + erro tipado impresso.</details> |
| `9c63a2e` | Fase B design specs (zram-writeback, ublk) | Esteira SSDV3 até SPECv2 (go); IMPL kernel-gated | <details><summary>detalhes</summary>**Arquivos:** `docs/zram-writeback-vram/{PRD,SPEC,SPECv2}.md`, `docs/ublk-backend/{PRD,SPEC,SPECv2}.md`.<br>**Resultado:** zram-writeback ingênuo **rejeitado** (reentrância sob reclaim + DEMOTE sem drenagem) → kernel-side / manter 2-tier; ublk threading corrigido (ring = 1 thread) + unsafe-vs-crate ao ADR.<br>**Validação:** design-only (kernel-gated); 2 rodadas de Passo 2.5 (no-go→go).</details> |
| `29593df` | Corrige comentários stale + memória de sessão | Revisão final: 2 comentários ainda diziam "espera na fila" vs código serve-only | <details><summary>detalhes</summary>**Arquivos:** `main.rs` (2 comentários → serve-only), `MEMORY.md` (entrada da sessão).<br>**Validação:** comment-only + doc; build ok.</details> |

## Issue

Closes #3

## Responsavel

@emersonbusson

## Labels

`type:feat`, `area:core`, `area:mm`

## Validacao

- [x] `cargo fmt --all -- --check` — limpo
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — limpo
- [x] `cargo test --workspace` — **61 passou / 0 falhou / 2 ignorado** (GPU `--ignored`)
- [x] **§14.3 ao vivo** (RTX 2060, sudo): spill **511 MiB** / 332.800 páginas íntegras, sem falso-DEMOTE
- [x] **§14.4 ao vivo**: DEMOTE **480 MiB** migrados VRAM→VHDX / 384.000 páginas / **0 corrupção**
- [x] **`-C 2` ao vivo**: 2 conexões + hog íntegro (worker serializa)
- [x] **Auditoria adversarial** por item (H1: 3 rodadas; Fase B: 2 rodadas) + revisão holística final do branch (GO)
- [x] Fase B: kernel-gated honesto (sem `CONFIG_ZRAM_WRITEBACK`/`CONFIG_BLK_DEV_UBLK` — verificado); IMPL adiada

## Rollback trigger

- **H1:** DEMOTE indevido sob carga normal (pico nbd0 < ~100 MiB no §14.3) ou corrupção sob
  `-C N` → reverter (app-only; sem migração/dados).
- **Geral:** qualquer regressão no §14 (spill/DEMOTE) vs baseline (511 MiB / 0 corrupção) → revert.
