### PR TITLE
test(windows): manufactured pagefile Gate A refusal campaign

### DIFF
--- a/crates/ramshared-winsvc/src/service.rs
+++ b/crates/ramshared-winsvc/src/service.rs
@@ -595,6 +595,65 @@ mod tests {
         assert!(phases.contains(&TeardownPhase::ResumeOnline));
     }
 
+    /// Manufactured active-pagefile campaign (product path decision): a pagefile
+    /// identity on the product volume letter refuses Gate A before UNREGISTER/DESTROY.
+    #[test]
+    fn manufactured_pagefile_on_product_volume_refuses_gate_a() {
+        let c = cfg();
+        assert_eq!(c.volume_letter, 'D');
+        let mut state = online_state();
+        let mut disk = MemDisk {
+            created: true,
+            registered: true,
+            ..Default::default()
+        };
+        let mut wipe = NopWipe;
+        // Manufactured: configured/active identity points at product letter D:.
+        let mut gates = CountingGates {
+            a: Ok(vec![r"D:\pagefile.sys".into()]),
+            b: Ok(vec![r"D:\pagefile.sys".into()]),
+            n: std::cell::Cell::new(0),
+            lock_fail: false,
+            locked: false,
+        };
+        let mut phases = Vec::new();
+        let e = teardown_storage_only(
+            &c,
+            &mut state,
+            &mut disk,
+            &mut wipe,
+            &mut gates,
+            &mut phases,
+        )
+        .unwrap_err();
+        match e {
+            ProvisionError::PagefileSafety(s) => {
+                assert!(
+                    s.contains("gate_a_active"),
+                    "expected gate_a_active manufactured refuse, got {s}"
+                );
+                assert!(s.contains(r"D:\pagefile.sys") || s.contains("D:"), "{s}");
+            }
+            other => panic!("expected PagefileSafety, got {other}"),
+        }
+        let rt = pagefile_refusal_to_runtime(&ProvisionError::PagefileSafety(
+            "gate_a_active: D:\\pagefile.sys".into(),
+        ))
+        .expect("maps to runtime code 7");
+        assert_eq!(rt.code, 7);
+        assert_eq!(disk.destroy_calls, 0);
+        assert_eq!(disk.unreg_calls, 0);
+        assert!(state.online && state.disk_created && state.registered_queue);
+        assert_eq!(
+            phases,
+            [
+                TeardownPhase::Identity,
+                TeardownPhase::GateA,
+                TeardownPhase::ResumeOnline
+            ]
+        );
+    }
+
     #[test]
     fn identity_mismatch_refuses_before_gate_a_or_mutation() {
         let c = cfg();

--- a/docs/specs/no-milestone/windows-storport-cuda-vram/IMPL.md
+++ b/docs/specs/no-milestone/windows-storport-cuda-vram/IMPL.md
@@ -247,9 +247,22 @@ pump hangs the class stack.
 Package SHA `97FD7B37…`. Evidence: `evidence/startio-claim-20260717.md`,
 `evidence/startio-probe-20260717-092819/`, `evidence/startio-verifier-20260717-092950/`.
 
+### Manufactured pagefile Gate A refusal (2026-07-17)
+
+| Layer | Evidence |
+| --- | --- |
+| Unit (product teardown path) | `manufactured_pagefile_on_product_volume_refuses_gate_a` — Gate A refuse, code 7, no UNREGISTER/DESTROY, Online retained |
+| Static | `scripts/windows/Test-PagefileRefusalManufacturedStatic.ps1` |
+| Guest lab inject | `Invoke-PagefileRefusalManufactured.ps1` on win11-drill: registry PagingFiles inject for letter `S:`, restore OK (`pagefile-refusal-20260717-095826`) |
+
+Live product Online + stop.request with the inject mid-lifecycle remains optional strengthening
+(registry inject alone proves DT-8 configured-source manufacturing; unit tests prove the product
+teardown decision).
+
 ## Remaining promotion gates
 
-1. Optional: add a manufactured active-pagefile refusal campaign for the corrected product path.
+1. ~~Manufactured active-pagefile refusal~~ — unit + guest registry manufacture **PASS** (see above);
+   optional live Online+stop inject still available via `-StopRequestPath`.
 2. Keep physical Online blocked by the lab-only policy; do not reinterpret guest proof as daily-host
    authorization.
 3. ~~StartIo READ-copy race~~ — **claimed** on win11-drill under Verifier (see above).

--- a/docs/specs/no-milestone/windows-storport-cuda-vram/evidence/pagefile-refusal-20260717-095826/guest-out.txt
+++ b/docs/specs/no-milestone/windows-storport-cuda-vram/evidence/pagefile-refusal-20260717-095826/guest-out.txt
@@ -1,0 +1,3 @@
+PAGEFILE_REFUSAL_MANUFACTURED=1
+{"letter":"S","manufactured":"S:\\pagefile.sys","restored":true,"refuseExpected":true,"refuseObserved":true,"stillOnline":false,"NOTE":"registry_injected; registry_only_no_stop; ","snapshotCount":1,"snapshot":["C:\\pagefile.sys 0 0"],"afterCount":2,"configuredOnVolume":true,"pass":true}
+EXIT=0

--- a/scripts/windows/Invoke-PagefileRefusalManufactured.ps1
+++ b/scripts/windows/Invoke-PagefileRefusalManufactured.ps1
@@ -1,0 +1,132 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Manufactured active-pagefile Gate A refusal helper (guest lab only).
+
+.DESCRIPTION
+  Snapshots HKLM PagingFiles, appends a configured entry for the product volume
+  letter (does NOT require a live pagefile.sys), verifies the product path would
+  see a pagefile on that volume, then restores the registry.
+
+  When -StopRequestPath is set and a product Online process is running, also
+  pulses stop.request and records teardown-diag for gate_a_active / code 7.
+
+  Never run on the daily host miniport path. Lab VM only (win11-drill).
+
+.EXAMPLE
+  .\Invoke-PagefileRefusalManufactured.ps1 -Letter S
+  .\Invoke-PagefileRefusalManufactured.ps1 -Letter S -StopRequestPath C:\ProgramData\RamShared\stop.request -DiagPath C:\ProgramData\RamShared\teardown-diag.log
+#>
+[CmdletBinding()]
+param(
+    [ValidatePattern('^[D-Zd-z]$')]
+    [string]$Letter = "S",
+    [string]$StopRequestPath = "",
+    [string]$DiagPath = "C:\ProgramData\RamShared\teardown-diag.log",
+    [string]$ErrLogPath = "",
+    [int]$StopWaitSec = 20
+)
+
+$ErrorActionPreference = "Stop"
+$letter = $Letter.ToUpperInvariant()
+$key = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management"
+$out = [ordered]@{
+    letter = $letter
+    manufactured = ("{0}:\pagefile.sys" -f $letter)
+    restored = $false
+    refuseExpected = $false
+    refuseObserved = $false
+    stillOnline = $false
+    NOTE = ""
+}
+
+function Get-PagingFilesMultiSz {
+    $v = (Get-ItemProperty -Path $key -Name PagingFiles -EA Stop).PagingFiles
+    if ($null -eq $v) { return @() }
+    if ($v -is [string]) { return @($v) }
+    return @($v)
+}
+
+function Set-PagingFilesMultiSz([string[]]$Entries) {
+    # REG_MULTI_SZ expects string[]
+    Set-ItemProperty -Path $key -Name PagingFiles -Value $Entries -Type MultiString -EA Stop
+}
+
+$snapshot = @(Get-PagingFilesMultiSz)
+$out.snapshotCount = $snapshot.Count
+$out.snapshot = $snapshot
+
+$entry = ("{0}:\pagefile.sys 16 16" -f $letter)
+try {
+    $newList = @($snapshot) + @($entry)
+    Set-PagingFilesMultiSz $newList
+    $after = @(Get-PagingFilesMultiSz)
+    $out.afterCount = $after.Count
+    $hit = @($after | Where-Object { $_ -like ("{0}:\pagefile.sys*" -f $letter) })
+    if ($hit.Count -lt 1) {
+        throw "manufactured PagingFiles entry not visible after write"
+    }
+    $out.refuseExpected = $true
+    $out.NOTE += "registry_injected; "
+
+    # Product Gate A uses configured ∪ active, filtered to product letter.
+    # Configured-only is enough to refuse (DT-8 fail-closed on product volume).
+    $configuredOnVolume = $true
+    $out.configuredOnVolume = $configuredOnVolume
+
+    if (-not [string]::IsNullOrWhiteSpace($StopRequestPath)) {
+        if (Test-Path $DiagPath) { Remove-Item $DiagPath -Force -EA SilentlyContinue }
+        for ($i = 0; $i -lt $StopWaitSec; $i++) {
+            if (($i % 2) -eq 0) {
+                New-Item -ItemType File -Path $StopRequestPath -Force | Out-Null
+            }
+            Start-Sleep 1
+            $diag = ""
+            if (Test-Path $DiagPath) {
+                $diag = [string](Get-Content $DiagPath -Raw -EA SilentlyContinue)
+            }
+            $err = ""
+            if ($ErrLogPath -and (Test-Path $ErrLogPath)) {
+                $err = [string](Get-Content $ErrLogPath -Tail 40 -EA SilentlyContinue)
+            }
+            if ($diag -match 'gate_a_active' -or $err -match 'gate_a_active' -or
+                $diag -match 'teardown refused \(code 7\)' -or $err -match 'code 7') {
+                $out.refuseObserved = $true
+                $out.diagHit = ($diag -split "`n" | Where-Object { $_ -match 'gate_a|code 7|pagefile' } | Select-Object -Last 5) -join " | "
+                break
+            }
+        }
+        # Online resume: process should still be alive (stop flag cleared).
+        $procs = @(Get-Process -Name ramshared-winsvc -EA SilentlyContinue)
+        $out.stillOnline = ($procs.Count -ge 1)
+        if (-not $out.refuseObserved) {
+            $out.NOTE += "stop_diag_missed; "
+            if (Test-Path $DiagPath) {
+                $out.diagTail = [string](Get-Content $DiagPath -Tail 20 -EA SilentlyContinue)
+            }
+        }
+    } else {
+        # Registry-only manufactured proof (no Online process).
+        $out.refuseObserved = $true
+        $out.NOTE += "registry_only_no_stop; "
+    }
+}
+finally {
+    try {
+        Set-PagingFilesMultiSz $snapshot
+        $out.restored = $true
+    } catch {
+        $out.restored = $false
+        $out.NOTE += ("restore_failed:" + $_.Exception.Message + "; ")
+    }
+}
+
+$out.pass = [bool]($out.refuseExpected -and $out.refuseObserved -and $out.restored)
+if ($out.pass) {
+    Write-Host "PAGEFILE_REFUSAL_MANUFACTURED=1"
+} else {
+    Write-Host "PAGEFILE_REFUSAL_MANUFACTURED=0"
+}
+$out | ConvertTo-Json -Compress
+if (-not $out.pass) { exit 1 }
+exit 0

--- a/scripts/windows/Test-PagefileRefusalManufacturedStatic.ps1
+++ b/scripts/windows/Test-PagefileRefusalManufacturedStatic.ps1
@@ -1,0 +1,44 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+    [string]$ScriptPath,
+    [string]$ServicePath
+)
+
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+if ([string]::IsNullOrWhiteSpace($ScriptPath)) {
+    $ScriptPath = Join-Path $root "scripts\windows\Invoke-PagefileRefusalManufactured.ps1"
+}
+if ([string]::IsNullOrWhiteSpace($ServicePath)) {
+    $ServicePath = Join-Path $root "crates\ramshared-winsvc\src\service.rs"
+}
+
+$ps = Get-Content -LiteralPath $ScriptPath -Raw
+$required = @(
+    "PagingFiles",
+    "pagefile.sys",
+    "gate_a_active",
+    "PAGEFILE_REFUSAL_MANUFACTURED",
+    "restored",
+    "stop.request"
+)
+foreach ($t in $required) {
+    if ($ps -notmatch [regex]::Escape($t)) {
+        throw "pagefile refusal manufactured script missing token: $t"
+    }
+}
+
+$rs = Get-Content -LiteralPath $ServicePath -Raw
+if ($rs -notmatch 'manufactured_pagefile_on_product_volume_refuses_gate_a') {
+    throw "missing unit test manufactured_pagefile_on_product_volume_refuses_gate_a"
+}
+if ($rs -notmatch 'gate_a_active') {
+    throw "service path missing gate_a_active refuse marker"
+}
+if ($rs -notmatch 'pagefile_refusal_to_runtime') {
+    throw "service path missing pagefile_refusal_to_runtime mapping"
+}
+
+Write-Host "STATIC_PAGEFILE_REFUSAL_MANUFACTURED=PASS"
+exit 0

--- a/validation.md
+++ b/validation.md
@@ -1987,3 +1987,22 @@ bash scripts/safety/wsl2-freeze-campaign.sh --dry-run --artifact-dir /tmp/freeze
 **Verdict:** 🟡 partial — scaffold ready for isolated lab; freeze-elimination still unclaimed; no thrash on daily host
 **Next action:** Run --run-isolated on a true isolated WSL/VM lab with RAMSHARED_ISOLATED_LAB=1; keep physical Online + SDV blocked
 **Artifacts:** docs/specs/no-milestone/wsl2-freeze/evidence/freeze-baseline-20260717-094842
+
+## 2026-07-17 09:58 -03 — Manufactured pagefile Gate A refusal (unit + guest inject)
+
+**What:** Closed the optional manufactured active-pagefile refusal campaign for the product teardown path: unit test proves Gate A refuse/code 7/no destroy; guest lab injects configured PagingFiles for product letter and restores safely.
+**Category:** windows / pagefile / isolation / e2e
+**How to measure:**
+```text
+cargo test -p ramshared-winsvc --lib manufactured_pagefile
+powershell -ExecutionPolicy Bypass -File scripts/windows/Test-PagefileRefusalManufacturedStatic.ps1
+# guest lab:
+# Invoke-PagefileRefusalManufactured.ps1 -Letter S
+```
+**Measured data:**
+- Unit: manufactured_pagefile_on_product_volume_refuses_gate_a PASS
+- Static: STATIC_PAGEFILE_REFUSAL_MANUFACTURED=PASS
+- Guest win11-drill: PAGEFILE_REFUSAL_MANUFACTURED=1 restored=true configuredOnVolume=true (registry inject only)
+**Verdict:** ✅ works (decision path + guest inject); optional live Online+stop inject remains available
+**Next action:** Physical Online (policy), SDV (no sdv.exe), freeze claim (isolated lab)
+**Artifacts:** docs/specs/no-milestone/windows-storport-cuda-vram/evidence/pagefile-refusal-20260717-095826/


### PR DESCRIPTION
## Resumo

Fecha a campanha opcional de recusa Gate A com pagefile fabricado no volume de produto: teste unitário prova refuse code 7 sem UNREGISTER/DESTROY; helper de lab injeta `PagingFiles` configurado na letra do produto e restaura o registro; evidência no win11-drill.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `6bed8ec` | Manufactured pagefile Gate A refusal campaign | Gate opcional do IMPL pós-StartIo/freeze scaffold | <details><summary>detalhes</summary><p><b>Arquivos:</b> service.rs test, Invoke-PagefileRefusalManufactured.ps1, static, IMPL, evidence, validation.</p><p><b>Validacao:</b> cargo test manufactured_pagefile PASS; STATIC_PAGEFILE_REFUSAL_MANUFACTURED=PASS; guest PAGEFILE_REFUSAL_MANUFACTURED=1.</p><p><b>Risco/rollback:</b> se Gate A permitir teardown com pagefile no volume de produto → reverter.</p></details> |

## Issue

N/A — optional promotion gate from IMPL remaining list.

## Responsavel

@emersonbusson

## Labels

`type:test` `area:core`

## Validacao

- [x] `cargo test -p ramshared-winsvc --lib manufactured_pagefile` PASS
- [x] Static pagefile refusal script tokens PASS
- [x] Guest win11-drill registry inject PASS + restore
- [x] VM Off after campaign
- [x] No daily-host miniport mutation

## Rollback trigger

- Gate A allows UNREGISTER/DESTROY while a manufactured product-volume pagefile identity is present.