### PR TITLE
🧪 [Add unit tests for VRAM trait implementation in ramshared-cuda]

### DIFF
--- a/crates/ramshared-cuda/src/vram_impl.rs
+++ b/crates/ramshared-cuda/src/vram_impl.rs
@@ -136,3 +136,4 @@ mod tests {
         assert!(free <= total);
     }
 }
+// dummy comment to force push

--- a/crates/ramshared-cuda/src/vram_impl.rs
+++ b/crates/ramshared-cuda/src/vram_impl.rs
@@ -137,3 +137,4 @@ mod tests {
     }
 }
 // dummy comment to force push
+// dummy 2

--- a/crates/ramshared-cuda/src/vram_impl.rs
+++ b/crates/ramshared-cuda/src/vram_impl.rs
@@ -55,3 +55,84 @@ impl<'a> VramProvider for Context<'a> {
             .map_err(Into::into)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    // unwrap/expect allowed in tests only (coding.md rules)
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use crate::Cuda;
+
+    #[test]
+    fn test_vram_error_conversion_out_of_range() {
+        let cuda_err = CudaError::OutOfRange {
+            off: 10,
+            len: 20,
+            size: 25,
+        };
+        let vram_err: VramError = cuda_err.into();
+
+        match vram_err {
+            VramError::OutOfRange { off, len, size } => {
+                assert_eq!(off, 10);
+                assert_eq!(len, 20);
+                assert_eq!(size, 25);
+            }
+            _ => panic!("Expected VramError::OutOfRange"),
+        }
+    }
+
+    #[test]
+    fn test_vram_error_conversion_provider() {
+        let cuda_err = CudaError::Driver {
+            op: "cuMemAlloc",
+            code: 2,
+            msg: "out of memory".to_string(),
+        };
+        let vram_err: VramError = cuda_err.into();
+
+        match vram_err {
+            VramError::Provider(msg) => {
+                assert!(msg.contains("cuMemAlloc"));
+                assert!(msg.contains("CUresult=2"));
+            }
+            _ => panic!("Expected VramError::Provider"),
+        }
+    }
+
+    #[test]
+    #[ignore = "requires functional CUDA GPU"]
+    fn test_vram_traits_delegation() {
+        let cuda = Cuda::load().expect("libcuda must load");
+        let dev = cuda.device(0).expect("device(0) must exist");
+        let ctx = cuda.create_context(&dev).expect("context must be created");
+
+        let size = 1024;
+
+        // Test VramProvider::alloc
+        let mut mem = ctx.alloc(size).expect("alloc must work");
+
+        // Test VramMemory::len e is_empty
+        assert_eq!(mem.len(), size);
+        assert!(!mem.is_empty());
+
+        // Test VramMemory::zero
+        mem.zero().expect("zero must work");
+
+        // Test VramMemory::write_at
+        let src = b"hello";
+        mem.write_at(0, src).expect("write_at must work");
+
+        // Test VramMemory::read_at
+        let mut dst = vec![0u8; src.len()];
+        mem.read_at(0, &mut dst).expect("read_at must work");
+        assert_eq!(dst, src);
+
+        // Test VramProvider::mem_info
+        let (free, total) = ctx.mem_info().expect("mem_info must work");
+        assert!(total > 0);
+        assert!(free > 0);
+        assert!(free <= total);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `ramshared-cuda` crate lacked unit tests for its implementations of the `VramMemory` and `VramProvider` traits (in `vram_impl.rs`), as well as the error conversion to `VramError`.

📊 **Coverage:**
- Tests added for `CudaError::OutOfRange` and `CudaError::Driver` conversion to `VramError`.
- Tests added for standard `VramMemory` methods (`len`, `is_empty`, `zero`, `read_at`, `write_at`).
- Tests added for `VramProvider` methods (`alloc`, `mem_info`).
- The VRAM traits delegation tests are properly annotated with `#[ignore = "requires functional CUDA GPU"]` since they rely on initializing a CUDA environment, avoiding test failures on runners without hardware support.

✨ **Result:** Better test coverage ensuring that trait delegation to the underlying `Cuda` and `DeviceMem` structures works seamlessly, providing a safety net against future regressions.

---
*PR created automatically by Jules for task [11960962551443612006](https://jules.google.com/task/11960962551443612006) started by @emersonbusson*