### PR TITLE
🔒 Fix path traversal in read_memcg_swap_impl

### DIFF
--- a/crates/ramshared-agent/src/psi.rs
+++ b/crates/ramshared-agent/src/psi.rs
@@ -90,11 +90,17 @@ pub fn parse_memcg_swap(content: &str) -> Option<u64> {
 fn read_memcg_swap_impl(cgroup_path: &str, sysfs_base: &str) -> Option<u64> {
     let cg = std::fs::read_to_string(cgroup_path).ok()?;
     let path = cg.lines().find_map(|l| l.strip_prefix("0::"))?; // cgroup v2: single line `0::/<path>`
-    let file = format!(
-        "{}{}/memory.swap.current",
-        sysfs_base,
-        path.trim().trim_end_matches('/')
-    );
+
+    let mut file = std::path::PathBuf::from(sysfs_base);
+    for component in std::path::Path::new(path.trim()).components() {
+        match component {
+            std::path::Component::Normal(c) => file.push(c),
+            std::path::Component::RootDir => {} // Allow leading slash
+            _ => return None,                   // Reject traversal (.., .) and others
+        }
+    }
+    file.push("memory.swap.current");
+
     parse_memcg_swap(&std::fs::read_to_string(file).ok()?)
 }
 
@@ -342,6 +348,17 @@ mod tests {
         let cgroup_content = "1:name=systemd:/\n";
         let cgroup_path = write_temp_file(cgroup_content);
 
+        assert!(read_memcg_swap_impl(&cgroup_path, "/sys/fs/cgroup").is_none());
+
+        std::fs::remove_file(cgroup_path).unwrap();
+    }
+
+    #[test]
+    fn read_memcg_swap_impl_path_traversal() {
+        let cgroup_content = "0::/../../etc/shadow\n";
+        let cgroup_path = write_temp_file(cgroup_content);
+
+        // Path traversal should be rejected and return None
         assert!(read_memcg_swap_impl(&cgroup_path, "/sys/fs/cgroup").is_none());
 
         std::fs::remove_file(cgroup_path).unwrap();


### PR DESCRIPTION
## Resumo

Fixes a path traversal vulnerability in `crates/ramshared-agent/src/psi.rs:331` (CWE-22) where an unchecked string read from the procfs/cgroup was concatenated directly into a file path to access `memory.swap.current`.

🎯 **What:** The `read_memcg_swap_impl` function allowed path traversal when constructing file paths from parsed cgroup outputs.
⚠️ **Risk:** Arbitrary file read access. Malicious actors could theoretically craft a cgroup namespace layout containing `..` sequences to bypass the cgroup root restriction and read any file on the system that the agent has access to.
🛡️ **Solution:** Implemented explicit path sanitization utilizing `std::path::PathBuf` and `Component` iteration, exclusively allowing `Normal` components (safe directory or file names) and `RootDir` (leading slash) to prevent parent (`..`) or current (`.`) directory traversal. A test case was added to ensure path traversal attempts are rejected.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `pending` | Fix path traversal in read_memcg_swap_impl | Prevenir acesso a arquivos arbitrarios mitigando CWE-22 (Path Traversal) na leitura de procfs/cgroup | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-agent/src/psi.rs`<br>**Validacao:** Unit tests (`cargo test`) rodados localmente.<br>**Risco/rollback:** Baixo. Modificacao restrita a string parsing em userspace com teste associado.</details> |

## Issue

N/A

## Responsavel

@jules

## Labels

type:security, area:core, area:agent

## Validacao

- [x] Gates de build/test do escopo tocado
- [ ] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
- [ ] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)

## Rollback trigger

Falhas no parseamento de paths legitimos resultando em falsas rejeicoes (`None` ou logs de `memory.swap.current` indisponivel em maquinas onde o cgroup-v2 swap account esta ativo) numa amostragem > 5% das leituras.

---
*PR created automatically by Jules for task [6968126141698763267](https://jules.google.com/task/6968126141698763267) started by @emersonbusson*