### PR TITLE
🔒 Security Fix: Address unchecked file operation (Path Traversal)

### DIFF
--- a/crates/ramshared-agent/src/psi.rs
+++ b/crates/ramshared-agent/src/psi.rs
@@ -90,6 +90,9 @@ pub fn parse_memcg_swap(content: &str) -> Option<u64> {
 fn read_memcg_swap_impl(cgroup_path: &str, sysfs_base: &str) -> Option<u64> {
     let cg = std::fs::read_to_string(cgroup_path).ok()?;
     let path = cg.lines().find_map(|l| l.strip_prefix("0::"))?; // cgroup v2: single line `0::/<path>`
+    if path.contains("..") {
+        return None;
+    }
     let file = format!(
         "{}{}/memory.swap.current",
         sysfs_base,
@@ -270,6 +273,19 @@ mod tests {
         path.to_string_lossy().to_string()
     }
 
+    fn safe_remove_file(path: impl AsRef<std::path::Path>) {
+        let p = path.as_ref();
+        let p_str = p.to_string_lossy();
+        assert!(!p_str.contains(".."), "Path contains '..': {}", p_str);
+        assert!(!p_str.contains('\0'), "Path contains null byte: {}", p_str);
+        assert!(
+            p.starts_with(std::env::temp_dir()),
+            "Path is not in temp dir: {}",
+            p_str
+        );
+        std::fs::remove_file(p).unwrap();
+    }
+
     #[test]
     fn read_psi_impl_success() {
         let content = "some avg10=1.23 avg60=4.56 avg300=7.89 total=999\n";
@@ -278,7 +294,7 @@ mod tests {
         assert_eq!(psi.avg10, 1.23);
         assert_eq!(psi.avg60, 4.56);
         assert_eq!(psi.stall_us, 999);
-        std::fs::remove_file(path).unwrap();
+        safe_remove_file(path);
     }
 
     #[test]
@@ -291,7 +307,7 @@ mod tests {
         let path = write_temp_file("invalid content\n");
         let err = read_psi_impl(&path).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::InvalidData);
-        std::fs::remove_file(path).unwrap();
+        safe_remove_file(path);
     }
 
     #[test]
@@ -302,7 +318,7 @@ mod tests {
         let swaps = read_swaps_impl(&path).unwrap();
         assert_eq!(swaps.len(), 1);
         assert_eq!(swaps[0].dev, "/dev/nbd0");
-        std::fs::remove_file(path).unwrap();
+        safe_remove_file(path);
     }
 
     #[test]
@@ -328,7 +344,7 @@ mod tests {
         let val = read_memcg_swap_impl(&cgroup_path, &sysfs_base.to_string_lossy()).unwrap();
         assert_eq!(val, 4194304);
 
-        std::fs::remove_file(cgroup_path).unwrap();
+        safe_remove_file(cgroup_path);
         std::fs::remove_dir_all(sysfs_base).unwrap();
     }
 
@@ -344,7 +360,7 @@ mod tests {
 
         assert!(read_memcg_swap_impl(&cgroup_path, "/sys/fs/cgroup").is_none());
 
-        std::fs::remove_file(cgroup_path).unwrap();
+        safe_remove_file(cgroup_path);
     }
 
     #[test]
@@ -354,7 +370,7 @@ mod tests {
 
         assert_eq!(read_diskstats_impl(&path, "nbd0"), Some((200 + 80) * 512));
 
-        std::fs::remove_file(path).unwrap();
+        safe_remove_file(path);
     }
 
     #[test]
@@ -369,7 +385,7 @@ mod tests {
 
         assert_eq!(read_euid_impl(&path).unwrap(), 1001);
 
-        std::fs::remove_file(path).unwrap();
+        safe_remove_file(path);
     }
 
     #[test]
@@ -385,6 +401,6 @@ mod tests {
         let err = read_euid_impl(&path).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::InvalidData);
 
-        std::fs::remove_file(path).unwrap();
+        safe_remove_file(path);
     }
 }


### PR DESCRIPTION
## Resumo
Mitigates an unchecked file operation / path traversal vulnerability flagged in `crates/ramshared-agent/src/psi.rs:281`. Tests using raw `std::fs::remove_file` directly with predictable paths were converted to use a new `safe_remove_file` utility which enforces bounds checks against `..` components and null bytes (`\0`). Furthermore, proactive bounds-checking was added to `read_memcg_swap_impl` to prevent directory traversal vectors from being introduced via cgroup file content.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `pending` | Add path traversal sanitization to `psi.rs` operations. | Prevent path traversal risks in tests and `read_memcg_swap_impl` when parsing system files | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-agent/src/psi.rs`<br>**Validacao:** Cargo format, clippy tests and `cargo test --package ramshared-agent`<br>**Risco/rollback:** Low, strictly validates temporary testing directories and filters bad components</details> |

## Issue
Fixes Security Vulnerability

## Responsavel
@jules

## Labels
type:security, area:core

## Validacao
- [x] Gates de build/test do escopo tocado (cargo test/clippy)
- [ ] `./scripts/docs-check.sh`
- [ ] SSDV3

## Rollback trigger
Any unrecoverable file I/O panics during tests in CI or failure to read `memory.swap.current` properly in production setups.

---
*PR created automatically by Jules for task [2556183274613292166](https://jules.google.com/task/2556183274613292166) started by @emersonbusson*