### PR TITLE
🔒 Fix path traversal vulnerability in `ramshared-agent` cgroup reading

### DIFF
--- a/crates/ramshared-agent/src/psi.rs
+++ b/crates/ramshared-agent/src/psi.rs
@@ -90,11 +90,19 @@ pub fn parse_memcg_swap(content: &str) -> Option<u64> {
 fn read_memcg_swap_impl(cgroup_path: &str, sysfs_base: &str) -> Option<u64> {
     let cg = std::fs::read_to_string(cgroup_path).ok()?;
     let path = cg.lines().find_map(|l| l.strip_prefix("0::"))?; // cgroup v2: single line `0::/<path>`
-    let file = format!(
-        "{}{}/memory.swap.current",
-        sysfs_base,
-        path.trim().trim_end_matches('/')
-    );
+
+    let rel_path = path.trim().trim_matches('/');
+    if std::path::Path::new(rel_path)
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return None;
+    }
+
+    let file = std::path::Path::new(sysfs_base)
+        .join(rel_path)
+        .join("memory.swap.current");
+
     parse_memcg_swap(&std::fs::read_to_string(file).ok()?)
 }
 
@@ -340,6 +348,16 @@ mod tests {
     #[test]
     fn read_memcg_swap_impl_missing_0_line() {
         let cgroup_content = "1:name=systemd:/\n";
+        let cgroup_path = write_temp_file(cgroup_content);
+
+        assert!(read_memcg_swap_impl(&cgroup_path, "/sys/fs/cgroup").is_none());
+
+        std::fs::remove_file(cgroup_path).unwrap();
+    }
+
+    #[test]
+    fn read_memcg_swap_impl_traversal_attack() {
+        let cgroup_content = "0::/../../../../etc/shadow\n";
         let cgroup_path = write_temp_file(cgroup_content);
 
         assert!(read_memcg_swap_impl(&cgroup_path, "/sys/fs/cgroup").is_none());


### PR DESCRIPTION
## Resumo
Fixes a path traversal security vulnerability in `ramshared-agent`'s `read_memcg_swap_impl`.

## Commits
- fix(agent): mitigate path traversal in cgroup file read

## Issue
None

## Responsavel
Agent

## Labels
security, bug

## Validacao
- Added test case `read_memcg_swap_impl_traversal_attack`.
- Verified `cargo test` passes.
- Confirmed trailing/leading slashes are properly handled, and `..` components are correctly identified by the stdlib's `Path` components.

## Rollback trigger
Any issue reading cgroup metrics.

---
*PR created automatically by Jules for task [5033396169134746785](https://jules.google.com/task/5033396169134746785) started by @emersonbusson*