### PR TITLE
🧪 [testing improvement] Add missing error path test for merge_pagefile_sources

### DIFF
--- a/crates/ramshared-winsvc/src/host_safety.rs
+++ b/crates/ramshared-winsvc/src/host_safety.rs
@@ -133,6 +133,18 @@ mod tests {
     }
 
     #[test]
+    fn merge_pagefile_empty_path_returns_error() {
+        assert_eq!(
+            merge_pagefile_sources(Ok(vec!["".into()]), Ok(vec![])).unwrap_err(),
+            "pagefile source returned an empty path"
+        );
+        assert_eq!(
+            merge_pagefile_sources(Ok(vec![]), Ok(vec!["   ".into()])).unwrap_err(),
+            "pagefile source returned an empty path"
+        );
+    }
+
+    #[test]
     fn wildcard_or_ambiguous_pagefile_path_is_unsafe() {
         assert!(pagefile_may_target_volume(r"?:\pagefile.sys", 'S').unwrap());
         assert!(pagefile_may_target_volume(r"S:\pagefile.sys", 'S').unwrap());


### PR DESCRIPTION
🎯 **What**: Added a missing unit test to address the testing gap for `merge_pagefile_sources` in `host_safety.rs` when an empty pagefile path is provided.
📊 **Coverage**: Both the `configured` and `active` paths are tested with empty and whitespace-only strings.
✨ **Result**: The codebase is now more robust with improved unit test coverage for Windows product teardown safety decisions.

## Resumo
Adiciona um teste unitário para validar o tratamento de erro em caminhos de arquivo de paginação vazios.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| test(winsvc): add missing error path test for merge_pagefile_sources | Adicionou teste `merge_pagefile_empty_path_returns_error` | Para aumentar a cobertura e garantir o comportamento de erro | <details>Verificou strings vazias e em branco para os vetores active e configured</details> |

## Issue
N/A

## Responsavel
@Jules

## Labels
`testing`, `rust`

## Validacao
Passou no `cargo test --package ramshared-winsvc`.

## Rollback trigger
Se os testes falharem de forma não determinística em outras plataformas.

---
*PR created automatically by Jules for task [2551433560061735899](https://jules.google.com/task/2551433560061735899) started by @emersonbusson*