### PR TITLE
🧹 [Code Health] Remove unused 'target' field in HostGates

### DIFF
--- a/crates/ramshared-winsvc/src/product_online.rs
+++ b/crates/ramshared-winsvc/src/product_online.rs
@@ -1221,9 +1221,6 @@ struct HostGates {
     volume_letter: char,
     volume_mount_path: Option<std::path::PathBuf>,
     volume_device_path: Option<String>,
-    /// Validated at construction (letter/serial/size shape); kept for diagnostics.
-    #[allow(dead_code)]
-    target: TeardownTarget,
     target_serial: String,
     target_size: u64,
     identity_verified: bool,
@@ -1238,12 +1235,14 @@ impl HostGates {
         serial: &str,
         size_bytes: u64,
     ) -> Result<Self, String> {
+        // Validate target parameters (letter/serial/size shape).
+        let _ = TeardownTarget::new(volume_letter, serial, size_bytes)?;
+
         Ok(Self {
             locked: None,
             volume_letter,
             volume_mount_path,
             volume_device_path: None,
-            target: TeardownTarget::new(volume_letter, serial, size_bytes)?,
             target_serial: serial.to_string(),
             target_size: size_bytes,
             identity_verified: false,


### PR DESCRIPTION
🎯 **What:** Removed the explicitly marked unused `target` field from the `HostGates` struct in `ramshared-winsvc`.
💡 **Why:** To improve code health, simplify the struct definition, and remove dead code. The validation performed by `TeardownTarget::new` in the constructor is preserved.
✅ **Verification:** Ran `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --all-targets` to ensure no functionality is broken and all linters pass.
✨ **Result:** A cleaner and more maintainable `HostGates` struct without unused fields.

## Resumo
Remove unused 'target' field in HostGates.

## Commits
- refactor(winsvc): remove unused `target` field in HostGates

## Issue
N/A

## Responsavel
Agent

## Labels
code-health, refactor

## Validacao
Ran full test suite and clippy checks.

## Rollback trigger
N/A

---
*PR created automatically by Jules for task [15276652101165885367](https://jules.google.com/task/15276652101165885367) started by @emersonbusson*