### PR TITLE
🔒 Fix unchecked mkswap on /dev/zram0

### DIFF
--- a/crates/ramshared-cli/src/cascade/cascade_io.rs
+++ b/crates/ramshared-cli/src/cascade/cascade_io.rs
@@ -121,6 +121,16 @@ pub(crate) fn setup_zram_sysfs(mb: u64, prio: i32) -> Result<(), CascadeError> {
         .ok_or_else(|| CascadeError::Arg("zram size overflow".into()))?;
     fs::write(path.join("disksize"), bytes.to_string())
         .map_err(|e| CascadeError::Io(format!("disksize: {e}")))?;
+
+    let meta = fs::metadata("/dev/zram0")
+        .map_err(|e| CascadeError::Io(format!("stat /dev/zram0: {e}")))?;
+    use std::os::unix::fs::FileTypeExt;
+    if !meta.file_type().is_block_device() {
+        return Err(CascadeError::Precondition(
+            "/dev/zram0 is not a block device".into(),
+        ));
+    }
+
     sh("mkswap", &["/dev/zram0"])?;
     sh("swapon", &["-p", &prio.to_string(), "/dev/zram0"])?;
     fs::write(ZRAM_DEV_FILE, "/dev/zram0").map_err(|e| CascadeError::Io(e.to_string()))?;


### PR DESCRIPTION
## Resumo\nAdds block device validation in `ramshared up` before running destructive formatting operations (`mkswap` and `swapon`) on `/dev/zram0`.\n\n## Commits\n| Commit | O que fez | Por que fez | Detalhes |\n|---|---|---|---|\n| fix: Check if /dev/zram0 is a block device before mkswap | Verificou `is_block_device` em `setup_zram_sysfs` | Para mitigar CWE-362/symlink attack caso `/dev/zram0` não seja block device | <details>Adicionado `fs::metadata` e `FileTypeExt::is_block_device` antes do mkswap.</details> |\n\n## Issue\nN/A\n\n## Responsavel\n@agent\n\n## Labels\nsecurity, fix\n\n## Validacao\nPassou nos testes unitários e `cargo clippy`. \n\n## Rollback trigger\nFalhas relacionadas a provisionamento de zram em certas distros WSL2.\n\n🎯 **What:** The vulnerability fixed is an unchecked file operation prior to executing `mkswap` and `swapon` on `/dev/zram0` in `setup_zram_sysfs`.\n⚠️ **Risk:** A malicious user could pre-create `/dev/zram0` as a symlink pointing to a critical system file. `ramshared up` (running as root) would execute `mkswap` on the symlink target, corrupting or destroying the system file.\n🛡️ **Solution:** The fix adds a verification using `std::fs::metadata("/dev/zram0")` and `std::os::unix::fs::FileTypeExt::is_block_device()` to ensure the target is actually a block device before executing the destructive commands, preventing the symlink attack.

---
*PR created automatically by Jules for task [11186357435056982137](https://jules.google.com/task/11186357435056982137) started by @emersonbusson*