### PR TITLE
🔒 Fix unchecked file operation in cascade_io

### DIFF
--- a/crates/ramshared-cli/src/cascade/cascade_io.rs
+++ b/crates/ramshared-cli/src/cascade/cascade_io.rs
@@ -18,11 +18,22 @@ pub(crate) fn arm_forensics() {
     );
     for path in ARMED_MARKER_CANDIDATES {
         if let Some(parent) = Path::new(path).parent() {
+            if fs::symlink_metadata(parent).is_ok_and(|meta| meta.is_symlink()) {
+                continue;
+            }
             let _ = fs::create_dir_all(parent);
         }
-        if fs::write(path, &payload).is_ok() {
-            eprintln!("[up] forensics armed: {path}");
-            return;
+        let _ = fs::remove_file(path);
+        #[allow(clippy::collapsible_if)]
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+        {
+            if std::io::Write::write_all(&mut f, payload.as_bytes()).is_ok() {
+                eprintln!("[up] forensics armed: {path}");
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
## Resumo
🔒 Fix unchecked file operation (symlink vulnerability) in `cascade_io.rs`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 🔒 fix(ramshared-cli): mitigate symlink vulnerabilities in forensics files | Replaced `fs::write` with `OpenOptions::new().create_new(true)`. | To prevent symlink attacks (TOCTOU) where an attacker could overwrite system files. | <details>By using `create_new(true)`, the kernel atomically fails the open operation if the file (or a symlink) already exists, neutralizing the vulnerability.</details> |

## Issue
Fixes # (no issue provided)

## Responsavel
@jules

## Labels
type:security
area:cli

## Validacao
- [x] `cargo test` passes
- [x] Code formatting (cargo fmt/clippy) passes
- [x] Manual testing of symlink behavior simulated successfully

## Rollback trigger
Se o `ramshared up` falhar de forma consistente ao criar os arquivos de marker devido a falsos positivos em `create_new(true)` ou erros de permissão de diretório em ambientes legítimos.

---
*PR created automatically by Jules for task [14175436862807275970](https://jules.google.com/task/14175436862807275970) started by @emersonbusson*