### PR TITLE
🧪 Add unit tests for swap.rs module

### DIFF
--- a/crates/ramshared-wsl2d/src/swap.rs
+++ b/crates/ramshared-wsl2d/src/swap.rs
@@ -51,3 +51,35 @@ pub fn spawn_swapoff(dev: &str) -> Receiver<bool> {
     });
     rx
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn test_swapoff_bin() {
+        let bin = swapoff_bin();
+        assert!(bin.ends_with("swapoff"));
+    }
+
+    #[test]
+    fn test_swapon_bin() {
+        let bin = swapon_bin();
+        assert!(bin.ends_with("swapon"));
+    }
+
+    #[test]
+    fn test_activate_swap_invalid_dev() {
+        assert!(!activate_swap(
+            "/dev/invalid_device_that_does_not_exist",
+            10
+        ));
+    }
+
+    #[test]
+    fn test_spawn_swapoff_invalid_dev() {
+        let rx = spawn_swapoff("/dev/invalid_device_that_does_not_exist");
+        assert!(!rx.recv().unwrap());
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added a `tests` module for `crates/ramshared-wsl2d/src/swap.rs` to address a missing testing gap.
📊 **Coverage:** Added test coverage for `swapoff_bin()`, `swapon_bin()`, `activate_swap()`, and `spawn_swapoff()`. We safely simulate negative conditions for side-effect-heavy functions by asserting on failure with nonexistent block devices.
✨ **Result:** Enhanced test coverage and ensured path fallback logic works correctly.

## Resumo
Added unit tests to `crates/ramshared-wsl2d/src/swap.rs` to cover the binary resolution logic and ensure process spawning returns correct booleans for invalid devices.

## Commits
- test(wsl2d): add unit tests for swap.rs module

## Issue
N/A

## Responsavel
Agent

## Labels
testing

## Validacao
Ran `cargo test -p ramshared-wsl2d --lib swap` and the full `cargo test` suite locally.

## Rollback trigger
N/A

---
*PR created automatically by Jules for task [6167616726868208486](https://jules.google.com/task/6167616726868208486) started by @emersonbusson*