### PR TITLE
🔒 fix(agent): secure file deletion in test module

### DIFF
--- a/crates/ramshared-agent/src/psi.rs
+++ b/crates/ramshared-agent/src/psi.rs
@@ -258,6 +258,36 @@ mod tests {
         assert!(parse_euid("Name:\tx\nGid:\t0\t0\t0\t0\n").is_none());
     }
 
+    fn safe_remove_file<P: AsRef<std::path::Path>>(path: P) {
+        let p = path.as_ref();
+        let tmp = std::fs::canonicalize(std::env::temp_dir()).unwrap();
+        if let Ok(canon) = std::fs::canonicalize(p) {
+            if canon.starts_with(&tmp) {
+                std::fs::remove_file(canon).unwrap();
+            } else {
+                panic!(
+                    "Security violation: attempt to remove file outside of temp_dir: {:?}",
+                    p
+                );
+            }
+        }
+    }
+
+    fn safe_remove_dir_all<P: AsRef<std::path::Path>>(path: P) {
+        let p = path.as_ref();
+        let tmp = std::fs::canonicalize(std::env::temp_dir()).unwrap();
+        if let Ok(canon) = std::fs::canonicalize(p) {
+            if canon.starts_with(&tmp) {
+                std::fs::remove_dir_all(canon).unwrap();
+            } else {
+                panic!(
+                    "Security violation: attempt to remove dir outside of temp_dir: {:?}",
+                    p
+                );
+            }
+        }
+    }
+
     fn write_temp_file(content: &str) -> String {
         use std::env;
         use std::fs;
@@ -278,7 +308,7 @@ mod tests {
         assert_eq!(psi.avg10, 1.23);
         assert_eq!(psi.avg60, 4.56);
         assert_eq!(psi.stall_us, 999);
-        std::fs::remove_file(path).unwrap();
+        safe_remove_file(path);
     }
 
     #[test]
@@ -291,7 +321,7 @@ mod tests {
         let path = write_temp_file("invalid content\n");
         let err = read_psi_impl(&path).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::InvalidData);
-        std::fs::remove_file(path).unwrap();
+        safe_remove_file(path);
     }
 
     #[test]
@@ -302,7 +332,7 @@ mod tests {
         let swaps = read_swaps_impl(&path).unwrap();
         assert_eq!(swaps.len(), 1);
         assert_eq!(swaps[0].dev, "/dev/nbd0");
-        std::fs::remove_file(path).unwrap();
+        safe_remove_file(path);
     }
 
     #[test]
@@ -328,8 +358,8 @@ mod tests {
         let val = read_memcg_swap_impl(&cgroup_path, &sysfs_base.to_string_lossy()).unwrap();
         assert_eq!(val, 4194304);
 
-        std::fs::remove_file(cgroup_path).unwrap();
-        std::fs::remove_dir_all(sysfs_base).unwrap();
+        safe_remove_file(cgroup_path);
+        safe_remove_dir_all(sysfs_base);
     }
 
     #[test]
@@ -344,7 +374,7 @@ mod tests {
 
         assert!(read_memcg_swap_impl(&cgroup_path, "/sys/fs/cgroup").is_none());
 
-        std::fs::remove_file(cgroup_path).unwrap();
+        safe_remove_file(cgroup_path);
     }
 
     #[test]
@@ -354,7 +384,7 @@ mod tests {
 
         assert_eq!(read_diskstats_impl(&path, "nbd0"), Some((200 + 80) * 512));
 
-        std::fs::remove_file(path).unwrap();
+        safe_remove_file(path);
     }
 
     #[test]
@@ -369,7 +399,7 @@ mod tests {
 
         assert_eq!(read_euid_impl(&path).unwrap(), 1001);
 
-        std::fs::remove_file(path).unwrap();
+        safe_remove_file(path);
     }
 
     #[test]
@@ -385,6 +415,6 @@ mod tests {
         let err = read_euid_impl(&path).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::InvalidData);
 
-        std::fs::remove_file(path).unwrap();
+        safe_remove_file(path);
     }
 }


### PR DESCRIPTION
## Resumo

Fixes a security vulnerability (unchecked file operation) in the test module of `ramshared-agent` (`psi.rs`). Temporary test files were being deleted with raw `std::fs::remove_file` calls without ensuring the files were bounded to the temporary directory. The patch introduces `safe_remove_file` and `safe_remove_dir_all` to canonicalize paths and safely verify boundaries before OS deletion.

🎯 **What:** The vulnerability fixed is an unchecked file operation in the testing module (raw `std::fs::remove_file(path)` where `path` was constructed dynamically).
⚠️ **Risk:** While this is test cleanup code, if an external path or symlink vulnerability (e.g., path traversal) were introduced in test execution parameters, this could result in unintended arbitrary file/directory deletion.
🛡️ **Solution:** Implemented `safe_remove_file` and `safe_remove_dir_all` functions that enforce `path.canonicalize().unwrap().starts_with(&tmp.canonicalize().unwrap())` before executing the actual file removal, providing robust directory bounding and mitigating traversal/symlink tricks.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| (current) | Adicionou sanitização segura de exclusão de arquivo nos testes do ramshared-agent | Prevenir vulnerabilidades de exclusão não verificada no uso de `fs::remove_file` em caminhos gerados dinamicamente nos testes | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-agent/src/psi.rs`<br>**Validacao:** Testes unitários do crate ramshared-agent em `mod tests`<br>**Risco/rollback:** Risco zero, mudanças restritas apenas ao namespace dos testes (`#[cfg(test)] mod tests`).</details> |

## Issue

Closes #N/A

## Responsavel

@jules

## Labels

type:security, area:agent

## Validacao

- [x] Gates de build/test do escopo tocado
- [ ] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
- [ ] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)

## Rollback trigger

Falhas no CI pipeline relacionadas à exclusão de arquivos ou quebra nos testes que envolvam as rotinas `safe_remove_file` por problemas de permissão na árvore temporária do host runner.

---
*PR created automatically by Jules for task [591336580829499411](https://jules.google.com/task/591336580829499411) started by @emersonbusson*