### PR TITLE
🔒 Fix path traversal vulnerability in `read_memcg_swap_impl`

### DIFF
--- a/crates/ramshared-agent/src/psi.rs
+++ b/crates/ramshared-agent/src/psi.rs
@@ -90,6 +90,9 @@ pub fn parse_memcg_swap(content: &str) -> Option<u64> {
 fn read_memcg_swap_impl(cgroup_path: &str, sysfs_base: &str) -> Option<u64> {
     let cg = std::fs::read_to_string(cgroup_path).ok()?;
     let path = cg.lines().find_map(|l| l.strip_prefix("0::"))?; // cgroup v2: single line `0::/<path>`
+    if path.contains("..") {
+        return None;
+    }
     let file = format!(
         "{}{}/memory.swap.current",
         sysfs_base,
@@ -340,6 +343,16 @@ mod tests {
     #[test]
     fn read_memcg_swap_impl_missing_0_line() {
         let cgroup_content = "1:name=systemd:/\n";
+        let cgroup_path = write_temp_file(cgroup_content);
+
+        assert!(read_memcg_swap_impl(&cgroup_path, "/sys/fs/cgroup").is_none());
+
+        std::fs::remove_file(cgroup_path).unwrap();
+    }
+
+    #[test]
+    fn read_memcg_swap_impl_path_traversal() {
+        let cgroup_content = "0::/../../../../etc/passwd\n";
         let cgroup_path = write_temp_file(cgroup_content);
 
         assert!(read_memcg_swap_impl(&cgroup_path, "/sys/fs/cgroup").is_none());


### PR DESCRIPTION
## Resumo

Fixes a path traversal vulnerability in the `read_memcg_swap_impl` function within the `ramshared-agent` crate.

## Commits

* Fix path traversal vulnerability in `read_memcg_swap_impl`

## Issue

N/A

## Responsavel

@Jules

## Labels

security, bug

## Validacao

The fix was validated locally with `cargo test` which includes a newly added unit test explicitly asserting that path traversal attempts are rejected.

## Rollback trigger

If there are any issues with parsing valid cgroup configuration files on specific configurations.

---
*PR created automatically by Jules for task [7979722638169798940](https://jules.google.com/task/7979722638169798940) started by @emersonbusson*