### PR TITLE
Clean up completed fix comment in Invoke-B1SurpriseRemove

### DIFF
--- a/scripts/windows/Invoke-B1SurpriseRemove.ps1
+++ b/scripts/windows/Invoke-B1SurpriseRemove.ps1
@@ -101,14 +101,10 @@ Start-Sleep $PostWaitSec
 
 $dumpA = Dump-Name
 L "DUMP_AFTER=$dumpA"
-$newDump = ($dumpA -ne "none") -and ($dumpA -ne (Dump-Name)) # fix below
-# re-get before
-$dumpBefore = (Get-Content (Join-Path $ArtifactDir "dump-before.txt") -EA SilentlyContinue)
-if (-not $dumpBefore) { $dumpBefore = $null }
 
 # Store dump before properly at start
 # (re-read from first line we logged is fragile — capture now from variable we should have saved)
-# Fix: we logged DUMP_BEFORE — parse from that
+# We logged DUMP_BEFORE — parse from that
 $beforeLine = ($log | Where-Object { $_ -like "DUMP_BEFORE=*" } | Select-Object -First 1)
 $beforeName = if ($beforeLine) { $beforeLine.Substring("DUMP_BEFORE=".Length) } else { "none" }
 $newDump = ($dumpA -ne $beforeName) -and ($dumpA -ne "none")


### PR DESCRIPTION
The user requested that we address an issue regarding a "Fix:" comment in `scripts/windows/Invoke-B1SurpriseRemove.ps1:111`, noting that it documented a fix that had already been implemented.

This change:
1. Removes the "Fix:" prefix to clean up the documentation and prevent it from appearing as a pending issue.
2. Removes the block of dead code just above it that was superseded by the implemented fix, keeping the script clean.

---
*PR created automatically by Jules for task [16066859679489241341](https://jules.google.com/task/16066859679489241341) started by @emersonbusson*