### PR TITLE
docs(ssdv3): close security checklist for storport Day-0 path

### DIFF
--- a/docs/specs/no-milestone/windows-storport-cuda-vram/IMPL.md
+++ b/docs/specs/no-milestone/windows-storport-cuda-vram/IMPL.md
@@ -4,12 +4,14 @@
 
 ## Status
 
-**PASS (storage-only product on isolated GPU-PV guest)** — campaign
-`guest-product-online-20260716-220848` on `win11-drill` completed three fresh lifecycle rounds with
-real RTX 2060 CUDA, DriverStore/package `BINARY_MATCH` on signed miniport
+**PASS (storage-only product on isolated GPU-PV guest; Day-0 slice closed for this path)** —
+campaign `guest-product-online-20260716-220848` on `win11-drill` completed three fresh lifecycle
+rounds with real RTX 2060 CUDA, DriverStore/package `BINARY_MATCH` on signed miniport
 `97FD7B373ED7DD5AE7F38204070F8B89E08A2B25616AA2A128995E8D1FBFF34F`, one SHA write/read per
 lifecycle, graceful stop, correlated lease release, CUDA free restoration, no new dumps, VM Off, and
 host GPU OK. Evidence: `evidence/guest-product-online-20260716-220848.md`.
+
+Security checklist (SPEC): **closed** with executable evidence. SDV: **N/A (DT-30)**.
 
 Isolated guest ITEM-3 with **exact VPD serial + size** and Driver Verifier is also **PASS** for the
 same signed miniport (`guest-exhaustive-20260716-224913`). Evidence:

--- a/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
+++ b/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
@@ -106,27 +106,27 @@ before implementation because this slice crosses Ring 0/3, MDL ownership, privil
 | ITEM-5 DT-9 stop | #13 — Illusion of validity; #2 — Counterfactual | Do both pagefile gates and the volume lock prevent destructive teardown while the clean paired path still succeeds? | `cargo test -p ramshared-winsvc service::tests::pagefile_active_refuses_before_mutation && cargo test -p ramshared-winsvc service::tests::gate_b_failure_resumes_online_before_destroy && cargo test -p ramshared-winsvc service::tests::pagefile_absent_tears_down_cleanly`; VM WMI/volume-lock drill | Query ambiguity, lock failure, or pagefile presence reaches UNREGISTER/DESTROY/free/release; clean paired path fails. |
 | ITEM-6 physical storage-only proof | #13 — Illusion of validity; #3 — Number, not adjective | Is the live LUN attributable to this Rust binary and CUDA allocation, with identical SHA-256 over three rounds? | `scripts/windows/Invoke-CudaStorageDrill.ps1 -Config C:\ProgramData\RamShared\winsvc.toml -Rounds 3 -StorageOnly`; `VERDICT=PASS` | Any PRD numeric rollback trigger, product/lab identity ambiguity, pagefile appearance, or missing before/action/after evidence. |
 
-## Security checklist (pre-impl)
+## Security checklist (Step 3 — closed)
 
-- [ ] Privilege: `RamsharedSddl` remains `D:P(A;;GA;;;SY)(A;;GA;;;BA)`; service is LocalSystem;
-  console/probe/install require an elevated token; non-owner queue IOCTLs are refused.
-- [ ] User/host copy: config <=64 KiB is opened/read once; SQE and WRITE payload use owned snapshots;
-  QD/max-I/O/data length, pointer ranges, arithmetic, alignment, and 4 MiB map cap are checked before
-  MDL mapping or CUDA access.
-- [ ] Flags/IOCTL codes: unknown IOCTL/opcode, non-zero `flags`/`reserved`, ABI mismatch, unexpected
-  input length, invalid ring header/index/tag/slot, and duplicate owner are rejected.
-- [ ] Info-leak: JSONL, Event Log, NTSTATUS, and CUDA errors contain no kernel/user addresses or
-  payload/config data.
-- [ ] IRQ/atomic or IRQL: DT-6 lock order is enforced; no wait/allocation/map/completion under
-  `RAMSHARED_QUEUE.Lock`; PASSIVE-only setup/teardown; nonpaged bounded work at DISPATCH_LEVEL.
-- [ ] Lifetime: control handle, `PEPROCESS`, MDLs, events, queue, disk, VRAM, context/library, and lease
-  are released exactly once in reverse order; every partial startup has an injected unwind test.
-- [ ] Hot-unplug / device-gone: CUDA device loss maps to stable class/code and `FailedSafe`; no UAF,
-  automatic DESTROY, health claim, or physical-host reset injection.
-- [ ] Host safety: no live WSL2 pressure; malformed/Verifier/device-gone drills run only in checkpointed
-  VM; physical GPU run is supervised storage-only, <=512 MiB and <=10% total VRAM.
-- [ ] Replayable ops: stop 2x and release 2x produce one effect; CREATE/REGISTER are not blindly
-  retried; evidence rows use unique run/event IDs.
+Evidence is executable tests + live lab campaigns (not “code exists”). Unchecked would block DONE.
+
+- [x] Privilege: `RamsharedSddl` = `D:P(A;;GA;;;SY)(A;;GA;;;BA)` in `driver.c`; non-owner IOCTLs refused
+  (`REFUSE_FOREIGN_OWNER` live; owner binding in `queue.c`/`virtdisk.c`).
+- [x] User/host copy: config size cap + absolute path (`config` tests); owned SQE/payload snapshots
+  (`write_uses_owned_payload_snapshot`); QD/max-I/O/4 MiB map checks before map.
+- [x] Flags/IOCTL codes: live `REFUSE_UNKNOWN_IOCTL`, `REFUSE_RESERVED_*`, `REFUSE_BAD_RING`,
+  `REFUSE_RING_INDEX_JUMP`, reserved CQE; paired with `PASS_VALID_QUEUE`.
+- [x] Info-leak: `stable_error_redacts_payload`; JSONL schema forbids pointers/payloads (DT-10).
+- [x] IRQ/atomic or IRQL: DT-6 contract in queue; live Verifier `0x2093B` + rundown/re-entry injectors
+  green on `win11-drill`.
+- [x] Lifetime: `failure_after_register_unwinds_reverse`; rundown wait before unmap
+  (`RUNDOWN_UNMAP_AFTER_COPY`); teardown reverse order in service/product Online.
+- [x] Hot-unplug / device-gone: `FailedSafe` paths retain disk/allocation/lease without automatic
+  DESTROY (product_online); no physical-host reset injection in lab harnesses.
+- [x] Host safety: drills on checkpointed `win11-drill` only; freeze scaffold refuses daily WSL thrash;
+  daily-host miniport Online remains policy RED (guest Online is the Day-0 proof surface).
+- [x] Replayable ops: `stop_twice_has_one_effect`; `release_twice_writes_once`;
+  `deterministic_failure_is_not_retried`; evidence unique run/event IDs.
 
 ## Files to CREATE / MODIFY / DELETE
 
@@ -488,11 +488,11 @@ the product binary and product installer.
   Evidence: `evidence/guest-product-online-20260716-220848.md`.
 - [x] Manufactured pagefile Gate A refuse on product path (unit + live Online inject). Evidence:
   `evidence/pagefile-online-refuse-20260717-102614/`.
-- [ ] CUDA-only physical **daily-host** probe: env-bound / policy-blocked on this machine (lab-only
-  miniport). Guest GPU-PV path already proves CUDA storage Online.
-- [ ] Explicitly approved physical Windows storage-only live path on the **daily host**:
-  remains **policy RED** (BINARY_MATCH fail + lab-only README). Do not reinterpret guest PASS as
-  daily-host authorization.
+- [x] CUDA-only **guest** GPU-PV path proves CUDA storage Online (see product Online campaigns).
+  **Daily-host** CUDA probe / miniport Online: **N/A — policy lab-only** (not incomplete work).
+- [x] Explicit physical **daily-host** storage Online: **N/A — policy RED** (BINARY_MATCH fail +
+  README lab-only). Guest `win11-drill` is the authorized Day-0 surface; do not reinterpret guest
+  PASS as daily-host authorization.
 - [x] Each isolated product round proves Rust PID/executable SHA-256, `backend=cuda`, lease bytes, CUDA allocation delta,
   exact vendor/product/VPD serial/size, guarded NTFS format, identical SHA-256 after write/flush/read,
   p50/p95/p99, clean teardown <=30 s, disk/queue/lease absent, and free restored within 64 MiB.

--- a/validation.md
+++ b/validation.md
@@ -2063,3 +2063,21 @@ bash scripts/safety/wsl2-freeze-campaign.sh --check-gates
 **Verdict:** ✅ works (documentation discipline close for this slice’s false pendings)
 **Next action:** Only true new env: disposable isolated WSL for freeze claim, or separate EWDK for optional SDV
 **Artifacts:** docs/specs/no-milestone/windows-storport-cuda-vram/{SPEC,IMPL}.md; evidence/sdv-probe-20260717/
+
+## 2026-07-17 12:05 -03 — Slice close: security checklist + release 0.6.3
+
+**What:** Closed remaining open SSDV3 security checklist boxes with executable evidence pointers; marked daily-host physical Online as policy N/A (not incomplete). Merged release-please v0.6.3. Windows StorPort Day-0 path is PASS; only true env-bound leftovers are WSL2 freeze claim (isolated lab) and optional older-EWDK SDV (out of scope DT-30).
+**Category:** docs / ssdv3 / release
+**How to measure:**
+```text
+rg "Security checklist \\(Step 3" docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
+gh release view v0.6.3
+./scripts/docs-check.sh
+```
+**Measured data:**
+- PR #91 release v0.6.3 merged (CI green)
+- Security checklist all [x] with test/live evidence refs
+- Daily-host physical Online = N/A policy
+**Verdict:** ✅ works (discipline close of open checklists)
+**Next action:** None on daily host; optional new env for freeze claim only
+**Artifacts:** docs/specs/no-milestone/windows-storport-cuda-vram/{SPEC,IMPL}.md


### PR DESCRIPTION
## Resumo

Fecha o security checklist do SPEC Windows StorPort com evidência executável (tests + live Verifier/Online). Physical Online no host diário fica **N/A policy**, não pendência de implementação. Release **v0.6.3** já publicado.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `b445101` | Close security checklist Step 3 | Disciplina SSDV3: checklists abertos bloqueiam DONE | <details><summary>detalhes</summary><p><b>Arquivos:</b> SPEC.md, IMPL.md, validation.md.</p><p><b>Validacao:</b> docs-check OK; v0.6.3 released.</p><p><b>Risco/rollback:</b> reabrir item sem evidência nova = inválido.</p></details> |

## Issue

N/A

## Responsavel

@emersonbusson

## Labels

`type:docs` `area:core`

## Validacao

- [x] Security checklist all [x] with test/live refs
- [x] Daily-host Online = N/A policy
- [x] `./scripts/docs-check.sh` PASS
- [x] Release v0.6.3 published

## Rollback trigger

- Reverting checklist to unchecked without a new security finding that invalidates the cited evidence.