### PR TITLE
🧪 [testing improvement] Add missing coverage tests for vram_safety_net

### DIFF
--- a/crates/ramshared-tier/src/cascade.rs
+++ b/crates/ramshared-tier/src/cascade.rs
@@ -64,6 +64,13 @@ mod tests {
     }
 
     #[test]
+    fn vhdx_present_but_no_ram_headroom_is_still_safe() {
+        let net = vram_safety_net(true, 512 * 1024 * 1024, GIB);
+        assert_eq!(net, SafetyNet::VhdxBelow);
+        assert!(net.is_safe());
+    }
+
+    #[test]
     fn ram_headroom_covers_when_no_vhdx() {
         // swap=0 in .wslconfig, but 4 GiB of free RAM covers 1 GiB of VRAM capacity.
         let net = vram_safety_net(false, 4 * GIB, GIB);
@@ -75,6 +82,14 @@ mod tests {
     fn no_vhdx_and_no_ram_is_unsafe() {
         // swap disabled and insufficient RAM: arming VRAM would trigger OOM during DEMOTE.
         let net = vram_safety_net(false, 256 * 1024 * 1024, GIB);
+        assert_eq!(net, SafetyNet::None);
+        assert!(!net.is_safe());
+    }
+
+    #[test]
+    fn ram_just_below_vram_is_unsafe() {
+        // Boundary condition: RAM is 1 byte short of VRAM size.
+        let net = vram_safety_net(false, GIB - 1, GIB);
         assert_eq!(net, SafetyNet::None);
         assert!(!net.is_safe());
     }


### PR DESCRIPTION
## Resumo
Adiciona testes de cobertura e tratamento de falha na verificação de limites do `vram_safety_net`

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | Adicionou teste `ram_just_below_vram_is_unsafe` | Garantir que o limite exato de falta de RAM retorne um estado inseguro. | <details>Verifica a borda -1 byte.</details> |
| 2 | Adicionou teste `vhdx_present_but_no_ram_headroom_is_still_safe` | Garantir a consistência da presença do VHDX como overriding de segurança. | <details>Condição dupla cruzada.</details> |

## Issue
Adicionou testes para falhas ausentes na verificação de RAM.

## Responsavel
@agent

## Labels
testing, rust

## Validacao
Os testes unitários na biblioteca `ramshared-tier` foram executados localmente (`cargo test`) com sucesso.

## Rollback trigger
Se os testes falharem de forma não determinística no pipeline.

---
*PR created automatically by Jules for task [5418974125581263233](https://jules.google.com/task/5418974125581263233) started by @emersonbusson*