### PR TITLE
🧪 [Testing] Add error path test for detach_swap sequence

### DIFF
--- a/crates/ramshared-agent/src/swap.rs
+++ b/crates/ramshared-agent/src/swap.rs
@@ -135,4 +135,12 @@ mod tests {
         );
         assert_eq!(swapon_args("/dev/nbd0", None), vec!["/dev/nbd0"]);
     }
+
+    #[test]
+    fn detach_swap_error_path() {
+        let res = detach_swap("/dev/invalid_device_for_test");
+        assert!(res.is_err());
+        let err = res.unwrap_err();
+        assert!(err.starts_with("swapoff: "));
+    }
 }

--- a/pr_desc.txt
+++ b/pr_desc.txt
@@ -1,0 +1,24 @@
+## Resumo
+Adiciona teste de erro para `detach_swap` para garantir a propagacao de erros caso o comando `swapoff` falhe.
+
+## Commits
+| Commit | O que fez | Por que fez | Detalhes |
+|---|---|---|---|
+| `HEAD` | Adicionou teste `detach_swap_error_path` | Cobertura de falhas em chamadas de swap | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-agent/src/swap.rs`<br>**Validacao:** `cargo test`<br>**Risco/rollback:** N/A (Apenas teste novo)</details> |
+
+## Issue
+Closes #
+
+## Responsavel
+@
+
+## Labels
+type:test area:agent
+
+## Validacao
+- [x] Gates de build/test do escopo tocado
+- [ ] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
+- [ ] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudanca nao estrutural / so scripts)
+
+## Rollback trigger
+N/A


### PR DESCRIPTION
🎯 **What:** Added an error path test for `detach_swap` to ensure it propagates errors properly from `swapoff`.
📊 **Coverage:** Tests the failure path of `detach_swap` using an invalid device name, verifying that it correctly emits a `"swapoff: ..."` error.
✨ **Result:** Improved test coverage in `crates/ramshared-agent/src/swap.rs` without requiring root or modifying the command runner structure.

---
*PR created automatically by Jules for task [5192220319971396700](https://jules.google.com/task/5192220319971396700) started by @emersonbusson*