### PR TITLE
🔒 fix: mitigate unchecked file operation on zram0 sysfs device configuration

### DIFF
--- a/crates/ramshared-cli/src/cascade/cascade_io.rs
+++ b/crates/ramshared-cli/src/cascade/cascade_io.rs
@@ -104,15 +104,33 @@ pub(crate) fn setup_zram(mb: u64, prio: i32) -> Result<String, CascadeError> {
 }
 
 pub(crate) fn setup_zram_sysfs(mb: u64, prio: i32) -> Result<(), CascadeError> {
-    let path = PathBuf::from("/sys/block/zram0");
-    if !path.exists() {
+    let raw_path = PathBuf::from("/sys/block/zram0");
+    if !raw_path.exists() {
         return Err(CascadeError::Precondition(
             "/sys/block/zram0 ausente".into(),
         ));
     }
-    let _ = fs::write(path.join("reset"), "1");
+
+    // Path sanitization: ensure canonical resolution prevents traversal/symlink trickery
+    let path = raw_path.canonicalize().map_err(|e| {
+        CascadeError::Precondition(format!("/sys/block/zram0 ausente ou invalido: {e}"))
+    })?;
+
+    if !path.starts_with("/sys/") {
+        return Err(CascadeError::Precondition(
+            "zram0 sysfs path invalido (fora de /sys)".into(),
+        ));
+    }
+
+    let reset_path = path.join("reset");
+    if !reset_path.exists() {
+        return Err(CascadeError::Precondition("reset file ausente".into()));
+    }
+    fs::write(&reset_path, "1").map_err(|e| CascadeError::Io(format!("reset falhou: {e}")))?;
+
     for algo in ZRAM_ALGOS {
-        if fs::write(path.join("comp_algorithm"), algo.as_bytes()).is_ok() {
+        let algo_path = path.join("comp_algorithm");
+        if algo_path.exists() && fs::write(&algo_path, algo.as_bytes()).is_ok() {
             break;
         }
     }


### PR DESCRIPTION
## Resumo

Corrige uma vulnerabilidade de "Unchecked file operation" em `crates/ramshared-cli/src/cascade/cascade_io.rs` na rotina `setup_zram_sysfs`. O código anterior ignorava erros de gravação no arquivo `reset` do zram (usando `let _ = fs::write(...)`) e escrevia sem validar ou higienizar os diretórios. Isso foi consertado através da canonicalização do caminho, verificando a existência dos arquivos (check before file access) e utilizando `.map_err()` apropriadamente para falhar seguro caso os acessos falhem.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `HEAD` | Adiciona canonicalização e checagem do result em `setup_zram_sysfs` | Para corrigir vulnerabilidade classificada como "Unchecked file operation" (CWE-754/CWE-377) e garantir a integridade dos device nodes em `/sys/` | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-cli/src/cascade/cascade_io.rs`<br>**Validacao:** cargo test, cargo check e clippy.<br>**Risco/rollback:** Baixo. Restrito à inicialização do sysfs zram0.</details> |

## Issue

N/A

## Responsavel

@jules

## Labels

type:security
area:cli
area:cascade

## Validacao

- [x] Gates de build/test do escopo tocado
- [ ] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
- [ ] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)

## Rollback trigger

Falha sistêmica durante `ramshared up` relatando erros de "zram0 sysfs path invalido" no start da cascata na versão correta do WSL kernel, impedindo a montagem inicial.

---
*PR created automatically by Jules for task [13506821186948650836](https://jules.google.com/task/13506821186948650836) started by @emersonbusson*