### PR TITLE
test(mm): cascade demote drill #31 integrity PASS

### DIFF
--- a/scripts/p0/measure-cascade-demote.sh
+++ b/scripts/p0/measure-cascade-demote.sh
@@ -26,13 +26,21 @@ set -u
 HOG_BIN="${HOG_BIN:-/home/emdev/fase0/cascade-hog}"
 RAW="${RAW:-/home/emdev/fase0/CASCADE-DEMOTE-$(date +%Y%m%d-%H%M%S).txt}"
 CG="${CG:-/sys/fs/cgroup/ramshared-demote-drill}"
-HOG_MB="${HOG_MB:-2200}"
-CAP_MB="${CAP_MB:-512}"
-MIN_NBD_MIB="${MIN_NBD_MIB:-150}"
+# Defaults tuned for product cascade sizes ~2G zram + 2G nbd (2026-07):
+# need hog >> zram free so pages spill to nbd under cgroup cap.
+HOG_MB="${HOG_MB:-2800}"
+CAP_MB="${CAP_MB:-256}"
+MIN_NBD_MIB="${MIN_NBD_MIB:-100}"
 RESTORE="${RESTORE:-1}"   # 1 = swapon -p 100 /dev/nbd0 apos prova
 NBD_DEV="${NBD_DEV:-/dev/nbd0}"
 SWAPOFF_BIN="${SWAPOFF_BIN:-/usr/sbin/swapoff}"
 SWAPON_BIN="${SWAPON_BIN:-/usr/sbin/swapon}"
+STATUS_BIN="${STATUS_BIN:-}"
+if [ -z "$STATUS_BIN" ]; then
+  if [ -x ./target/release/ramshared ]; then STATUS_BIN=./target/release/ramshared
+  elif command -v ramshared >/dev/null 2>&1; then STATUS_BIN=$(command -v ramshared)
+  fi
+fi
 
 HOG_PID=""
 DEMOTE_DONE=0
@@ -92,8 +100,24 @@ teardown() {
 trap teardown EXIT
 trap 'exit 143' INT TERM
 
+log_status() {
+  local tag="$1"
+  log "--- status ($tag) ---"
+  if [ -n "$STATUS_BIN" ] && [ -x "$STATUS_BIN" ]; then
+    "$STATUS_BIN" status --json 2>/dev/null | tee -a "$RAW" || log "status --json failed"
+  else
+    log "status bin missing"
+  fi
+  if [ -f /run/ramshared/demote-status.json ]; then
+    log "demote-status: $(cat /run/ramshared/demote-status.json)"
+  else
+    log "demote-status: (absent)"
+  fi
+}
+
 log "### CASCADE DEMOTE DRILL — $(date -Is) ###"
 log "params: HOG_MB=$HOG_MB CAP_MB=$CAP_MB MIN_NBD_MIB=$MIN_NBD_MIB RESTORE=$RESTORE NBD=$NBD_DEV"
+log "issue: #31 demote under pressure + integrity (action path = spawn_swapoff)"
 [ "$(id -u)" = 0 ] || { log "precisa root"; exit 2; }
 [ -x "$HOG_BIN" ] || { log "hog ausente: $HOG_BIN"; exit 2; }
 [ -b "$NBD_DEV" ] || { log "block device ausente: $NBD_DEV"; exit 2; }
@@ -101,6 +125,7 @@ log "params: HOG_MB=$HOG_MB CAP_MB=$CAP_MB MIN_NBD_MIB=$MIN_NBD_MIB RESTORE=$RES
 log ""
 log "=== 0. preflight cascade ==="
 snapshot_swaps
+log_status preflight
 tier_present "$NBD_DEV" || { log "FALHA: $NBD_DEV nao esta em /proc/swaps (suba a cascata antes)"; exit 1; }
 tier_present /dev/zram0 || tier_present /dev/zram1 || log "WARN: sem zram (A1 ainda ok se VHDX existir)"
 # A1: precisa sink abaixo da VRAM
@@ -108,7 +133,7 @@ if ! awk '$1 ~ /\/dev\/sd/ && $5+0 < 100 {ok=1} END{exit !ok}' /proc/swaps; then
   log "FALHA: invariante A1 — sem VHDX (prio < 100) para absorver DEMOTE"
   exit 1
 fi
-if ! pgrep -f 'ramsharedd' >/dev/null 2>&1; then
+if ! pgrep -x ramsharedd >/dev/null 2>&1 && ! pgrep -f 'ramsharedd ' >/dev/null 2>&1; then
   log "FALHA: ramsharedd nao esta vivo (swapoff sem servidor = hang)"
   exit 1
 fi
@@ -165,6 +190,7 @@ NBD_BEFORE=$(nbd_used_mib); NBD_BEFORE=${NBD_BEFORE:-0}
 VHDX_BEFORE=$(vhdx_used_mib); VHDX_BEFORE=${VHDX_BEFORE:-0}
 ZRAM_BEFORE=$(zram_used_mib); ZRAM_BEFORE=${ZRAM_BEFORE:-0}
 log "antes DEMOTE: nbd=${NBD_BEFORE} MiB zram=${ZRAM_BEFORE} MiB vhdx=${VHDX_BEFORE} MiB"
+log_status before-demote
 if [ "$NBD_BEFORE" -lt "$MIN_NBD_MIB" ]; then
   log "FALHA: poucas paginas na VRAM ($NBD_BEFORE < $MIN_NBD_MIB). Aumente HOG_MB ou reduza CAP_MB/zram."
   exit 1
@@ -172,14 +198,28 @@ fi
 
 log ""
 log "=== 2. DEMOTE action: swapoff $NBD_DEV (daemon serve read-back) ==="
+log "NOTE: sparse product path skips FreeFloor/Latency auto-swapoff; this drills the same"
+log "      spawn_swapoff action the daemon uses for Corruption/WDDM-constrained demote."
+# Raise cgroup cap so page-in during swapoff does not OOM-kill the hog (integrity).
+if [ -n "${HOG_PID:-}" ] && [ -d "$CG" ]; then
+  DEMOTE_CAP_MB="${DEMOTE_CAP_MB:-$((HOG_MB + 512))}"
+  log "raising cgroup memory.max to ${DEMOTE_CAP_MB}M for demote page-in"
+  echo "${DEMOTE_CAP_MB}M" >"$CG/memory.max" 2>>"$RAW" || log "WARN: could not raise memory.max"
+fi
 T0=$(date +%s%N)
-if timeout 120 "$SWAPOFF_BIN" "$NBD_DEV" >>"$RAW" 2>&1; then
+if timeout 300 "$SWAPOFF_BIN" "$NBD_DEV" >>"$RAW" 2>&1; then
   T1=$(date +%s%N)
   MS=$(( (T1 - T0) / 1000000 ))
   log "swapoff $NBD_DEV OK em ${MS} ms"
   DEMOTE_DONE=1
 else
   log "FALHA: swapoff $NBD_DEV (timeout ou erro) — risco de paginas presas"
+  # show hog still alive?
+  if [ -n "${HOG_PID:-}" ]; then
+    if kill -0 "$HOG_PID" 2>/dev/null; then log "hog still alive pid=$HOG_PID"
+    else log "hog dead during swapoff (likely OOM in cgroup)"
+    fi
+  fi
   exit 1
 fi
 
@@ -190,6 +230,7 @@ fi
 VHDX_AFTER=$(vhdx_used_mib); VHDX_AFTER=${VHDX_AFTER:-0}
 ZRAM_AFTER=$(zram_used_mib); ZRAM_AFTER=${ZRAM_AFTER:-0}
 log "apos DEMOTE: nbd=AUSENTE zram=${ZRAM_AFTER} MiB vhdx=${VHDX_AFTER} MiB"
+log_status after-demote
 # zram e/ou vhdx devem continuar
 if ! awk 'NR>1{n++} END{exit !(n>=1)}' /proc/swaps; then
   log "FALHA: nenhum swap restante apos demote"

--- a/validation.md
+++ b/validation.md
@@ -1048,6 +1048,27 @@ cat /run/ramshared/demote-status.json
 **Verdict:** ✅ ITEM-3 closed; demote export live
 **Next action:** optional idle reclaim of residual disk swap pages under pressure only
 
+## 2026-07-14 11:30 -03 — issue #31 demote under pressure + integrity (action path)
+
+**What:** Re-run `scripts/p0/measure-cascade-demote.sh` for issue #31: cgroup-isolated hog fills VRAM tier, swapoff demote while daemon serves, hog verify checksum pages.
+**Category:** e2e / integration
+**How to measure:**
+```bash
+sudo env HOG_MB=4500 CAP_MB=256 MIN_NBD_MIB=150 DEMOTE_CAP_MB=5500 RESTORE=1 \
+  STATUS_BIN=./target/release/ramshared \
+  bash scripts/p0/measure-cascade-demote.sh
+```
+**Measured data:**
+- before demote: nbd **2047 MiB**, zram 2047 MiB, vhdx 1040 MiB; phase UsingDisk (disk residual) + UsingVram path for vram used
+- demote action: `swapoff /dev/nbd0` **OK in 143973 ms** (~144 s)
+- after: nbd **absent**; zram 137 MiB; vhdx 1130 MiB; daemon still alive
+- integrity: hog **VERIFY OK 1152000 pages**, **0 corruption** (rc=0)
+- cgroup: fill under memory.max=256M; raised to 5500M for demote page-in (avoids OOM kill)
+- observability: `status --json` + demote-status captured before/after (manual swapoff does not increment daemon demote.total — expected; total still 0)
+- host-safety: hog in cgroup only; no global thrash; RESTORE swapon failed once → `cascade-up` restored cushion after
+**Verdict:** ✅ DEMOTE action path PASS under severe multi-tier pressure + integrity; sparse FreeFloor/Latency auto-swapoff still skipped by design (WDDM/Corruption path uses same spawn_swapoff)
+**Next action:** optional separate drill for WDDM-budget demote (host GPU load) to increment demote-status total; close #31 acceptance for action+integrity
+
 ## 2026-07-14 11:52 -03 — Task Manager 100%/0KB: root-cause fix (StorPort + format + measure)
 
 **What:** Senior fix for screenshot "RAMSHARE VRAMDISK 100% active / 0 KB/s / 0 ms / Formatado 0 MB".


### PR DESCRIPTION
## Resumo

Atualiza o drill de DEMOTE (cgroup) para não OOM no page-in, captura `status --json`, e registra validação live do issue #31 (2047 MiB nbd → swapoff OK, 0 corrupção).

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| (this) | demote drill + validation | fechar #31 action path | <details><summary>detalhes</summary>**Arquivos:** measure-cascade-demote.sh, validation.md<br>**Validacao:** live demote 144s, 1152000 pages OK<br>**Risco/rollback:** script only</details> |

## Issue

Closes #31

## Responsavel

@emersonbusson

## Labels

type:test, area:mm

## Validacao

- [x] live demote drill PASS
- [x] cascade restored via up after RESTORE miss

## Rollback trigger

Se o drill causar hang WSL > 60s ou corrupcao no hog → reverter script defaults e exigir lab isolado.