### PR TITLE
🧹 [code health] Extract baseline calculation in ublk_server.rs

### DIFF
--- a/crates/ramshared-wsl2d/src/ublk_server.rs
+++ b/crates/ramshared-wsl2d/src/ublk_server.rs
@@ -519,10 +519,7 @@ fn serve_ublk_residency<M: VramMemory, F: Fn() -> Option<u64>>(
         if touches_vram && !demoted && demote_rx.is_none() {
             match canary.as_mut() {
                 None => {
-                    baseline.push(lat_us);
-                    if baseline.len() >= 16 {
-                        baseline.sort_unstable();
-                        let med = baseline[baseline.len() / 2].max(1);
+                    if let Some(med) = calculate_baseline(&mut baseline, lat_us) {
                         canary = Some(Canary::new(residency, med));
                     }
                 }
@@ -555,6 +552,19 @@ fn serve_ublk_residency<M: VramMemory, F: Fn() -> Option<u64>>(
     let _ = backend.zero();
     let _ = probe.zero();
     Ok(())
+}
+
+/// Helper function to calculate the baseline median from the latency samples.
+/// Once enough samples (16) are collected, it returns the median value.
+fn calculate_baseline(baseline: &mut Vec<u64>, lat_us: u64) -> Option<u64> {
+    baseline.push(lat_us);
+    if baseline.len() >= 16 {
+        baseline.sort_unstable();
+        let med = baseline[baseline.len() / 2].max(1);
+        Some(med)
+    } else {
+        None
+    }
 }
 
 /// Like [`spawn_server_dt3_vram`], but the worker (owner of the CUDA context) **also runs


### PR DESCRIPTION
🎯 **What:** Extracted inline baseline median calculation in `crates/ramshared-wsl2d/src/ublk_server.rs` to a new helper function `calculate_baseline`.
💡 **Why:** To address the deep nesting in `serve_ublk_residency`, improving overall codebase maintainability and readability without altering the existing behavior.
✅ **Verification:** Verified via `cargo test` which fully passed without introducing regressions. The extracted function adheres to original logic completely.
✨ **Result:** A more readable block inside `serve_ublk_residency` logic with reduced nesting depth.

---
*PR created automatically by Jules for task [880953780574830866](https://jules.google.com/task/880953780574830866) started by @emersonbusson*