### PR TITLE
🧪 [Add boundary and edge case tests for vram_safety_net]

### DIFF
--- a/crates/ramshared-tier/src/cascade.rs
+++ b/crates/ramshared-tier/src/cascade.rs
@@ -83,4 +83,14 @@ mod tests {
     fn ram_exactly_equal_to_vram_is_safe() {
         assert_eq!(vram_safety_net(false, GIB, GIB), SafetyNet::RamHeadroom);
     }
+
+    #[test]
+    fn ram_just_short_of_vram_is_unsafe() {
+        assert_eq!(vram_safety_net(false, GIB - 1, GIB), SafetyNet::None);
+    }
+
+    #[test]
+    fn vhdx_present_precedence_over_ram_headroom() {
+        assert_eq!(vram_safety_net(true, 4 * GIB, GIB), SafetyNet::VhdxBelow);
+    }
 }


### PR DESCRIPTION
## Resumo
Added missing error test cases and boundary conditions for `vram_safety_net`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Added test `ram_just_short_of_vram_is_unsafe` and `vhdx_present_precedence_over_ram_headroom` | Improve test coverage and catch edge case logic bugs | <details>Modifies `crates/ramshared-tier/src/cascade.rs`</details> |

## Issue
N/A

## Responsavel
@jules

## Labels
testing

## Validacao
Ran `cargo test` and all tests pass with no regressions.

## Rollback trigger
Revert commit

---

🎯 **What:** The testing gap for `vram_safety_net` was addressed, specifically the boundary missing error test where no safety net is available.
📊 **Coverage:** The scenarios now tested include a missing safety net (RAM just 1 byte short) and correctly prioritizing `VhdxBelow` when both constraints are met.
✨ **Result:** Test coverage improved, protecting against logical boundary bugs for VRAM safety checks.

---
*PR created automatically by Jules for task [15447287720430851711](https://jules.google.com/task/15447287720430851711) started by @emersonbusson*