### PR TITLE
🔒 Fix unchecked file operations in ramshared-cli

### DIFF
--- a/crates/ramshared-cli/src/cascade/cascade_io.rs
+++ b/crates/ramshared-cli/src/cascade/cascade_io.rs
@@ -27,9 +27,20 @@ pub(crate) fn arm_forensics() {
     }
 }
 
+pub(crate) fn safe_remove_file(path: &str) {
+    let p = Path::new(path);
+    match fs::remove_file(p) {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            eprintln!("[warn] falha ao remover arquivo {}: {}", path, e);
+        }
+    }
+}
+
 pub(crate) fn disarm_forensics() {
     for path in ARMED_MARKER_CANDIDATES {
-        let _ = fs::remove_file(path);
+        safe_remove_file(path);
     }
 }
 
@@ -45,7 +56,7 @@ pub(crate) fn stop_daemon_gracefully() {
     // Wait up to 10s for voluntary exit (allows VRAM zero()).
     for _ in 0..100 {
         if sh("pgrep", &["-x", "ramsharedd"]).is_err() {
-            let _ = fs::remove_file(PID_FILE);
+            safe_remove_file(PID_FILE);
             return;
         }
         sleep(Duration::from_millis(100));
@@ -61,7 +72,7 @@ pub(crate) fn stop_daemon_gracefully() {
     eprintln!("[down] daemon nao saiu em 10s; pkill -TERM (sem -9)");
     let _ = sh("pkill", &["-x", "ramsharedd"]);
     sleep(Duration::from_millis(500));
-    let _ = fs::remove_file(PID_FILE);
+    safe_remove_file(PID_FILE);
 }
 
 pub(crate) fn setup_zram(mb: u64, prio: i32) -> Result<String, CascadeError> {
@@ -169,7 +180,7 @@ fn check_safety_net(vram_mb: u64, force: bool, prios: &TierPriorities) -> Result
 }
 
 fn spawn_daemon(daemon_path: &str, vram_mb: u64, swap_dev: &str) -> Result<(), CascadeError> {
-    let _ = fs::remove_file(SOCK);
+    safe_remove_file(SOCK);
     let child = Command::new(daemon_path)
         .args([
             "--size",
@@ -361,10 +372,10 @@ pub fn down() -> Result<(), CascadeError> {
     // 4) Daemon stop — only if no block VRAM swap remains
     stop_daemon_gracefully();
 
-    let _ = fs::remove_file(SOCK);
-    let _ = fs::remove_file(ZRAM_DEV_FILE);
-    let _ = fs::remove_file(SWAP_DEV_FILE);
-    let _ = fs::remove_file(PID_FILE);
+    safe_remove_file(SOCK);
+    safe_remove_file(ZRAM_DEV_FILE);
+    safe_remove_file(SWAP_DEV_FILE);
+    safe_remove_file(PID_FILE);
     disarm_forensics();
     eprintln!("[down] cascata desmontada (swapoff-first, sem kill -9)");
     status(false)

--- a/crates/ramshared-cli/src/cascade/mod.rs
+++ b/crates/ramshared-cli/src/cascade/mod.rs
@@ -486,11 +486,11 @@ fn plan_orphan_action(entries: &[SwapEntry], cascade_healthy: bool) -> OrphanPla
 }
 
 fn clear_run_ramshared_state() {
-    let _ = fs::remove_file(SOCK);
-    let _ = fs::remove_file(ZRAM_DEV_FILE);
-    let _ = fs::remove_file(SWAP_DEV_FILE);
-    let _ = fs::remove_file(PID_FILE);
-    let _ = fs::remove_file("/run/ramshared/.armed");
+    cascade_io::safe_remove_file(SOCK);
+    cascade_io::safe_remove_file(ZRAM_DEV_FILE);
+    cascade_io::safe_remove_file(SWAP_DEV_FILE);
+    cascade_io::safe_remove_file(PID_FILE);
+    cascade_io::safe_remove_file("/run/ramshared/.armed");
 }
 
 /// Auto-heal zero-used managed orphans (WSL terminate class). Single pass.


### PR DESCRIPTION
## Resumo
Fix the security vulnerability regarding unchecked file operations when removing state files in `ramshared-cli` during `ramshared down`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| Fix unchecked remove_file operations in cascade_io | Added `safe_remove_file` to handle removal results safely | To prevent silent errors and mitigate TOCTOU vulnerabilities by directly handling the `Result` of `fs::remove_file` | <details>Replaced usages of `let _ = fs::remove_file(...)` with `safe_remove_file(...)` across `cascade_io.rs` and `cascade/mod.rs` to handle `ErrorKind::NotFound` specifically instead of ignoring all errors.</details> |

## Issue
Fixes # (replace with actual issue number if applicable)

## Responsavel
Agent

## Labels
security, bug

## Validacao
Ran `cargo test --workspace` to ensure no functionality is broken, and used `cargo check -p ramshared-cli` to guarantee correctness.

## Rollback trigger
Any disruptions in the cascade daemon stop sequence.

---

### 🎯 What
Fixed a security vulnerability regarding unchecked file operations when deleting temporary PID, SOCK, and DEV files during cascade teardown.

### ⚠️ Risk
If the file removal fails due to permissions, file locking, or other system errors, ignoring the result (via `let _ =`) will leave dangling artifacts. These unhandled scenarios can lead to resource leaks, misbehavior on subsequent `up` commands, and denial of service or hang states (like WSL hangs referenced in the prompt).

### 🛡️ Solution
Introduced a `safe_remove_file` helper function that attempts the file removal natively and explicitly matches on the `Result`. It suppresses `ErrorKind::NotFound` (as it acts as an idempotent operation) but properly logs to stderr if a meaningful error occurs. This avoids the Time-Of-Check to Time-Of-Use (TOCTOU) problem inherent in `if p.exists() { remove() }` check patterns.

---
*PR created automatically by Jules for task [7804859191270706088](https://jules.google.com/task/7804859191270706088) started by @emersonbusson*