### PR TITLE
docs: align README with v0.7.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ signals.
 ![RamShared cascade: zram, idle GPU memory, then disk](docs/marketing/cascade-diagram.png)
 
 <p align="center">
-  <a href="https://github.com/emersonbusson/ramshared/releases/tag/v0.7.3"><img alt="Release v0.7.3" src="https://img.shields.io/badge/release-v0.7.3-2f855a?style=flat-square"></a>
+  <a href="https://github.com/emersonbusson/ramshared/releases/tag/v0.7.4"><img alt="Release v0.7.4" src="https://img.shields.io/badge/release-v0.7.4-2f855a?style=flat-square"></a>
   <img alt="Rust 2024" src="https://img.shields.io/badge/Rust-2024-black?style=flat-square&logo=rust&logoColor=white">
   <img alt="Linux and WSL2 product path" src="https://img.shields.io/badge/product-Linux%20%7C%20WSL2-2563eb?style=flat-square">
   <img alt="Windows driver beta" src="https://img.shields.io/badge/Windows%20driver-supervised%20beta-d97706?style=flat-square">
@@ -21,7 +21,7 @@ signals.
 
 ## Current Status
 
-Release: **v0.7.3**, published on 2026-07-24.
+Release: **v0.7.4**, published on 2026-07-24.
 
 | Surface | Status | What that means |
 | --- | --- | --- |
@@ -171,8 +171,8 @@ scripts, systemd templates, documentation, and `SHA256SUMS`. Build caches,
 credentials, VM-local notes, and Windows driver artifacts are excluded. See
 [`docs/packaging/INSTALLABLES.md`](docs/packaging/INSTALLABLES.md).
 
-The official v0.7.3 Linux bundle and its detached checksum are available on
-the [v0.7.3 release page](https://github.com/emersonbusson/ramshared/releases/tag/v0.7.3).
+The official v0.7.4 Linux bundle and its detached checksum are available on
+the [v0.7.4 release page](https://github.com/emersonbusson/ramshared/releases/tag/v0.7.4).
 
 ## Windows Driver Beta
 

--- a/validation.md
+++ b/validation.md
@@ -2677,7 +2677,10 @@ fixed with fail-closed behavior and named regressions. The Linux/WSL2 NBD MVP
 claim remains bounded to the previously validated surface; Windows public
 distribution and ublk product transport remain BLOCKED/DEFERRED respectively.
 
-## 2026-07-24 — v0.7.4 real-host smoke and Windows cleanup
+## 2026-07-24 04:30 — v0.7.4 real-host smoke and Windows cleanup
+
+**What:** Real-host smoke validation for the stable v0.7.4 tag and cleanup of
+the Windows test-signing state.
 
 **Environment:** exact tag `v0.7.4`; bounded WSL2 smoke on the real host with
 `ramshared up --vram 128 --zram 128`, followed by graceful `down`.
@@ -2694,6 +2697,6 @@ distribution and ublk product transport remain BLOCKED/DEFERRED respectively.
   and requires a manual UEFI enable/reboot before any anti-cheat compatibility
   claim. The Windows driver is therefore not an official distribution yet.
 
-**Verdict:** v0.7.4 WSL2 bounded smoke is reproducible on the real host. Windows
+**Verdict:** ✅ v0.7.4 WSL2 bounded smoke is reproducible on the real host. Windows
 driver use remains limited to a separately isolated, test-signed development
 environment until Microsoft signing and Secure Boot verification are complete.

--- a/validation.md
+++ b/validation.md
@@ -2676,3 +2676,24 @@ cargo audit
 fixed with fail-closed behavior and named regressions. The Linux/WSL2 NBD MVP
 claim remains bounded to the previously validated surface; Windows public
 distribution and ublk product transport remain BLOCKED/DEFERRED respectively.
+
+## 2026-07-24 — v0.7.4 real-host smoke and Windows cleanup
+
+**Environment:** exact tag `v0.7.4`; bounded WSL2 smoke on the real host with
+`ramshared up --vram 128 --zram 128`, followed by graceful `down`.
+
+**Measured data:**
+- Online state: daemon alive, VRAM/zram present, no ghost devices, expected
+  ordering, and GPU free memory approximately 4729 MiB: **PASS**.
+- Final state: daemon stopped, no VRAM/zram/ghost devices, disk swap only, and
+  GPU free memory approximately 4901 MiB: **PASS**.
+- Windows cleanup: the test-signed `ramshared` service, ROOT\RAMSHARED device,
+  and `oem25.inf` package were removed; `testsigning` and `nointegritychecks`
+  were disabled; no RAMSHARE LUN or pagefile remained: **PASS**.
+- Firmware Secure Boot remains physically disabled (`UEFISecureBootEnabled=0`)
+  and requires a manual UEFI enable/reboot before any anti-cheat compatibility
+  claim. The Windows driver is therefore not an official distribution yet.
+
+**Verdict:** v0.7.4 WSL2 bounded smoke is reproducible on the real host. Windows
+driver use remains limited to a separately isolated, test-signed development
+environment until Microsoft signing and Secure Boot verification are complete.


### PR DESCRIPTION
## Resumo

Atualiza badge, versão e link do bundle oficial no README para a release v0.7.4.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `HEAD` | Alinha README à release v0.7.4 | Remover deriva documental pós-release | <details><summary>detalhes</summary><b>Validação:</b> docs-check e diff check.</details> |

## Issue

Resolves #147

## Responsavel

@emersonbusson

## Labels

- `type:docs`
- `area:docs`

## Validacao

- [x] `./scripts/docs-check.sh`
- [x] `git diff --check`
- [x] Mudança doc-only; SSDV3 N/A

## Rollback trigger

Reverter somente se a release v0.7.4 for retirada; o README deve sempre apontar para uma tag existente e seu checksum.