### PR TITLE
🔒 Fix symlink traversal (TOCTOU) vulnerability in arm_forensics

### DIFF
--- a/crates/ramshared-cli/src/cascade/cascade_io.rs
+++ b/crates/ramshared-cli/src/cascade/cascade_io.rs
@@ -20,9 +20,18 @@ pub(crate) fn arm_forensics() {
         if let Some(parent) = Path::new(path).parent() {
             let _ = fs::create_dir_all(parent);
         }
-        if fs::write(path, &payload).is_ok() {
-            eprintln!("[up] forensics armed: {path}");
-            return;
+
+        let _ = fs::remove_file(path);
+        if let Ok(mut f) = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+        {
+            use std::io::Write;
+            if f.write_all(payload.as_bytes()).is_ok() {
+                eprintln!("[up] forensics armed: {path}");
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
## Resumo
Correção de vulnerabilidade de gravação insegura de arquivo (TOCTOU/Symlink attack) em `arm_forensics`. O processo root agora recria o arquivo atomicamente sem seguir possíveis symlinks injetados por usuários sem privilégios em `/mnt/c/wsl-forensics/`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `TBD` | Corrigiu gravação insegura | Para mitigar vulnerabilidade de escalonamento de privilégios ou sobrescrita arbitrária via symlink attack | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-cli/src/cascade/cascade_io.rs`<br>**Validacao:** Testado localmente, pass clippy/fmt/tests.<br>**Risco/rollback:** Baixo. Rollback se erro de I/O em pastas read-only causar panics de daemon setup.</details> |

## Issue
Fixes # (nenhuma issue vinculada previamente)

## Responsavel
@jules

## Labels
type:security
area:cli

## Validacao
- [x] Gates de build/test do escopo tocado
- [ ] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
- [ ] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)

## Rollback trigger
Falha contínua do `ramshared up` (erro no I/O ao rearmar forensics, negando a execução do cascade).

---
*PR created automatically by Jules for task [5609409387643274695](https://jules.google.com/task/5609409387643274695) started by @emersonbusson*