### PR TITLE
🧹 [Remove #[allow(dead_code)] from RAII drop guards]

### DIFF
--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -257,8 +257,7 @@ pub struct UblkFetchRing {
     /// Data buffers per tag: the `addr` of each FETCH points to its corresponding
     /// buffer, which must remain alive while the command is parked in the kernel.
     /// Never read directly; exists to enforce the lifetime (drop guard).
-    #[allow(dead_code)]
-    buffers: Vec<Vec<u8>>,
+    _buffers: Vec<Vec<u8>>,
 }
 
 impl UblkFetchRing {
@@ -295,7 +294,10 @@ impl UblkFetchRing {
         // Does not block (want=0); the FETCH requests remain parked in the driver.
         ring.submit()?;
 
-        Ok(Self { ring, buffers })
+        Ok(Self {
+            ring,
+            _buffers: buffers,
+        })
     }
 
     /// Drains currently available CQEs without blocking.

--- a/crates/ramshared-winsvc/src/product_online.rs
+++ b/crates/ramshared-winsvc/src/product_online.rs
@@ -1222,8 +1222,7 @@ struct HostGates {
     volume_mount_path: Option<std::path::PathBuf>,
     volume_device_path: Option<String>,
     /// Validated at construction (letter/serial/size shape); kept for diagnostics.
-    #[allow(dead_code)]
-    target: TeardownTarget,
+    _target: TeardownTarget,
     target_serial: String,
     target_size: u64,
     identity_verified: bool,
@@ -1243,7 +1242,7 @@ impl HostGates {
             volume_letter,
             volume_mount_path,
             volume_device_path: None,
-            target: TeardownTarget::new(volume_letter, serial, size_bytes)?,
+            _target: TeardownTarget::new(volume_letter, serial, size_bytes)?,
             target_serial: serial.to_string(),
             target_size: size_bytes,
             identity_verified: false,

--- a/crates/ramshared-wsl2d/src/ublk_queue.rs
+++ b/crates/ramshared-wsl2d/src/ublk_queue.rs
@@ -52,8 +52,7 @@ pub fn read_io_desc(
 pub struct FetchSession {
     ring: ramshared_uring::UblkFetchRing,
     /// Char device `File`, kept open while the ring lives (drop guard).
-    #[allow(dead_code)]
-    char_dev: File,
+    _char_dev: File,
 }
 
 impl FetchSession {
@@ -71,7 +70,10 @@ impl FetchSession {
             buf_size,
         )?;
 
-        Ok(Self { ring, char_dev })
+        Ok(Self {
+            ring,
+            _char_dev: char_dev,
+        })
     }
 
     /// Drains available CQEs (does not block).


### PR DESCRIPTION
## Resumo
🧹 [Remove #[allow(dead_code)] from RAII drop guards]

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| Remove #[allow(dead_code)] from drop guards | Renamed drop guard fields to have a leading underscore (`_buffers`, `_char_dev`, `_target`) in UblkFetchRing, FetchSession, and HostGates | To idiomatically silence compiler warnings without suppressing them broadly, which improves code readability and safety. | <details>Updated struct instantiations to match the new field names.</details> |

## Issue
N/A

## Responsavel
Agent

## Labels
code-health

## Validacao
🎯 **What:** Removed `#[allow(dead_code)]` from structurally necessary RAII drop guards in `UblkFetchRing`, `FetchSession`, and `HostGates`.
💡 **Why:** Using an underscore prefix (e.g., `_buffers`) is the idiomatic Rust way to intentionally silence dead-code warnings while retaining memory lifetimes without applying broad allow macros.
✅ **Verification:** Ran `cargo check` and `cargo test` across the workspace to ensure compilability, verify no functional changes occurred, and validate the correct implementation.
✨ **Result:** A cleaner codebase complying with Rust idiomatic rules for unused variables.

## Rollback trigger
Revert this PR if unexpected memory drops or borrowing issues occur on the affected structs.

---
*PR created automatically by Jules for task [418091320337506076](https://jules.google.com/task/418091320337506076) started by @emersonbusson*