### PR TITLE
🔒 Fix insecure temporary file creation in psi tests

### DIFF
--- a/crates/ramshared-agent/src/psi.rs
+++ b/crates/ramshared-agent/src/psi.rs
@@ -261,12 +261,18 @@ mod tests {
     fn write_temp_file(content: &str) -> String {
         use std::env;
         use std::fs;
+        use std::io::Write;
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let id = COUNTER.fetch_add(1, Ordering::SeqCst);
         let path = env::temp_dir().join(format!("ramshared_test_{}_{}", std::process::id(), id));
-        fs::write(&path, content).unwrap();
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .unwrap();
+        file.write_all(content.as_bytes()).unwrap();
         path.to_string_lossy().to_string()
     }
 


### PR DESCRIPTION
## Resumo

Este PR corrige uma vulnerabilidade de segurança (CWE-377) no helper de teste `write_temp_file` do crate `ramshared-agent`. O código utilizava `std::fs::write`, que internamente usa `File::create` permitindo sobrescrever arquivos existentes ou seguir links simbólicos. A solução modifica a função para usar `OpenOptions::new().write(true).create_new(true)`, garantindo que o arquivo seja criado do zero e evite ataques de criação previsível através de symlinks (TOCTOU).

🎯 **What:** Vulnerabilidade de segurança CWE-377 mitigada no helper de testes.
⚠️ **Risk:** Um atacante local na mesma máquina que o serviço de testes poderia colocar um symlink e sobrescrever arquivos arbitrários ou dar Denial-of-Service no momento do teste.
🛡️ **Solution:** Utiliza `OpenOptions::new().create_new(true)` para prevenir o seguimento de links simbólicos e obrigar que o arquivo precise ser efetivamente criado novo.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `HEAD` | Substitui `std::fs::write` por `OpenOptions::new().create_new(true)` | Previne symlink attacks durante a criação de test files previsíveis no `/tmp` | <details><summary>detalhes</summary>**Arquivos:** crates/ramshared-agent/src/psi.rs<br>**Validacao:** cargo test e verificação manual da correção de segurança<br>**Risco/rollback:** Baixo. Modificação limitada apenas a test mod.</details> |

## Issue

N/A

## Responsavel

@jules

## Labels

type:security, area:core

## Validacao

- [x] Gates de build/test do escopo tocado
- [x] Rust userspace: cargo fmt --all --check, cargo clippy --workspace -D warnings, cargo test.

## Rollback trigger

Qualquer falha sistemática na CI por causa de `cargo test` no crate `ramshared-agent` devido a falha ao abrir/gravar o arquivo de testes.

---
*PR created automatically by Jules for task [12200476984506483950](https://jules.google.com/task/12200476984506483950) started by @emersonbusson*