### PR TITLE
🧪 [Added error path test for read_json_line]

### DIFF
--- a/crates/ramshared-agent/src/local.rs
+++ b/crates/ramshared-agent/src/local.rs
@@ -95,7 +95,7 @@ mod tests {
     #[test]
     fn local_protocol_read_too_large() {
         let buf = vec![b'a'; MAX_LINE_BYTES + 1];
-        let err = read_json_line::<_, LocalMsg>(&mut Cursor::new(buf)).unwrap_err();
+        let err = read_json_line::<_, LocalMsg>(&mut Cursor::new(buf)).expect_err("read expected to fail");
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
         assert_eq!(err.to_string(), "local message too large");
     }

--- a/crates/ramshared-agent/src/local.rs
+++ b/crates/ramshared-agent/src/local.rs
@@ -91,4 +91,12 @@ mod tests {
             .expect("msg");
         assert_eq!(decoded, msg);
     }
+
+    #[test]
+    fn local_protocol_read_too_large() {
+        let buf = vec![b'a'; MAX_LINE_BYTES + 1];
+        let err = read_json_line::<_, LocalMsg>(&mut Cursor::new(buf)).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(err.to_string(), "local message too large");
+    }
 }

--- a/crates/ramshared-agent/src/local.rs
+++ b/crates/ramshared-agent/src/local.rs
@@ -95,7 +95,8 @@ mod tests {
     #[test]
     fn local_protocol_read_too_large() {
         let buf = vec![b'a'; MAX_LINE_BYTES + 1];
-        let err = read_json_line::<_, LocalMsg>(&mut Cursor::new(buf)).expect_err("read expected to fail");
+        let err = read_json_line::<_, LocalMsg>(&mut Cursor::new(buf))
+            .expect_err("read expected to fail");
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
         assert_eq!(err.to_string(), "local message too large");
     }


### PR DESCRIPTION
## Resumo
Added a test for the error path of `read_json_line` in the `ramshared-agent` crate. The test covers the condition where a message line exceeds `MAX_LINE_BYTES`.

🎯 **What:** The testing gap addressed is the lack of test coverage for the error condition in `read_json_line` when a read buffer receives a message longer than `MAX_LINE_BYTES`.
📊 **Coverage:** The test ensures that an overly long message results in an `std::io::ErrorKind::InvalidData` error with the correct error string.
✨ **Result:** Improved test coverage for edge case limits and safer deserialization assumptions.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | Added test case `local_protocol_read_too_large` | Fix testing gap for missing error path on long json lines. | <details>Added a test using a dummy buffer of `MAX_LINE_BYTES + 1` bytes of valid utf-8 to verify it returns `InvalidData`.</details> |

## Issue
N/A

## Responsavel
@AI

## Labels
testing

## Validacao
Ran `cargo test -p ramshared-agent` locally which passed the new tests and ensured existing tests had no regressions.

## Rollback trigger
Revert the commit if it causes any flakiness in the CI test suite.

---
*PR created automatically by Jules for task [8158138704111478322](https://jules.google.com/task/8158138704111478322) started by @emersonbusson*