### PR TITLE
🧪 Add tests for Windows dynamic loader error formatting

### DIFF
--- a/crates/ramshared-cuda/src/loader_win.rs
+++ b/crates/ramshared-cuda/src/loader_win.rs
@@ -66,3 +66,23 @@ pub fn error() -> String {
     let code = unsafe { GetLastError() };
     format!("Windows error code: 0x{code:08X}")
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use windows_sys::Win32::Foundation::SetLastError;
+
+    #[test]
+    fn test_error_formatting() {
+        unsafe { SetLastError(0x00000005) };
+        assert_eq!(error(), "Windows error code: 0x00000005");
+
+        unsafe { SetLastError(0xC0000005) };
+        assert_eq!(error(), "Windows error code: 0xC0000005");
+
+        unsafe { SetLastError(0) };
+        assert_eq!(error(), "Windows error code: 0x00000000");
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `error()` function in `crates/ramshared-cuda/src/loader_win.rs` formats the result of the Windows API `GetLastError()`. This logic lacked test coverage because `GetLastError()` behaves dynamically based on the last failed Windows API call, making deterministic testing challenging.

📊 **Coverage:** What scenarios are now tested
This PR introduces unit tests that explicitly manage the thread-local Windows error code using `SetLastError()` before calling `error()`. The tests verify scenarios for:
*   A standard small error code (`0x00000005` - Access Denied).
*   An error code with higher bits set (`0xC0000005`).
*   A zero error code (`0x00000000`).

✨ **Result:** The improvement in test coverage
The `error()` function is now fully covered by deterministic tests, guaranteeing that Windows error codes are always zero-padded and formatted accurately as 8-character hexadecimal strings (e.g., `0x00000005`).

---
*PR created automatically by Jules for task [9122506383694369368](https://jules.google.com/task/9122506383694369368) started by @emersonbusson*