### PR TITLE
🔒 Fix Command Injection in PowerShell Script (observe_product_volume)

### DIFF
--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -466,7 +466,7 @@ impl WindowsHostState {
         if !('D'..='Z').contains(&letter) {
             return Err(HostError::Volume("letter must be D..=Z".into()));
         }
-        if serial.len() != 16 {
+        if serial.len() != 16 || !serial.chars().all(|c| c.is_ascii_hexdigit()) {
             return Err(HostError::Identity("serial must be 16 hex chars".into()));
         }
         // Bind the configured letter to the exact disk. Serial+size without the


### PR DESCRIPTION
🎯 **What:** Fixed a Command Injection vulnerability in `observe_product_volume`.
⚠️ **Risk:** A malicious actor could inject arbitrary PowerShell commands if they could control the `serial` parameter, potentially leading to arbitrary code execution or privilege escalation.
🛡️ **Solution:** Added strict validation to ensure that the `serial` parameter contains only valid hexadecimal characters (`!serial.chars().all(|c| c.is_ascii_hexdigit())`). This guarantees that shell metacharacters cannot be injected into the PowerShell script format string.

---
*PR created automatically by Jules for task [4828358285381861075](https://jules.google.com/task/4828358285381861075) started by @emersonbusson*