### PR TITLE
🔒 fix: validate stop.request file removal to prevent DoS

### DIFF
--- a/crates/ramshared-winsvc/src/main.rs
+++ b/crates/ramshared-winsvc/src/main.rs
@@ -242,15 +242,16 @@ mod windows_svc {
         thread::spawn(move || {
             let path = stop_request_path();
             loop {
-                if path.exists() {
-                    let _ = std::fs::remove_file(&path);
-                    stop_c.store(true, Ordering::SeqCst);
-                    // Unbuffered diagnostic: redirected stderr can lose last lines on kill.
-                    diag_line("stop.request observed; AtomicBool=true");
-                    while stop_c.load(Ordering::Acquire) {
-                        thread::sleep(Duration::from_millis(50));
+                if path.is_file() {
+                    if std::fs::remove_file(&path).is_ok() {
+                        stop_c.store(true, Ordering::SeqCst);
+                        // Unbuffered diagnostic: redirected stderr can lose last lines on kill.
+                        diag_line("stop.request observed and removed; AtomicBool=true");
+                        while stop_c.load(Ordering::Acquire) {
+                            thread::sleep(Duration::from_millis(50));
+                        }
+                        diag_line("stop flag cleared (resume Online or process exit)");
                     }
-                    diag_line("stop flag cleared (resume Online or process exit)");
                 }
                 thread::sleep(Duration::from_millis(200));
             }


### PR DESCRIPTION
## Resumo

This PR addresses a security vulnerability related to unchecked file operations in the Windows Service (`ramshared-winsvc`). The vulnerability occurred because `stop.request` was unvalidated during deletion, posing a risk of entering infinite loops or creating a Denial of Service (DoS) state if an attacker created an undeletable directory or file.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `pending` | Fix unchecked file removal on `stop.request` in `ramshared-winsvc` | Prevent DoS by validating file type and verifying removal before signalling service stop. | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-winsvc/src/main.rs`<br>**Validacao:** cargo test, cargo fmt, cargo clippy.<br>**Risco/rollback:** Minimal; safely handles file removal and falls back gracefully if unable to remove.</details> |

## Issue

Closes #N/A

## Responsavel

@jules

## Labels

type:security, area:winsvc

## Validacao

- [x] Gates de build/test do escopo tocado
- [x] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
- [x] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)

## Rollback trigger

Fails to stop service correctly via the `stop.request` file due to edge cases in file permissions causing valid delete attempts to fail.

---
*PR created automatically by Jules for task [15027098426921891382](https://jules.google.com/task/15027098426921891382) started by @emersonbusson*