### PR TITLE
chore(ci): update gitignore to ignore local VM screenshots and tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,12 @@ MEMORY.md
 # IDEs e Editores
 .vscode/
 .idea/
+
+# Temporary directories
+/tmp/
+/temp/
+
+# Temporary validation media
+/vm_screen.png
+/vm_screen.jpg
+/vm_screen.jpeg


### PR DESCRIPTION
## Resumo
Adiciona regras no `.gitignore` para ignorar diretórios temporários `/tmp`, `/temp` e arquivos de prints locais `vm_screen.jpg` e `vm_screen.png`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `9e61ec5` | Atualiza .gitignore | Evitar ruído no git status com arquivos locais | <details><summary>detalhes</summary>Adiciona regras de ignore.</details> |

## Issue
N/A

## Responsavel
@emersonbusson

## Labels
type:chore, area:ci

## Validacao
- [x] Gates de build/test do escopo tocado

## Rollback trigger
N/A
