### PR TITLE
🧹 [code health] Use idiomatic underscore prefix for RAII drop guard in UblkFetchRing

### DIFF
--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -257,8 +257,7 @@ pub struct UblkFetchRing {
     /// Data buffers per tag: the `addr` of each FETCH points to its corresponding
     /// buffer, which must remain alive while the command is parked in the kernel.
     /// Never read directly; exists to enforce the lifetime (drop guard).
-    #[allow(dead_code)]
-    buffers: Vec<Vec<u8>>,
+    _buffers: Vec<Vec<u8>>,
 }
 
 impl UblkFetchRing {
@@ -295,7 +294,10 @@ impl UblkFetchRing {
         // Does not block (want=0); the FETCH requests remain parked in the driver.
         ring.submit()?;
 
-        Ok(Self { ring, buffers })
+        Ok(Self {
+            ring,
+            _buffers: buffers,
+        })
     }
 
     /// Drains currently available CQEs without blocking.

--- a/pr_desc.md
+++ b/pr_desc.md
@@ -1,0 +1,20 @@
+## Resumo
+Refactored the `UblkFetchRing` struct in `ramshared-uring` to address a code health issue where an structurally-required `buffers` field used an `allow(dead_code)` attribute instead of the idiomatic `_` naming convention.
+
+## Commits
+* Remove allow(dead_code) in UblkFetchRing by using idiomatic underscore prefix
+
+## Issue
+Code Health Improvement Task
+
+## Responsavel
+Agent
+
+## Labels
+enhancement, refactor
+
+## Validacao
+Ran `cargo clippy --all` and `cargo test --all` to verify standard checks pass cleanly without regressions.
+
+## Rollback trigger
+Any compilation issues or regressions in ublk IO testing/fetching.


### PR DESCRIPTION
🎯 **What:** Removed the `#[allow(dead_code)]` attribute from the `buffers` field in `UblkFetchRing` and renamed it to `_buffers`.
💡 **Why:** The field is structurally necessary for drop-guard lifetime enforcement while parking commands in the kernel, so removing it entirely would cause safety issues. Using an underscore prefix is the idiomatic Rust way to signal an intentionally unread variable/field, cleanly avoiding the dead code warning without requiring macro-level suppression.
✅ **Verification:** Verified locally via `git diff` that no behavior changes occurred. Executed `cargo fmt --all`, `cargo clippy --all`, and `cargo test --all` to ensure no compile errors or formatting violations were introduced, and all current tests pass. 
✨ **Result:** A cleaner implementation that relies on standard language conventions over procedural macros for dead code warnings.

## Resumo
Refactored the `UblkFetchRing` struct in `ramshared-uring` to address a code health issue where an structurally-required `buffers` field used an `allow(dead_code)` attribute instead of the idiomatic `_` naming convention.

## Commits
* Remove allow(dead_code) in UblkFetchRing by using idiomatic underscore prefix

## Issue
Code Health Improvement Task

## Responsavel
Agent

## Labels
enhancement, refactor

## Validacao
Ran `cargo clippy --all` and `cargo test --all` to verify standard checks pass cleanly without regressions. 

## Rollback trigger
Any compilation issues or regressions in ublk IO testing/fetching.

---
*PR created automatically by Jules for task [2455654535228653985](https://jules.google.com/task/2455654535228653985) started by @emersonbusson*