### PR TITLE
🔒 Fix CWE-59 Unchecked File Operation in zram setup

### DIFF
--- a/crates/ramshared-cli/src/cascade/cascade_io.rs
+++ b/crates/ramshared-cli/src/cascade/cascade_io.rs
@@ -105,26 +105,43 @@ pub(crate) fn setup_zram(mb: u64, prio: i32) -> Result<String, CascadeError> {
 
 pub(crate) fn setup_zram_sysfs(mb: u64, prio: i32) -> Result<(), CascadeError> {
     let path = PathBuf::from("/sys/block/zram0");
-    if !path.exists() {
+    let canon_path = fs::canonicalize(&path).map_err(|e| {
+        CascadeError::Precondition(format!("/sys/block/zram0 ausente ou inacessivel: {e}"))
+    })?;
+
+    if !canon_path.starts_with("/sys/") {
         return Err(CascadeError::Precondition(
-            "/sys/block/zram0 ausente".into(),
+            "Caminho sysfs do zram escapou do /sys/ (possivel symlink malicioso)".into(),
         ));
     }
-    let _ = fs::write(path.join("reset"), "1");
+
+    let _ = fs::write(canon_path.join("reset"), "1");
     for algo in ZRAM_ALGOS {
-        if fs::write(path.join("comp_algorithm"), algo.as_bytes()).is_ok() {
+        if fs::write(canon_path.join("comp_algorithm"), algo.as_bytes()).is_ok() {
             break;
         }
     }
     let bytes = mb
         .checked_mul(1024 * 1024)
         .ok_or_else(|| CascadeError::Arg("zram size overflow".into()))?;
-    fs::write(path.join("disksize"), bytes.to_string())
+    fs::write(canon_path.join("disksize"), bytes.to_string())
         .map_err(|e| CascadeError::Io(format!("disksize: {e}")))?;
-    sh("mkswap", &["/dev/zram0"])?;
-    sh("swapon", &["-p", &prio.to_string(), "/dev/zram0"])?;
-    fs::write(ZRAM_DEV_FILE, "/dev/zram0").map_err(|e| CascadeError::Io(e.to_string()))?;
-    eprintln!("[up] zram /dev/zram0 via sysfs prio={prio}");
+
+    let dev_path = fs::canonicalize("/dev/zram0").map_err(|e| {
+        CascadeError::Precondition(format!("/dev/zram0 ausente ou inacessivel: {e}"))
+    })?;
+
+    if !dev_path.starts_with("/dev/") {
+        return Err(CascadeError::Precondition(
+            "Caminho do dispositivo zram escapou do /dev/ (possivel symlink malicioso)".into(),
+        ));
+    }
+    let dev_str = dev_path.to_str().unwrap_or("/dev/zram0");
+
+    sh("mkswap", &[dev_str])?;
+    sh("swapon", &["-p", &prio.to_string(), dev_str])?;
+    fs::write(ZRAM_DEV_FILE, dev_str).map_err(|e| CascadeError::Io(e.to_string()))?;
+    eprintln!("[up] zram {dev_str} via sysfs prio={prio}");
     Ok(())
 }
 


### PR DESCRIPTION
## Resumo
Fixes an Unchecked File Operation vulnerability (CWE-59) in `setup_zram_sysfs` where writing to hardcoded paths like `/sys/block/zram0` and using `/dev/zram0` without resolving symlinks or validating directory bounds could result in an Arbitrary File Write or disk wipe via maliciously planted symlinks.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `TBD` | Canonicalizes `/sys/block/zram0` and `/dev/zram0` and adds boundary checks before usage. | Prevents CWE-59 Arbitrary File Write and ensures filesystem boundary constraints are maintained against potential symlink attacks. | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-cli/src/cascade/cascade_io.rs`<br>**Validacao:** Unit tests, e2e tests, cargo clippy, and cargo test.<br>**Risco/rollback:** Low risk. Rollback if `ramshared up` begins rejecting valid sysfs/devfs targets.</details> |

## Issue
Fixes # (Security finding)

## Responsavel
@emersonbusson

## Labels
type:bug area:cli area:security

## Validacao
- [x] Gates de build/test do escopo tocado (`cargo check`, `cargo fmt`, `cargo clippy`, `cargo test`)
- [ ] `./scripts/docs-check.sh` (N/A)
- [ ] SSDV3 (N/A)

## Rollback trigger
Se usuários reportarem falha ao iniciar com `--zram` dizendo que o caminho `escapou do /sys/` ou `/dev/` em ambientes válidos onde `/sys/block/zram0` ou `/dev/zram0` são corretamente montados.

---
*PR created automatically by Jules for task [8526034400999016401](https://jules.google.com/task/8526034400999016401) started by @emersonbusson*