### PR TITLE
🧹 [code health improvement] Refactor UblkFetchRing and UblkServer to use OwnedFd

### DIFF
--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -254,6 +254,9 @@ pub struct UblkCompletion {
 /// I/O is ready or aborted). It owns the data buffers while FETCH calls are pending.
 pub struct UblkFetchRing {
     ring: IoUring<squeue::Entry128>,
+    /// The char device file descriptor, kept open for the lifetime of this ring.
+    #[allow(dead_code)]
+    fd: std::os::fd::OwnedFd,
     /// Data buffers per tag: the `addr` of each FETCH points to its corresponding
     /// buffer, which must remain alive while the command is parked in the kernel.
     /// Never read directly; exists to enforce the lifetime (drop guard).
@@ -265,7 +268,11 @@ impl UblkFetchRing {
     /// Submits `FETCH_REQ` for tags in `[0, queue_depth)` of queue 0 on `fd`, each using
     /// a buffer of `buf_size` bytes. Does not wait for CQE (`submit()` with want=0).
     /// The `fd` must remain open for the lifetime of this ring.
-    pub fn submit_fetch_all(fd: RawFd, queue_depth: u16, buf_size: usize) -> io::Result<Self> {
+    pub fn submit_fetch_all(
+        fd: std::os::fd::OwnedFd,
+        queue_depth: u16,
+        buf_size: usize,
+    ) -> io::Result<Self> {
         const UBLK_U_IO_FETCH_REQ: u32 = 0xc010_7520;
         const QUEUE_ID_ZERO: u16 = 0;
 
@@ -276,10 +283,13 @@ impl UblkFetchRing {
         for tag in 0..queue_depth {
             let addr = buffers[usize::from(tag)].as_mut_ptr() as u64;
             let cmd = fetch_cmd80(QUEUE_ID_ZERO, tag, addr);
-            let entry = opcode::UringCmd80::new(types::Fd(fd), UBLK_U_IO_FETCH_REQ)
-                .cmd(cmd)
-                .build()
-                .user_data(u64::from(tag));
+            let entry = opcode::UringCmd80::new(
+                types::Fd(std::os::fd::AsRawFd::as_raw_fd(&fd)),
+                UBLK_U_IO_FETCH_REQ,
+            )
+            .cmd(cmd)
+            .build()
+            .user_data(u64::from(tag));
 
             // SAFETY: `cmd` (including `addr`) is copied into the SQE during `push`.
             // The `addr` points to `buffers[tag]`, which remains valid inside this struct
@@ -295,7 +305,7 @@ impl UblkFetchRing {
         // Does not block (want=0); the FETCH requests remain parked in the driver.
         ring.submit()?;
 
-        Ok(Self { ring, buffers })
+        Ok(Self { ring, buffers, fd })
     }
 
     /// Drains currently available CQEs without blocking.
@@ -332,7 +342,7 @@ fn fetch_cmd80(q_id: u16, tag: u16, addr: u64) -> [u8; 80] {
 /// `COMMIT_AND_FETCH_REQ`. The `fd` of the char device must remain open for the
 /// lifetime of the server.
 pub struct UblkServer {
-    fd: RawFd,
+    fd: std::os::fd::OwnedFd,
     ring: IoUring<squeue::Entry128>,
     iodesc: MmapRo,
     buffers: Vec<Vec<u8>>,
@@ -344,11 +354,11 @@ impl UblkServer {
     const IO_DESC_SIZE: usize = 24;
 
     /// Creates the ring and maps the io-desc buffer for queue 0; does NOT submit FETCH commands.
-    pub fn new(fd: RawFd, queue_depth: u16, buf_size: usize) -> io::Result<Self> {
+    pub fn new(fd: std::os::fd::OwnedFd, queue_depth: u16, buf_size: usize) -> io::Result<Self> {
         let entries = u32::from(queue_depth).max(1).next_power_of_two();
         let ring = IoUring::<squeue::Entry128>::builder().build(entries)?;
         let iodesc_len = round_up_to_page(usize::from(queue_depth) * Self::IO_DESC_SIZE);
-        let iodesc = MmapRo::map_readonly(fd, iodesc_len, 0)?;
+        let iodesc = MmapRo::map_readonly(std::os::fd::AsRawFd::as_raw_fd(&fd), iodesc_len, 0)?;
         let buffers = (0..queue_depth).map(|_| vec![0u8; buf_size]).collect();
         Ok(Self {
             fd,
@@ -421,10 +431,11 @@ impl UblkServer {
 
     fn push(&mut self, cmd_op: u32, tag: u16, result: i32, addr: u64) -> io::Result<()> {
         let cmd = io_cmd80(0, tag, result, addr);
-        let entry = opcode::UringCmd80::new(types::Fd(self.fd), cmd_op)
-            .cmd(cmd)
-            .build()
-            .user_data(u64::from(tag));
+        let entry =
+            opcode::UringCmd80::new(types::Fd(std::os::fd::AsRawFd::as_raw_fd(&self.fd)), cmd_op)
+                .cmd(cmd)
+                .build()
+                .user_data(u64::from(tag));
 
         // SAFETY: `cmd` (carrying `addr`) is copied into the SQE in `push`. `addr` points
         // to `self.buffers[tag]`, which remains valid for the server's lifetime; `self.fd`

--- a/crates/ramshared-wsl2d/src/ublk_queue.rs
+++ b/crates/ramshared-wsl2d/src/ublk_queue.rs
@@ -4,7 +4,7 @@
 //! descriptors by tag. Does not call `START_DEV`, does not create `/dev/ublkbN`, and does not touch
 //! swap. The `unsafe` of `mmap` is isolated in `ramshared-uring`.
 
-use std::fs::{File, OpenOptions};
+use std::fs::OpenOptions;
 use std::io;
 use std::os::fd::AsRawFd;
 use std::path::Path;
@@ -51,9 +51,6 @@ pub fn read_io_desc(
 /// must remain open while the ring exists).
 pub struct FetchSession {
     ring: ramshared_uring::UblkFetchRing,
-    /// Char device `File`, kept open while the ring lives (drop guard).
-    #[allow(dead_code)]
-    char_dev: File,
 }
 
 impl FetchSession {
@@ -66,12 +63,12 @@ impl FetchSession {
     ) -> io::Result<Self> {
         let char_dev = OpenOptions::new().read(true).write(true).open(char_path)?;
         let ring = ramshared_uring::UblkFetchRing::submit_fetch_all(
-            char_dev.as_raw_fd(),
+            char_dev.into(),
             queue_depth,
             buf_size,
         )?;
 
-        Ok(Self { ring, char_dev })
+        Ok(Self { ring })
     }
 
     /// Drains available CQEs (does not block).

--- a/crates/ramshared-wsl2d/src/ublk_server.rs
+++ b/crates/ramshared-wsl2d/src/ublk_server.rs
@@ -7,7 +7,6 @@
 
 use std::fs::OpenOptions;
 use std::io;
-use std::os::fd::AsRawFd;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -88,13 +87,9 @@ pub fn spawn_server(
     backend: RamBackend,
 ) -> io::Result<ServerHandle> {
     let char_dev = OpenOptions::new().read(true).write(true).open(char_path)?;
-    let server = ramshared_uring::UblkServer::new(char_dev.as_raw_fd(), queue_depth, buf_size)?;
+    let server = ramshared_uring::UblkServer::new(char_dev.into(), queue_depth, buf_size)?;
 
-    let thread = thread::spawn(move || {
-        // Keeps the char device open while the loop uses the ring (dropped after).
-        let _char_dev = char_dev;
-        run_server_loop(server, backend)
-    });
+    let thread = thread::spawn(move || run_server_loop(server, backend));
 
     Ok(ServerHandle { thread })
 }
@@ -232,16 +227,14 @@ pub fn spawn_server_dt3<B: BlockBackend + Send + 'static>(
     backend: B,
 ) -> io::Result<ServerHandleDt3<B>> {
     let char_dev = OpenOptions::new().read(true).write(true).open(char_path)?;
-    let server = ramshared_uring::UblkServer::new(char_dev.as_raw_fd(), queue_depth, buf_size)?;
+    let server = ramshared_uring::UblkServer::new(char_dev.into(), queue_depth, buf_size)?;
 
     let (work_tx, work_rx) = mpsc::sync_channel::<ublk::IoWork>(RING_CHAN_CAP);
     let (reply_tx, reply_rx) = mpsc::channel::<WorkerReply>();
     let worker = spawn_ublk_worker(backend, work_rx, reply_tx);
 
     let ring = thread::spawn(move || {
-        // The char device remains open while the ring lives; `work_tx` drops upon returning
-        // (terminates the worker).
-        let _char_dev = char_dev;
+        // `work_tx` drops upon returning (terminates the worker).
         run_ring_owner(server, queue_depth, buf_size, work_tx, reply_rx)
     });
 
@@ -407,7 +400,7 @@ pub fn spawn_server_dt3_vram(
     block_size: u32,
 ) -> io::Result<ServerHandleDt3Vram> {
     let char_dev = OpenOptions::new().read(true).write(true).open(char_path)?;
-    let server = ramshared_uring::UblkServer::new(char_dev.as_raw_fd(), queue_depth, buf_size)?;
+    let server = ramshared_uring::UblkServer::new(char_dev.into(), queue_depth, buf_size)?;
 
     let (work_tx, work_rx) = mpsc::sync_channel::<ublk::IoWork>(RING_CHAN_CAP);
     let (reply_tx, reply_rx) = mpsc::channel::<WorkerReply>();
@@ -424,10 +417,8 @@ pub fn spawn_server_dt3_vram(
         Ok(())
     });
 
-    let ring = thread::spawn(move || {
-        let _char_dev = char_dev;
-        run_ring_owner(server, queue_depth, buf_size, work_tx, reply_rx)
-    });
+    let ring =
+        thread::spawn(move || run_ring_owner(server, queue_depth, buf_size, work_tx, reply_rx));
 
     Ok(ServerHandleDt3Vram { ring, worker })
 }
@@ -582,7 +573,7 @@ pub fn spawn_server_dt3_vram_with_residency(
     residency: ResidencyConfig,
 ) -> io::Result<ServerHandleDt3VramResidency> {
     let char_dev = OpenOptions::new().read(true).write(true).open(char_path)?;
-    let server = ramshared_uring::UblkServer::new(char_dev.as_raw_fd(), queue_depth, buf_size)?;
+    let server = ramshared_uring::UblkServer::new(char_dev.into(), queue_depth, buf_size)?;
 
     let (work_tx, work_rx) = mpsc::sync_channel::<ublk::IoWork>(RING_CHAN_CAP);
     let (reply_tx, reply_rx) = mpsc::channel::<WorkerReply>();
@@ -616,10 +607,8 @@ pub fn spawn_server_dt3_vram_with_residency(
         )
     });
 
-    let ring = thread::spawn(move || {
-        let _char_dev = char_dev;
-        run_ring_owner(server, queue_depth, buf_size, work_tx, reply_rx)
-    });
+    let ring =
+        thread::spawn(move || run_ring_owner(server, queue_depth, buf_size, work_tx, reply_rx));
 
     Ok(ServerHandleDt3VramResidency {
         ring,


### PR DESCRIPTION
## Resumo
Refactored `UblkFetchRing` and `UblkServer` to take ownership of the char device file descriptor using `OwnedFd`, eliminating dead drop guard fields.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| Refactor UblkFetchRing and UblkServer to use OwnedFd | Replaced `RawFd` parameters with `OwnedFd` inside `UblkFetchRing` and `UblkServer` and updated callers. | To remove the dead code `char_dev` drop guard pattern in `FetchSession` and dummy variables in `ublk_server.rs`. | <details>This enforces RAII natively inside the lowest-level structures using `io_uring` instead of placing the burden on the caller.</details> |

## Issue
Code Health Improvement Task

## Responsavel
Agent

## Labels
refactor, code-health

## Validacao
Ran `cargo check` and `cargo test`. All compiled without errors or unused import warnings, and all tests passed.

## Rollback trigger
Any compilation failures on cross-platform targets or unexpected file descriptor closures during standard I/O serving operations.

---
*PR created automatically by Jules for task [17821013094862213704](https://jules.google.com/task/17821013094862213704) started by @emersonbusson*