### PR TITLE
🧪 Improve test coverage for evidence reading logic

### DIFF
--- a/crates/ramshared-winsvc/src/evidence.rs
+++ b/crates/ramshared-winsvc/src/evidence.rs
@@ -384,7 +384,11 @@ mod tests {
 
     #[test]
     fn read_all_rows_missing_file_yields_not_found() {
-        let dir = std::env::temp_dir().join(format!("ramshared-ev-missing-{}-{}", std::process::id(), utc_ms()));
+        let dir = std::env::temp_dir().join(format!(
+            "ramshared-ev-missing-{}-{}",
+            std::process::id(),
+            utc_ms()
+        ));
         let path = dir.join("does_not_exist.jsonl");
         let result = read_all_rows(&path);
         assert!(result.is_err());
@@ -393,7 +397,11 @@ mod tests {
 
     #[test]
     fn read_all_rows_ignores_empty_lines() {
-        let dir = std::env::temp_dir().join(format!("ramshared-ev-empty-{}-{}", std::process::id(), utc_ms()));
+        let dir = std::env::temp_dir().join(format!(
+            "ramshared-ev-empty-{}-{}",
+            std::process::id(),
+            utc_ms()
+        ));
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("empty.jsonl");
         {
@@ -414,7 +422,11 @@ mod tests {
 
     #[test]
     fn read_all_rows_invalid_json_yields_invalid_data() {
-        let dir = std::env::temp_dir().join(format!("ramshared-ev-invalid-{}-{}", std::process::id(), utc_ms()));
+        let dir = std::env::temp_dir().join(format!(
+            "ramshared-ev-invalid-{}-{}",
+            std::process::id(),
+            utc_ms()
+        ));
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("invalid.jsonl");
         {

--- a/crates/ramshared-winsvc/src/evidence.rs
+++ b/crates/ramshared-winsvc/src/evidence.rs
@@ -381,4 +381,49 @@ mod tests {
         assert_ne!(row.event_id, first_event);
         assert_eq!(row.ts_utc_ms, first_ts + 1);
     }
+
+    #[test]
+    fn read_all_rows_missing_file_yields_not_found() {
+        let dir = std::env::temp_dir().join(format!("ramshared-ev-missing-{}-{}", std::process::id(), utc_ms()));
+        let path = dir.join("does_not_exist.jsonl");
+        let result = read_all_rows(&path);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn read_all_rows_ignores_empty_lines() {
+        let dir = std::env::temp_dir().join(format!("ramshared-ev-empty-{}-{}", std::process::id(), utc_ms()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("empty.jsonl");
+        {
+            let mut file = File::create(&path).unwrap();
+            let row = RuntimeEvidence::base("run-1", "Online");
+            let json = serde_json::to_string(&row).unwrap();
+            file.write_all(b"\n").unwrap();
+            file.write_all(b"   \n").unwrap();
+            file.write_all(json.as_bytes()).unwrap();
+            file.write_all(b"\n").unwrap();
+            file.write_all(b"\t\n").unwrap();
+        }
+        let rows = read_all_rows(&path).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].run_id, "run-1");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_all_rows_invalid_json_yields_invalid_data() {
+        let dir = std::env::temp_dir().join(format!("ramshared-ev-invalid-{}-{}", std::process::id(), utc_ms()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("invalid.jsonl");
+        {
+            let mut file = File::create(&path).unwrap();
+            file.write_all(b"{ invalid json\n").unwrap();
+        }
+        let result = read_all_rows(&path);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
+        let _ = fs::remove_dir_all(&dir);
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap in `read_all_rows` logic is addressed by adding tests for parsing JSON lines.
📊 **Coverage:** The tests now cover:
  - Error when trying to read a non-existent file (`std::io::ErrorKind::NotFound`).
  - Skipping empty or whitespace-only lines without causing parsing errors.
  - Correctly propagating a `std::io::ErrorKind::InvalidData` error when encountering invalid JSON data.
✨ **Result:** Test coverage in `crates/ramshared-winsvc/src/evidence.rs` is significantly improved. The code is thoroughly verified against standard IO and parsing error conditions.

---
*PR created automatically by Jules for task [8539735657677613080](https://jules.google.com/task/8539735657677613080) started by @emersonbusson*