### PR TITLE
fix(win-driver): secure partition formatting in install script

### DIFF
--- a/scripts/windows/Install-InfAndBackend.ps1
+++ b/scripts/windows/Install-InfAndBackend.ps1
@@ -114,8 +114,8 @@ if ($FormatNtfs) {
     Write-Host "FORMAT disk $($found.Number) -> ${DriveLetter}:"
     if ($found.PartitionStyle -eq 'RAW' -or $found.NumberOfPartitions -eq 0) {
         Initialize-Disk -Number $found.Number -PartitionStyle GPT -Confirm:$false -EA SilentlyContinue
-        $part = New-Partition -DiskNumber $found.Number -UseMaximumSize -DriveLetter $DriveLetter[0]
-        Format-Volume -DriveLetter $DriveLetter[0] -FileSystem NTFS -NewFileSystemLabel "RAMSHARED" -Confirm:$false
+        $part = New-Partition -DiskNumber $found.Number -UseMaximumSize -DriveLetter $DriveLetter[0] -ErrorAction Stop
+        $part | Format-Volume -FileSystem NTFS -NewFileSystemLabel "RAMSHARED" -Confirm:$false
         Write-Host "FORMAT_OK ${DriveLetter}:"
     } else {
         Write-Host "disk already partitioned"


### PR DESCRIPTION
## Resumo
Pipes the partition object directly to Format-Volume instead of referencing by drive letter, and adds -ErrorAction Stop to New-Partition to prevent accidental formatting if partition creation fails.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `f4c88cb` | Secures partition format logic | Prevent formatting target drive letter on failure | <details><summary>detalhes</summary>Uses partition pipe to format-volume.</details> |

## Issue
N/A

## Responsavel
@emersonbusson

## Labels
type:fix, area:win-driver

## Validacao
- [x] Gates de build/test do escopo tocado

## Rollback trigger
N/A
