### PR TITLE
🔒 [security fix description] Fix insecure file permissions on Evidence files

### DIFF
--- a/crates/ramshared-winsvc/src/evidence.rs
+++ b/crates/ramshared-winsvc/src/evidence.rs
@@ -150,11 +150,14 @@ impl EvidenceWriter {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .read(true)
-            .open(&path)?;
+        let mut opts = OpenOptions::new();
+        opts.create(true).append(true).read(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let file = opts.open(&path)?;
         Ok(Self { path, file })
     }
 
@@ -405,7 +408,14 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("empty.jsonl");
         {
-            let mut file = File::create(&path).unwrap();
+            let mut opts = OpenOptions::new();
+            opts.create(true).write(true).truncate(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                opts.mode(0o600);
+            }
+            let mut file = opts.open(&path).unwrap();
             let row = RuntimeEvidence::base("run-1", "Online");
             let json = serde_json::to_string(&row).unwrap();
             file.write_all(b"\n").unwrap();
@@ -430,7 +440,14 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("invalid.jsonl");
         {
-            let mut file = File::create(&path).unwrap();
+            let mut opts = OpenOptions::new();
+            opts.create(true).write(true).truncate(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                opts.mode(0o600);
+            }
+            let mut file = opts.open(&path).unwrap();
             file.write_all(b"{ invalid json\n").unwrap();
         }
         let result = read_all_rows(&path);


### PR DESCRIPTION
## Resumo

Fix insecure file permissions on Evidence files in `ramshared-winsvc`.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| Fix insecure file permissions on Evidence files | Replaced `File::create` and basic `OpenOptions` with `OpenOptions` including `.mode(0o600)` on Unix. | To prevent unauthorized access to sensitive runtime evidence logs on Unix-like environments (e.g. WSL). | <details>Updated `EvidenceWriter::open` and test cases in `evidence.rs` to set restrictive permissions (`0o600`) using `std::os::unix::fs::OpenOptionsExt` when compiled on Unix, ensuring files aren't world-readable.</details> |

## Issue

N/A

## Responsavel

@agent

## Labels

security, bug

## Validacao

- Ran `cargo clippy --all-targets` to verify no regressions.
- Ran `cargo test --package ramshared-winsvc` to verify `read_all_rows_ignores_empty_lines` and `read_all_rows_invalid_json_yields_invalid_data` tests still pass successfully.
- Verified standard `cargo fmt --all` is respected.

## Rollback trigger

N/A

---

🎯 **What:** The vulnerability fixed
Insecure file permissions were used when creating `evidence.jsonl` files (via `EvidenceWriter::open` and in tests), making the files world-readable on Unix-like systems (such as WSL).

⚠️ **Risk:** The potential impact if left unfixed
Unauthorized local users could read sensitive runtime diagnostic information (evidence logs) detailing GPU and VRAM resource allocations and PIDs, potentially aiding in further exploitation or information disclosure.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced `File::create` and generic `OpenOptions` with explicitly configured `OpenOptions` that invoke `mode(0o600)` via `std::os::unix::fs::OpenOptionsExt` when compiling on Unix (`#[cfg(unix)]`), ensuring only the file owner can read/write the created evidence files.

---
*PR created automatically by Jules for task [4447478098579041494](https://jules.google.com/task/4447478098579041494) started by @emersonbusson*