### PR TITLE
🧪 [Add empty pagefile path test for merge_pagefile_sources]

### DIFF
--- a/crates/ramshared-winsvc/src/host_safety.rs
+++ b/crates/ramshared-winsvc/src/host_safety.rs
@@ -133,6 +133,16 @@ mod tests {
     }
 
     #[test]
+    fn empty_pagefile_path_returns_error() {
+        // Empty path
+        assert!(merge_pagefile_sources(Ok(vec!["".into()]), Ok(vec![])).is_err());
+        assert!(merge_pagefile_sources(Ok(vec![]), Ok(vec!["".into()])).is_err());
+
+        // Whitespace-only path (which gets trimmed to empty)
+        assert!(merge_pagefile_sources(Ok(vec!["   ".into()]), Ok(vec![])).is_err());
+    }
+
+    #[test]
     fn wildcard_or_ambiguous_pagefile_path_is_unsafe() {
         assert!(pagefile_may_target_volume(r"?:\pagefile.sys", 'S').unwrap());
         assert!(pagefile_may_target_volume(r"S:\pagefile.sys", 'S').unwrap());


### PR DESCRIPTION
## Resumo
Adiciona testes para caminhos vazios no `merge_pagefile_sources` no `ramshared-winsvc`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| test(winsvc): add empty path coverage for merge_pagefile_sources | Adiciona teste `empty_pagefile_path_returns_error` | Para garantir a cobertura do caso de falha de caminho vazio (<10 linhas) | <details>Adicionado o teste no módulo `host_safety::tests` do `ramshared-winsvc`</details> |

## Issue
N/A

## Responsavel
@Jules

## Labels
🧪 testing, rust

## Validacao
Os testes de unidade foram executados localmente (`cargo test --package ramshared-winsvc`) com sucesso (94 passando).

## Rollback trigger
N/A

---
🎯 **What:** The testing gap addressed for `merge_pagefile_sources` (missing error path test for empty string).
📊 **Coverage:** Empty string paths and whitespace-only string paths (which are trimmed to empty) are now properly verified to return an error.
✨ **Result:** Test suite coverage has been improved to protect against regressions on invalid empty paths.

---
*PR created automatically by Jules for task [11901350615598454709](https://jules.google.com/task/11901350615598454709) started by @emersonbusson*