### PR TITLE
🔒 Fix potential command injection in read_kernel_config

### DIFF
--- a/crates/ramshared-cli/src/main.rs
+++ b/crates/ramshared-cli/src/main.rs
@@ -349,7 +349,7 @@ fn read_kernel_config(release: &str) -> (Option<String>, Option<String>) {
 
     let proc_config = Path::new("/proc/config.gz");
     if proc_config.exists() {
-        match Command::new("zcat").arg(proc_config).output() {
+        match Command::new("zcat").arg("--").arg(proc_config).output() {
             Ok(output) if output.status.success() => {
                 let text = String::from_utf8_lossy(&output.stdout).into_owned();
                 return (Some("/proc/config.gz".to_string()), Some(text));


### PR DESCRIPTION
🎯 **What:** Adding end-of-options delimiter (`--`) to `zcat` invocation in `crates/ramshared-cli/src/main.rs`.
⚠️ **Risk:** Prevents potential argument injection vulnerabilities if paths starting with `-` were somehow passed as arguments to the command (or modified to be dynamic in the future).
🛡️ **Solution:** Used `--` before passing file paths to `Command::new`, preventing the external process from parsing subsequent arguments as flags.

## Resumo

Adiciona o delimitador `--` na invocação do `zcat` em `read_kernel_config` para prevenir potencial argument/flag injection.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `HEAD` | Previne command injection no CLI | Segurança de execução de comandos (zcat) | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-cli/src/main.rs`<br>**Validacao:** cargo test / clippy<br>**Risco/rollback:** Baixo risco. Reverter se zcat falhar com --.</details> |

## Issue

Closes #security

## Responsavel

@jules

## Labels

type:security, area:cli

## Validacao

- [x] Gates de build/test do escopo tocado
- [x] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
- [x] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)

## Rollback trigger

Falha generalizada de CLI ao rodar testes de integração ou zcat ignorando o argumento `--` em distribuições muito antigas causando erro contínuo.

---
*PR created automatically by Jules for task [16066859679489243816](https://jules.google.com/task/16066859679489243816) started by @emersonbusson*