### PR TITLE
🧹 Refactor print_text_report function into helper functions

### DIFF
--- a/crates/ramshared-cli/src/main.rs
+++ b/crates/ramshared-cli/src/main.rs
@@ -635,6 +635,15 @@ fn cuda_probe_via_lib() -> Result<GpuInfo, String> {
 }
 
 fn print_text_report(report: &CheckReport) {
+    print_basic_info(report);
+    print_swap_info(report);
+    print_backend_info(report);
+    print_decision(report);
+    print_details(report);
+    print_issues(report);
+}
+
+fn print_basic_info(report: &CheckReport) {
     println!(
         "WSL2: {} ({})",
         report.wsl.status.as_str(),
@@ -655,7 +664,9 @@ fn print_text_report(report: &CheckReport) {
         ),
         None => println!("GPU: unavailable"),
     }
+}
 
+fn print_swap_info(report: &CheckReport) {
     match report.swaps.first() {
         Some(swap) => println!(
             "Swap atual: {}, size={}MiB, used={}MiB, prio={}",
@@ -666,7 +677,9 @@ fn print_text_report(report: &CheckReport) {
         ),
         None => println!("Swap atual: none"),
     }
+}
 
+fn print_backend_info(report: &CheckReport) {
     println!(
         "Backends: nbd={}, ublk={}",
         report.backends.nbd_status.as_str(),
@@ -686,8 +699,13 @@ fn print_text_report(report: &CheckReport) {
             .map(|s| s.filename.as_str())
             .unwrap_or("none")
     );
-    println!("Decisao: {}", report.decision().as_str());
+}
 
+fn print_decision(report: &CheckReport) {
+    println!("Decisao: {}", report.decision().as_str());
+}
+
+fn print_details(report: &CheckReport) {
     println!("Detalhes:");
     println!(
         "  config: {}",
@@ -728,7 +746,9 @@ fn print_text_report(report: &CheckReport) {
     {
         println!("  nvidia-smi output: {}", one_line(output));
     }
+}
 
+fn print_issues(report: &CheckReport) {
     if !report.blockers.is_empty() {
         println!("Bloqueios:");
         for blocker in &report.blockers {

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,25 @@
+## Resumo
+Refactored the `print_text_report` function in `crates/ramshared-cli/src/main.rs` to improve maintainability and readability by splitting it into smaller helper functions.
+
+## Commits
+| Commit | O que fez | Por que fez | Detalhes |
+|---|---|---|---|
+| `hash` | Split `print_text_report` | Improve readability and maintainability | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-cli/src/main.rs`<br>**Validacao:** `cargo check`, `cargo fmt`, `cargo test`<br>**Risco/rollback:** Low risk, pure refactoring.</details> |
+
+## Issue
+N/A - Code health improvement
+
+## Responsavel
+@jules
+
+## Labels
+type:refactor
+area:cli
+
+## Validacao
+- [x] Gates de build/test do escopo tocado
+- [ ] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
+- [ ] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)
+
+## Rollback trigger
+Nenhum - Refactoring only, functionally equivalent.


### PR DESCRIPTION
🎯 **What:** Split the large `print_text_report` function in `crates/ramshared-cli/src/main.rs` into smaller, logically-grouped helper functions to improve maintainability and readability.
💡 **Why:** Formatting and printing logic is usually easy to extract into separate formatting methods with low risk. The original function was over 100 lines long, making it hard to follow.
✅ **Verification:** Verified by running `cargo check`, `cargo fmt`, and `cargo test`. All checks and tests passed successfully, and a code review confirmed the behavior was preserved exactly.
✨ **Result:** The large print function is now split into multiple smaller, named helper functions, dramatically increasing the legibility of the report generation module.

---
*PR created automatically by Jules for task [10518803135889858457](https://jules.google.com/task/10518803135889858457) started by @emersonbusson*