### PR TITLE
🧪 [testing improvement] Add error path test for write_json_line exceeding MAX_LINE_BYTES

### DIFF
--- a/crates/ramshared-agent/src/local.rs
+++ b/crates/ramshared-agent/src/local.rs
@@ -91,4 +91,16 @@ mod tests {
             .expect("msg");
         assert_eq!(decoded, msg);
     }
+
+    #[test]
+    fn write_json_line_too_large_errors() {
+        let msg = LocalMsg::LeaseRequest {
+            bytes: 4096,
+            client: "A".repeat(MAX_LINE_BYTES),
+        };
+        let mut buf = Vec::new();
+        let err = write_json_line(&mut buf, &msg).expect_err("expected write to fail");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(err.to_string(), "local message too large");
+    }
 }


### PR DESCRIPTION
## Resumo

Added a missing test case `write_json_line_too_large_errors` in `crates/ramshared-agent/src/local.rs` to verify that `write_json_line` correctly returns an error when attempting to serialize a JSON message that exceeds `MAX_LINE_BYTES`.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| test: add error path test for write_json_line size limit | Added a test function in `local.rs`. | To cover the error path where a serialized message exceeds `MAX_LINE_BYTES`. | <details>Constructed a `LocalMsg::LeaseRequest` with a heavily padded client string exceeding the size limit and used `expect_err` to verify `write_json_line` correctly rejects it with an `InvalidData` error.</details> |

## Issue

N/A

## Responsavel

Jules

## Labels

~"testing"

## Validacao

- Ran `cargo test` and verified the new `write_json_line_too_large_errors` test passes locally.
- Verified that the full workspace test suite continues to pass with 0 regressions.

## Rollback trigger

None. Test-only change.

🎯 **What:** The testing gap addressed was the lack of coverage for the error returned by `write_json_line` when the payload exceeds `MAX_LINE_BYTES`.
📊 **Coverage:** The scenario where the serialized JSON payload size > `MAX_LINE_BYTES` (64KB) is now explicitly tested and verified to return an `InvalidData` IO error.
✨ **Result:** Test coverage for `crates/ramshared-agent/src/local.rs` is improved, ensuring the size limit logic is safely guarded against future regressions.

---
*PR created automatically by Jules for task [7651916202154350689](https://jules.google.com/task/7651916202154350689) started by @emersonbusson*