### PR TITLE
docs(windows): record SDV retirement on modern WDK

### DIFF
--- a/docs/specs/no-milestone/windows-storport-cuda-vram/IMPL.md
+++ b/docs/specs/no-milestone/windows-storport-cuda-vram/IMPL.md
@@ -260,25 +260,35 @@ Live product Online + stop with mid-lifecycle inject is **PASS**
 `gate_a_active: S:\pagefile.sys`, Online resumed, then clean stop exit 0, lease release,
 CUDA restore, no dump. Flag: `Run-GuestProductOnline.ps1 -ManufacturedPagefileRefuse`.
 
-### SDV probe (2026-07-17)
+### SDV probe (2026-07-17, refreshed)
 
-`Invoke-SdvProbe.ps1`: `sdv.exe` not on PATH; MSBuild `/t:sdv` → MSB4057 (target missing).
-WDK has `WindowsDriver.Sdv.targets` but SDV tool package is not installed.
-**SDV_CLAIM=NOT_CLAIMED.** Evidence: `evidence/sdv-probe-20260717/`.
+`Invoke-SdvProbe.ps1` + WDK `10.0.26100.0` `WindowsDriver.Sdv.targets`:
+
+- `sdv.exe` is **not** on PATH (full tree search under Windows Kits / VS BuildTools: absent).
+- Winget package `Microsoft.WindowsWDK.10.0.26100` is already installed (no update available).
+- Official stub in WDK targets: **"Static Driver Verifier (SDV) is no longer included in the
+  Windows Driver Kit and is no longer compatible with VS2022 and later. To use SDV, install an
+  older version of the EWDK."**
+- MSBuild `/t:sdv` on `ramshared.vcxproj` → MSB4057 (project does not import a live SDV pipeline).
+
+**SDV_CLAIM=NOT_CLAIMED** — not an install oversight on this machine; modern WDK/VS2022 retired the
+tool. Claiming PASS would require a dedicated older EWDK environment (out of Day-0 VS2022 lab).
+Evidence: `evidence/sdv-probe-20260717/`.
 
 ## Remaining promotion gates
 
 1. ~~Manufactured active-pagefile refusal~~ — unit + guest inject + **live Online+stop** PASS.
 2. Keep physical Online blocked by the lab-only policy; do not reinterpret guest proof as daily-host
-   authorization.
+   authorization. (win11-drill GPU-PV Online is already claimed; daily-host miniport is not.)
 3. ~~StartIo READ-copy race~~ — **claimed** on win11-drill under Verifier (see above).
-4. Run the isolated WSL2 freeze campaign before any freeze-elimination claim.
-   Scaffold: `scripts/safety/wsl2-freeze-campaign.sh` — dry-run baseline + gate refuse on
-   daily host; full 2× before→action→after only with `--allow-isolated-lab`,
-   `RAMSHARED_ISOLATED_LAB=1`, and `--run-isolated` (cgroup-bounded pressure + watchdog).
-   Static: `scripts/safety/Test-Wsl2FreezeCampaignStatic.sh`.
-5. SDV PASS — install Static Driver Verifier component for WDK 10.0.26100, re-run
-   `Invoke-SdvProbe.ps1` / MSBuild `/t:sdv`, record defects=0.
+4. Run the isolated **WSL2** freeze campaign before any freeze-elimination claim.
+   Scaffold: `scripts/safety/wsl2-freeze-campaign.sh`. This is **not** win11-drill (Windows Hyper-V
+   guest). The daily WSL2 host (`Ubuntu-24.04` + `/mnt/c/Users`) is correctly refused
+   (`daily_host_refused_without_isolated_lab_flag`). Full 2× before→action→after only with
+   `--allow-isolated-lab`, `RAMSHARED_ISOLATED_LAB=1`, and a non-daily host (or
+   `RAMSHARED_FORCE_ISOLATED_LAB=1` only on a true disposable WSL lab VM — never the daily box).
+5. SDV PASS — **blocked by Microsoft tool retirement on VS2022/WDK 26100**, not missing local
+   install. Optional future: older EWDK image dedicated to SDV only.
 
 The WSL2 freeze claim is **BLOCKED, not PASS**. Promotion requires a dedicated isolated
 before→action→after campaign with watchdog/timeout, swapoff-first, ghost/deleted-plus-used-kB checks,

--- a/docs/specs/no-milestone/windows-storport-cuda-vram/evidence/sdv-probe-20260717/sdv-probe-summary.json
+++ b/docs/specs/no-milestone/windows-storport-cuda-vram/evidence/sdv-probe-20260717/sdv-probe-summary.json
@@ -1,5 +1,5 @@
 ﻿{
-    "ts":  "2026-07-17T10:25:56.1394657-03:00",
+    "ts":  "2026-07-17T11:09:21.7236814-03:00",
     "project":  "C:\\ramshared\\src\\drivers\\windows\\ramshared\\ramshared.vcxproj",
     "projectExists":  true,
     "sdvOnPath":  false,
@@ -11,7 +11,9 @@
     "msbuildSdvExit":  1,
     "claim":  "NOT_CLAIMED",
     "reasons":  [
+                    "sdv_retired_from_wdk_vs2022_plus",
                     "sdv.exe_not_on_path",
                     "msbuild_target_sdv_missing"
-                ]
+                ],
+    "sdvRetiredFromModernWdk":  true
 }

--- a/docs/specs/no-milestone/windows-storport-cuda-vram/evidence/sdv-probe-20260717/wdk-sdv-target-snippet.txt
+++ b/docs/specs/no-milestone/windows-storport-cuda-vram/evidence/sdv-probe-20260717/wdk-sdv-target-snippet.txt
@@ -1,0 +1,2 @@
+﻿<Target Name="sdv">
+<Warning Text="Static Driver Verifier (SDV) is no longer included in the Windows Driver Kit and is no longer compatible with VS2022 and later.  To use SDV, install an older version of the EWDK."

--- a/scripts/windows/Invoke-SdvProbe.ps1
+++ b/scripts/windows/Invoke-SdvProbe.ps1
@@ -51,8 +51,23 @@ $sdvTargets = "C:\Program Files (x86)\Windows Kits\10\build\$KitVersion\WindowsD
 if (Test-Path $sdvTargets) {
     $o.sdvTargetsPresent = $true
     $o.sdvTargetsPath = $sdvTargets
+    # WDK 10.0.26100+ ships a stub target that documents retirement.
+    $targetsText = Get-Content -LiteralPath $sdvTargets -Raw -EA SilentlyContinue
+    if ($targetsText -match 'no longer included in the Windows Driver Kit' -or
+        $targetsText -match 'no longer compatible with VS2022') {
+        $o.sdvRetiredFromModernWdk = $true
+        $o.reasons += "sdv_retired_from_wdk_vs2022_plus"
+        $snip = Join-Path $ArtifactDir "wdk-sdv-target-snippet.txt"
+        # Keep a short excerpt for evidence without copying the full targets file.
+        ($targetsText -split "`n" | Select-String -Pattern 'Target Name="sdv"|no longer included|no longer compatible|older version of the EWDK' |
+            ForEach-Object { $_.Line.Trim() }) -join "`n" |
+            Set-Content -Path $snip -Encoding utf8
+    } else {
+        $o.sdvRetiredFromModernWdk = $false
+    }
 } else {
     $o.reasons += "WindowsDriver.Sdv.targets_missing"
+    $o.sdvRetiredFromModernWdk = $null
 }
 
 # where after vcvars

--- a/scripts/windows/Test-SdvProbeStatic.ps1
+++ b/scripts/windows/Test-SdvProbeStatic.ps1
@@ -11,6 +11,7 @@ $required = @(
     "NOT_CLAIMED",
     "sdv.exe_not_on_path",
     "msbuild_target_sdv_missing",
+    "sdv_retired_from_wdk_vs2022_plus",
     "/t:sdv",
     "SDV_CLAIM",
     "WindowsDriver.Sdv.targets"

--- a/validation.md
+++ b/validation.md
@@ -2025,3 +2025,21 @@ powershell -ExecutionPolicy Bypass -File scripts/windows/Test-SdvProbeStatic.ps1
 **Verdict:** ✅ works (live pagefile Online refuse); 🟡 partial (SDV tool absent)
 **Next action:** Isolated freeze claim; install SDV; keep physical Online blocked
 **Artifacts:** docs/specs/no-milestone/windows-storport-cuda-vram/evidence/pagefile-online-refuse-20260717-102614/, evidence/sdv-probe-20260717/
+
+## 2026-07-17 11:10 -03 — SDV retired on modern WDK (verified, still NOT_CLAIMED)
+
+**What:** Verified SDV cannot be claimed on this Day-0 lab: WDK 10.0.26100 already installed; sdv.exe absent; official WindowsDriver.Sdv.targets stub states SDV is no longer in WDK and incompatible with VS2022+. Freeze remain daily-host refused; physical Online still policy-blocked.
+**Category:** windows / sdv / isolation
+**How to measure:**
+```text
+powershell -ExecutionPolicy Bypass -File scripts/windows/Invoke-SdvProbe.ps1
+bash scripts/safety/wsl2-freeze-campaign.sh --check-gates
+```
+**Measured data:**
+- winget: Microsoft.WindowsWDK.10.0.26100 installed, no update
+- tree search: no sdv.exe under Windows Kits / VS BuildTools
+- targets text: "no longer included in the Windows Driver Kit" / "no longer compatible with VS2022"
+- freeze --check-gates: daily_host=1 gates_ok=0
+**Verdict:** 🟡 partial — SDV gap is tool retirement (not agent install skip); freeze/physical still env/policy
+**Next action:** Optional older EWDK for SDV only; true isolated WSL lab for freeze claim
+**Artifacts:** docs/specs/no-milestone/windows-storport-cuda-vram/evidence/sdv-probe-20260717/


### PR DESCRIPTION
## Resumo

Verifiquei SDV de verdade neste lab: WDK 10.0.26100 já instalado, `sdv.exe` ausente, e o stub oficial do WDK declara que **SDV não vem mais no WDK e não é compatível com VS2022+**. Não é falha de instalação local. Freeze continua recusado no host diário; Physical Online continua política lab-only (product Online no win11-drill já claimado).

## Commits

| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `8ad6d8d` | Record SDV retirement on modern WDK | User asked to install/verify; truth is tool retired | <details><summary>detalhes</summary><p><b>Arquivos:</b> Invoke-SdvProbe.ps1, static, IMPL, evidence snippet, validation.</p><p><b>Validacao:</b> STATIC_SDV_PROBE=PASS; probe reasons include sdv_retired_from_wdk_vs2022_plus; freeze --check-gates daily_host refuse.</p><p><b>Risco/rollback:</b> claim SDV PASS sem EWDK antigo = inválido.</p></details> |

## Issue

N/A

## Responsavel

@emersonbusson

## Labels

`type:docs` `area:core`

## Validacao

- [x] winget WDK 26100 already installed
- [x] no sdv.exe under Kits/VS
- [x] WDK targets text documents retirement
- [x] freeze --check-gates refuses daily host
- [x] no thrash, no daily miniport Online

## Rollback trigger

- Claiming SDV PASS on VS2022/WDK 26100 without an older EWDK SDV run artifact.