### PR TITLE
🧹 [code health] Flatten deeply nested match statements in driver_link.rs

### DIFF
--- a/crates/ramshared-winsvc/src/driver_link.rs
+++ b/crates/ramshared-winsvc/src/driver_link.rs
@@ -402,9 +402,8 @@ impl<Q: QueueAccess> DriverLink<Q> {
             _ => return ST_EINVAL,
         }
         if sqe.op != OP_FLUSH {
-            let end = match sqe.offset.checked_add(sqe.len as u64) {
-                Some(e) => e,
-                None => return ST_EINVAL,
+            let Some(end) = sqe.offset.checked_add(sqe.len as u64) else {
+                return ST_EINVAL;
             };
             if end > backend.size_bytes() {
                 return ST_EINVAL;
@@ -413,29 +412,30 @@ impl<Q: QueueAccess> DriverLink<Q> {
         match sqe.op {
             OP_READ => {
                 let mut buf = vec![0u8; sqe.len as usize];
-                match backend.read_at(sqe.offset, &mut buf) {
-                    Ok(()) => match self.q.write_slot_from(sqe.buf_slot, &buf) {
-                        Ok(()) => ST_OK,
-                        Err(_) => ST_EINVAL,
-                    },
-                    Err(_) => ST_EIO,
+                if backend.read_at(sqe.offset, &mut buf).is_err() {
+                    return ST_EIO;
                 }
+                if self.q.write_slot_from(sqe.buf_slot, &buf).is_err() {
+                    return ST_EINVAL;
+                }
+                ST_OK
             }
             OP_WRITE => {
-                let data = match self.q.read_slot_owned(sqe.buf_slot, sqe.len) {
-                    Ok(d) => d,
-                    Err(_) => return ST_EINVAL,
+                let Ok(data) = self.q.read_slot_owned(sqe.buf_slot, sqe.len) else {
+                    return ST_EINVAL;
                 };
                 self.backend_writes += 1;
-                match backend.write_at(sqe.offset, &data) {
-                    Ok(()) => ST_OK,
-                    Err(_) => ST_EIO,
+                if backend.write_at(sqe.offset, &data).is_err() {
+                    return ST_EIO;
                 }
+                ST_OK
             }
-            OP_FLUSH => match backend.flush() {
-                Ok(()) => ST_OK,
-                Err(_) => ST_EIO,
-            },
+            OP_FLUSH => {
+                if backend.flush().is_err() {
+                    return ST_EIO;
+                }
+                ST_OK
+            }
             _ => ST_EINVAL,
         }
     }


### PR DESCRIPTION
🎯 **What:** The deeply nested match structures inside the `serve_one` function of `driver_link.rs` have been refactored into a flattened structure using idiomatic Rust early returns.
💡 **Why:** The extensive nesting made the code difficult to read and maintain. Using `is_err()` and `let-else` patterns makes the primary flow clearer.
✅ **Verification:** Unit tests within `ramshared-winsvc` still pass, ensuring that the behavior remains identical to before the refactor. A code review rated this change as `Correct`.
✨ **Result:** A more readable, flattened implementation of the `serve_one` logic.

---
*PR created automatically by Jules for task [1431475628864516334](https://jules.google.com/task/1431475628864516334) started by @emersonbusson*