### PR TITLE
🧪 test: expand coverage for vram_outros in telemetry

### DIFF
--- a/crates/ramshared-wsl2d/src/telemetry.rs
+++ b/crates/ramshared-wsl2d/src/telemetry.rs
@@ -204,9 +204,30 @@ mod tests {
     }
 
     #[test]
-    fn vram_outros_clamps_at_zero() {
+    fn vram_outros_normal_subtraction() {
         assert_eq!(vram_outros(2000, 500), 1500);
+    }
+
+    #[test]
+    fn vram_outros_clamps_at_zero() {
         assert_eq!(vram_outros(500, 2000), 0); // clamp (sampling skew)
+    }
+
+    #[test]
+    fn vram_outros_equal_values() {
+        assert_eq!(vram_outros(1024, 1024), 0);
+    }
+
+    #[test]
+    fn vram_outros_zero_values() {
+        assert_eq!(vram_outros(0, 0), 0);
+    }
+
+    #[test]
+    fn vram_outros_max_values() {
+        assert_eq!(vram_outros(u64::MAX, u64::MAX), 0);
+        assert_eq!(vram_outros(u64::MAX, 1), u64::MAX - 1);
+        assert_eq!(vram_outros(0, u64::MAX), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Resumo

Expansão da cobertura de testes unitários para a função `vram_outros` do módulo de telemetria em `ramshared-wsl2d`, garantindo a validação adequada dos casos limite (subtração normal, clamp no zero, valores iguais, valores zerados e limites de u64).

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `HEAD` | Adicionou casos de teste para `vram_outros` | Melhorar cobertura e previnir regressões silenciosas nas estatísticas de VRAM | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-wsl2d/src/telemetry.rs`<br>**Validacao:** cargo test --package ramshared-wsl2d<br>**Risco/rollback:** nulo (apenas testes foram tocados)</details> |

## Issue

Closes #000

## Responsavel

@jules

## Labels

type:test
area:wsl2d

## Validacao

- [X] Gates de build/test do escopo tocado
- [ ] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
- [X] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)

## Rollback trigger

Falha repentina nos pipelines de testes unitários em outras ramificações após o merge (falso positivo, N/A - apenas testes independentes).

---
*PR created automatically by Jules for task [4115748381841913183](https://jules.google.com/task/4115748381841913183) started by @emersonbusson*