### PR TITLE
🔒 Fix path traversal vulnerability in cgroup path parsing

### DIFF
--- a/crates/ramshared-agent/src/psi.rs
+++ b/crates/ramshared-agent/src/psi.rs
@@ -90,6 +90,9 @@ pub fn parse_memcg_swap(content: &str) -> Option<u64> {
 fn read_memcg_swap_impl(cgroup_path: &str, sysfs_base: &str) -> Option<u64> {
     let cg = std::fs::read_to_string(cgroup_path).ok()?;
     let path = cg.lines().find_map(|l| l.strip_prefix("0::"))?; // cgroup v2: single line `0::/<path>`
+    if path.contains("..") {
+        return None;
+    }
     let file = format!(
         "{}{}/memory.swap.current",
         sysfs_base,
@@ -340,6 +343,16 @@ mod tests {
     #[test]
     fn read_memcg_swap_impl_missing_0_line() {
         let cgroup_content = "1:name=systemd:/\n";
+        let cgroup_path = write_temp_file(cgroup_content);
+
+        assert!(read_memcg_swap_impl(&cgroup_path, "/sys/fs/cgroup").is_none());
+
+        std::fs::remove_file(cgroup_path).unwrap();
+    }
+
+    #[test]
+    fn read_memcg_swap_impl_path_traversal() {
+        let cgroup_content = "0::/../../etc\n";
         let cgroup_path = write_temp_file(cgroup_content);
 
         assert!(read_memcg_swap_impl(&cgroup_path, "/sys/fs/cgroup").is_none());


### PR DESCRIPTION
## Resumo
Fixes a path traversal vulnerability in `read_memcg_swap_impl` where malicious or malformed cgroup paths containing `..` could allow reading arbitrary files by bypassing the base path restriction.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| pending | Adiciona checagem de ".." na leitura do cgroup path | Para previnir path traversal (directory traversal) vulnerabilities | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-agent/src/psi.rs`<br>**Validacao:** Testes unitarios implementados<br>**Risco/rollback:** Baixo risco</details> |

## Issue
Closes #000

## Responsavel
@jules

## Labels
type:security, area:agent

## Validacao
- [x] Gates de build/test do escopo tocado
- [ ] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
- [ ] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)

## Rollback trigger
Se o `read_memcg_swap_impl` retornar None indevidamente causando problemas no parsing do agent no ambiente de producao real (não esperado pois paths legitimos do cgroup kernel v2 em `0::/` não utilizam parent traversal `..`).

---
*PR created automatically by Jules for task [11630932086199008611](https://jules.google.com/task/11630932086199008611) started by @emersonbusson*