### PR TITLE
🧪 [testing improvement] Add unit test for Watchdog::touch

### DIFF
--- a/crates/ramshared-agent/src/watchdog.rs
+++ b/crates/ramshared-agent/src/watchdog.rs
@@ -64,4 +64,14 @@ mod tests {
         assert!(!wd.expired(t1 + Duration::from_secs(89)));
         assert!(wd.expired(t1 + Duration::from_secs(90)));
     }
+
+    #[test]
+    fn touch_updates_last_field() {
+        let t0 = Instant::now();
+        let mut wd = Watchdog::new(Duration::from_secs(90), t0);
+        assert_eq!(wd.last, t0);
+        let t1 = t0 + Duration::from_secs(10);
+        wd.touch(t1);
+        assert_eq!(wd.last, t1);
+    }
 }


### PR DESCRIPTION
## Resumo
Add unit test for `Watchdog::touch` to improve test coverage in `ramshared-agent`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| test: add unit test for Watchdog::touch | Added `touch_updates_last_field` test to `watchdog.rs` | To verify that `touch()` correctly updates the `last` internal field, closing a gap in the test suite. | <details>Added a test function that asserts the `last` field equals the time passed to `touch`.</details> |

## Issue
Testing Improvement

## Responsavel
Agent

## Labels
testing

## Validacao
Ran `cargo test` across the workspace and specifically for `ramshared-agent`. The new test passes successfully without introducing any regressions.

## Rollback trigger
N/A (Test addition only)

---
*PR created automatically by Jules for task [8139583175485664918](https://jules.google.com/task/8139583175485664918) started by @emersonbusson*