### PR TITLE
fix(ci): check PR author instead of actor in pr-body gate

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR description sections
-        if: github.actor != 'dependabot[bot]' && !endsWith(github.actor, '[bot]')
+        if: github.event.pull_request.user.login != 'dependabot[bot]' && !endsWith(github.event.pull_request.user.login, '[bot]')
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Resumo
Corrige a validação do pr-body para verificar o criador do PR em vez do ator que disparou o run.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `71df1e5` | Usa github.event.pull_request.user.login | Evitar que bots falhem no check | <details><summary>detalhes</summary>Correção do gate de PR body.</details> |

## Issue
N/A

## Responsavel
@emersonbusson

## Labels
type:ci, area:ci

## Validacao
- [x] Gates de build/test do escopo tocado

## Rollback trigger
N/A
