### PR TITLE
🔒 Security Fix: Prevent command option injection in cascade-cli

### DIFF
--- a/crates/ramshared-cli/src/cascade/mod.rs
+++ b/crates/ramshared-cli/src/cascade/mod.rs
@@ -363,7 +363,7 @@ fn swapoff_try(path: &str) -> Result<(), CascadeError> {
         if p.is_empty() {
             continue;
         }
-        match sh("swapoff", &[p]) {
+        match sh("swapoff", &["--", p]) {
             Ok(_) => return Ok(()),
             Err(e) => last = e,
         }
@@ -535,11 +535,11 @@ fn try_recover_zero_used_orphans() -> Result<(), CascadeError> {
             for e in read_swaps() {
                 if e.filename.contains("nbd") && !e.is_ghost() {
                     let dev = e.canonical_path();
-                    let _ = sh("nbd-client", &["-d", &dev]);
+                    let _ = sh("nbd-client", &["-d", "--", &dev]);
                 }
             }
             // Also disconnect default product nbd even if already off swaps.
-            let _ = sh("nbd-client", &["-d", NBD]);
+            let _ = sh("nbd-client", &["-d", "--", NBD]);
 
             if daemon_kill_allowed(&read_swaps()) {
                 cascade_io::stop_daemon_gracefully();
@@ -1366,7 +1366,7 @@ Filename Type Size Used Priority
     #[test]
     fn swapoff_try_prefers_canonical_then_bare() {
         clear_test_seams();
-        push_sh("swapoff /dev/nbd0", Err("first fail"));
+        push_sh("swapoff -- /dev/nbd0", Err("first fail"));
         push_sh("swapoff", Ok(""));
         let r = swapoff_try("nbd0");
         clear_test_seams();


### PR DESCRIPTION
🔒 Security Fix: Prevent command option injection in `cascade-cli`

### 🎯 What: 
The `sh` helper in `cascade-cli` passes arguments directly to commands. Passing external paths from `/proc/swaps` to commands like `swapoff` or `nbd-client` without explicit delimiters allowed for unintended option/flag injection.

### ⚠️ Risk: 
An attacker with sufficient privileges or the ability to manipulate `/proc/swaps` names could cause `swapoff_try` to invoke `swapoff -a` (by supplying a path like `-a/nbd0` where the bare path `-a` is attempted by the fallback logic). This would result in the disabling of all system swaps, breaking memory isolation, causing DoS, or resulting in unintended resource freeing.

### 🛡️ Solution: 
Implemented `--` end-of-options delimiters in invocations of `swapoff` and `nbd-client` within `cascade_down` and `swapoff_try` loops to ensure any parameters acting as paths are interpreted safely. Adjusted relevant test mock to properly mirror this expectation.

---
*PR created automatically by Jules for task [15579726663802459736](https://jules.google.com/task/15579726663802459736) started by @emersonbusson*