### PR TITLE
🧪 [testing improvement] Add test for sample fallback in win_mem

### DIFF
--- a/crates/ramshared-agent/src/win_mem.rs
+++ b/crates/ramshared-agent/src/win_mem.rs
@@ -61,4 +61,10 @@ mod tests {
     fn malformed_output_is_rejected() {
         assert_eq!(parse_cim_sample("FreePhysicalMemory=abc"), None);
     }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn sample_fallback_returns_none() {
+        assert_eq!(sample(), None);
+    }
 }


### PR DESCRIPTION
## Resumo
Add unit test to verify that the `sample` fallback function returns `None` on non-Windows platforms.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| Add test for sample fallback in win_mem | Added `sample_fallback_returns_none` test | To increase test coverage and ensure correct cross-platform behavior of `win_mem::sample` | <details>Added a test function `sample_fallback_returns_none` within `crates/ramshared-agent/src/win_mem.rs` conditionally compiled for `not(windows)` to assert `sample()` evaluates to `None`.</details> |

## Issue
None

## Responsavel
Agent

## Labels
testing

## Validacao
Ran `cargo test --package ramshared-agent` locally which executed `win_mem::tests::sample_fallback_returns_none` and completed successfully.

## Rollback trigger
N/A


---
*PR created automatically by Jules for task [16031287668296233416](https://jules.google.com/task/16031287668296233416) started by @emersonbusson*