### PR TITLE
⚡ [performance improvement] Parallelize ramshared-agent swapoff cleanup loops

### DIFF
--- a/crates/ramshared-agent/src/main.rs
+++ b/crates/ramshared-agent/src/main.rs
@@ -347,10 +347,16 @@ fn session(
     }
 
     // Cleanup: releases active slices (best-effort; broker reconciles on re-register).
+    let mut handles = Vec::new();
     for (slice, dev) in active.drain() {
-        if let Err(e) = swap::detach_swap(&dev) {
-            eprintln!("[agent] cleanup swapoff s{slice} ({dev}) falhou: {e}");
-        }
+        handles.push(thread::spawn(move || {
+            if let Err(e) = swap::detach_swap(&dev) {
+                eprintln!("[agent] cleanup swapoff s{slice} ({dev}) falhou: {e}");
+            }
+        }));
+    }
+    for h in handles {
+        let _ = h.join();
     }
     let _ = w.shutdown(std::net::Shutdown::Both);
     let _ = reader_handle.join();


### PR DESCRIPTION
## Resumo
Optimized the cleanup loop in `crates/ramshared-agent/src/main.rs` to run concurrent threads during `detach_swap`.

## Commits
* perf: parallelize swapoff cleanup loops in ramshared-agent

## Issue
N/A

## Responsavel
Agent

## Labels
performance

## Validacao
Ran a mock test isolating I/O wait times which proved a drop from 500ms sequential to 100ms parallel on 5 slices. Also successfully compiled and ran unit/integration tests with `cargo test`. Code formatted with `cargo fmt` and statically analyzed by `cargo clippy`. 

💡 **What:** The optimization uses `std::thread::spawn` to loop over all active slices and run `detach_swap` in parallel. We store the join handles and finally await all of them before completing shutdown.
🎯 **Why:** The previous iteration was blocking on each synchronous I/O swap detach command. When detaching multiple swap slices, the system unnecessarily waited linearly causing extremely slow shutdowns.
📊 **Measured Improvement:** Simulated an I/O wait cost of 100ms per slice, dropping total task cost from sequential (~500ms) to parallel (~100ms) for an active loop of 5 dummy tasks.

## Rollback trigger
N/A

---
*PR created automatically by Jules for task [12022198659841210738](https://jules.google.com/task/12022198659841210738) started by @emersonbusson*