### PR TITLE
🧹 [code health improvement] Refactor SparseVramBackend to use SparseVramConfig

### DIFF
--- a/crates/ramshared-block/src/lib.rs
+++ b/crates/ramshared-block/src/lib.rs
@@ -21,7 +21,7 @@ pub use inflight::Inflight;
 pub use protocol::{Command, ProtocolError, Request, encode_simple_reply, parse_request};
 pub use request::{BlockBackend, IoError, ServeOutcome, serve};
 pub use sparse_vram::{
-    CommitBudgetGate, DEFAULT_CHUNK_MIB, SparseVramBackend, chunk_bytes_from_env,
+    CommitBudgetGate, DEFAULT_CHUNK_MIB, SparseVramBackend, SparseVramConfig, chunk_bytes_from_env,
     commit_cap_bytes_from_env, idle_free_secs_from_env, prealloc_enabled,
     reserve_floor_bytes_from_env, safe_commit_cap,
 };

--- a/crates/ramshared-block/src/sparse_vram.rs
+++ b/crates/ramshared-block/src/sparse_vram.rs
@@ -25,6 +25,15 @@ struct Chunk<'p, P: VramProvider + 'p> {
     last_write: Option<Instant>,
 }
 
+pub struct SparseVramConfig<'p> {
+    pub capacity: u64,
+    pub chunk_bytes: u64,
+    pub block_size: u32,
+    pub reserve_floor_bytes: u64,
+    pub commit_cap_bytes: Option<u64>,
+    pub budget_gate: Option<&'p dyn CommitBudgetGate>,
+}
+
 /// Block device: advertised `capacity`, physical commit in `chunk_bytes` units.
 pub struct SparseVramBackend<'p, P: VramProvider + 'p> {
     provider: &'p P,
@@ -52,63 +61,43 @@ impl<'p, P: VramProvider + 'p> SparseVramBackend<'p, P> {
         chunk_bytes: u64,
         block_size: u32,
     ) -> Result<Self, IoError> {
-        Self::new_with_limits_and_gate(
+        Self::new_with_config(
             provider,
-            capacity,
-            chunk_bytes,
-            block_size,
-            reserve_floor_bytes_from_env(),
-            None,
-            None,
+            SparseVramConfig {
+                capacity,
+                chunk_bytes,
+                block_size,
+                reserve_floor_bytes: reserve_floor_bytes_from_env(),
+                commit_cap_bytes: None,
+                budget_gate: None,
+            },
         )
     }
 
-    /// Same as [`new`] with explicit safety limits (tests + daemon).
-    pub fn new_with_limits(
-        provider: &'p P,
-        capacity: u64,
-        chunk_bytes: u64,
-        block_size: u32,
-        reserve_floor_bytes: u64,
-        commit_cap_bytes: Option<u64>,
-    ) -> Result<Self, IoError> {
-        Self::new_with_limits_and_gate(
-            provider,
-            capacity,
-            chunk_bytes,
-            block_size,
-            reserve_floor_bytes,
-            commit_cap_bytes,
-            None,
-        )
-    }
-
-    pub fn new_with_limits_and_gate(
-        provider: &'p P,
-        capacity: u64,
-        chunk_bytes: u64,
-        block_size: u32,
-        reserve_floor_bytes: u64,
-        commit_cap_bytes: Option<u64>,
-        budget_gate: Option<&'p dyn CommitBudgetGate>,
-    ) -> Result<Self, IoError> {
-        if capacity == 0 {
+    pub fn new_with_config(provider: &'p P, config: SparseVramConfig<'p>) -> Result<Self, IoError> {
+        if config.capacity == 0 {
             return Err(IoError("sparse: capacity 0".into()));
         }
-        if chunk_bytes == 0 || !chunk_bytes.is_multiple_of(u64::from(block_size)) {
+        if config.chunk_bytes == 0
+            || !config
+                .chunk_bytes
+                .is_multiple_of(u64::from(config.block_size))
+        {
             return Err(IoError(format!(
-                "sparse: chunk_bytes={chunk_bytes} must be >0 and multiple of block_size={block_size}"
+                "sparse: chunk_bytes={} must be >0 and multiple of block_size={}",
+                config.chunk_bytes, config.block_size
             )));
         }
-        let n = capacity.div_ceil(chunk_bytes);
+        let n = config.capacity.div_ceil(config.chunk_bytes);
         if n > 1_000_000 {
             return Err(IoError(format!("sparse: too many chunks ({n})")));
         }
         // Cap commit to capacity; optional env can lower further.
-        let commit_cap = commit_cap_bytes
+        let commit_cap = config
+            .commit_cap_bytes
             .unwrap_or_else(commit_cap_bytes_from_env)
-            .min(capacity)
-            .max(chunk_bytes);
+            .min(config.capacity)
+            .max(config.chunk_bytes);
         let mut chunks = Vec::with_capacity(n as usize);
         for _ in 0..n {
             chunks.push(Chunk {
@@ -119,12 +108,12 @@ impl<'p, P: VramProvider + 'p> SparseVramBackend<'p, P> {
         }
         Ok(Self {
             provider,
-            capacity,
-            chunk_bytes,
-            block_size,
-            reserve_floor_bytes,
+            capacity: config.capacity,
+            chunk_bytes: config.chunk_bytes,
+            block_size: config.block_size,
+            reserve_floor_bytes: config.reserve_floor_bytes,
             commit_cap_bytes: commit_cap,
-            budget_gate,
+            budget_gate: config.budget_gate,
             chunks,
             alloc_fails: 0,
             reclaim_frees: 0,
@@ -578,13 +567,16 @@ mod tests {
         // FakeProvider reports 8GiB free always — use commit_cap instead for hard stop.
         let p = FakeProvider::new();
         let chunk = 256 * 1024u64;
-        let mut be = SparseVramBackend::new_with_limits(
+        let mut be = SparseVramBackend::new_with_config(
             &p,
-            2 * chunk,
-            chunk,
-            4096,
-            0,           // no free-floor (fake has lots of free)
-            Some(chunk), // only one chunk allowed
+            SparseVramConfig {
+                capacity: 2 * chunk,
+                chunk_bytes: chunk,
+                block_size: 4096,
+                reserve_floor_bytes: 0,
+                commit_cap_bytes: Some(chunk),
+                budget_gate: None,
+            },
         )
         .unwrap();
         be.write_at(0, &[1u8; 4096]).unwrap();
@@ -603,14 +595,16 @@ mod tests {
             }
         }
         let p = FakeProvider::new();
-        let mut be = SparseVramBackend::new_with_limits_and_gate(
+        let mut be = SparseVramBackend::new_with_config(
             &p,
-            1024 * 1024,
-            256 * 1024,
-            4096,
-            0,
-            None,
-            Some(&Deny),
+            SparseVramConfig {
+                capacity: 1024 * 1024,
+                chunk_bytes: 256 * 1024,
+                block_size: 4096,
+                reserve_floor_bytes: 0,
+                commit_cap_bytes: None,
+                budget_gate: Some(&Deny),
+            },
         )
         .unwrap();
         be.write_at(0, &[1u8; 4096]).unwrap();
@@ -681,13 +675,16 @@ mod tests {
             }
         }
         let p = TightProvider;
-        let mut be = SparseVramBackend::new_with_limits(
+        let mut be = SparseVramBackend::new_with_config(
             &p,
-            1024 * 1024,
-            256 * 1024,
-            4096,
-            512 * 1024, // reserve 512KiB
-            None,
+            SparseVramConfig {
+                capacity: 1024 * 1024,
+                chunk_bytes: 256 * 1024,
+                block_size: 4096,
+                reserve_floor_bytes: 512 * 1024,
+                commit_cap_bytes: None,
+                budget_gate: None,
+            },
         )
         .unwrap();
         let err = be.write_at(0, &[1u8; 4096]).unwrap_err();
@@ -713,8 +710,18 @@ mod tests {
             }
         }
         let p = BadInfo;
-        let mut be =
-            SparseVramBackend::new_with_limits(&p, 1024 * 1024, 256 * 1024, 4096, 0, None).unwrap();
+        let mut be = SparseVramBackend::new_with_config(
+            &p,
+            SparseVramConfig {
+                capacity: 1024 * 1024,
+                chunk_bytes: 256 * 1024,
+                block_size: 4096,
+                reserve_floor_bytes: 0,
+                commit_cap_bytes: None,
+                budget_gate: None,
+            },
+        )
+        .unwrap();
         let err = be.write_at(0, &[1u8; 4096]).unwrap_err();
         assert!(
             err.0.contains("mem_info") || err.0.contains("no gpu"),

--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -21,8 +21,8 @@ use std::time::{Duration, Instant};
 
 use ramshared_block::protocol::{NBD_FLAG_CAN_MULTI_CONN, NBD_FLAG_HAS_FLAGS, NBD_FLAG_SEND_FLUSH};
 use ramshared_block::{
-    BlockBackend, Command, CommitBudgetGate, SparseVramBackend, chunk_bytes_from_env,
-    commit_cap_bytes_from_env, idle_free_secs_from_env, prealloc_enabled,
+    BlockBackend, Command, CommitBudgetGate, SparseVramBackend, SparseVramConfig,
+    chunk_bytes_from_env, commit_cap_bytes_from_env, idle_free_secs_from_env, prealloc_enabled,
     reserve_floor_bytes_from_env, safe_commit_cap, serve,
 };
 use ramshared_broker::arbiter::ArbiterConfig;
@@ -762,14 +762,16 @@ fn run_nbd<P: VramProvider>(
         let env_cap = commit_cap_bytes_from_env();
         let auto_cap = safe_commit_cap(size, total, reserve);
         let commit_cap = env_cap.min(auto_cap);
-        let sparse = SparseVramBackend::new_with_limits_and_gate(
+        let sparse = SparseVramBackend::new_with_config(
             &provider,
-            size,
-            chunk,
-            BLOCK_SIZE,
-            reserve,
-            Some(commit_cap),
-            budget_gate,
+            SparseVramConfig {
+                capacity: size,
+                chunk_bytes: chunk,
+                block_size: BLOCK_SIZE,
+                reserve_floor_bytes: reserve,
+                commit_cap_bytes: Some(commit_cap),
+                budget_gate,
+            },
         )
         .map_err(|e| e.0)?;
         eprintln!(


### PR DESCRIPTION
## Resumo
Refactored `SparseVramBackend` to use a new `SparseVramConfig` struct instead of a long list of parameters. This improves code readability and maintainability.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| Refactor SparseVramBackend to use SparseVramConfig | Refactored `SparseVramBackend::new_with_limits_and_gate` and `new_with_limits` into `new_with_config` using a new `SparseVramConfig` struct. Updated all tests and dependent usages. | To address the code health issue of long function argument lists, improving the builder/configuration pattern. | <details>Introduced `SparseVramConfig` with fields for capacity, chunk_bytes, block_size, reserve_floor_bytes, commit_cap_bytes, and budget_gate. Replaced usages in `sparse_vram.rs` and `main.rs` of `ramshared-wsl2d`.</details> |

## Issue
Fixes code health issue regarding long function arguments in `SparseVram::new_with_limits_and_gate`.

## Responsavel
Agent

## Labels
code-health, refactor

## Validacao
- Ran `cargo fmt --all`
- Ran `cargo clippy --workspace --all-targets -- -D warnings` (passed)
- Ran `cargo test --workspace` (passed)

## Rollback trigger
N/A - Internal API refactoring only.

🎯 **What:** Introduced a `SparseVramConfig` struct to encapsulate the 7 parameters previously passed to `SparseVramBackend::new_with_limits_and_gate`.
💡 **Why:** The long function signature was difficult to read and maintain. Encapsulating these arguments into a configuration struct provides a cleaner API and makes future additions to the configuration easier.
✅ **Verification:** Verified by running the full Rust formatting, clippy, and test suites across the workspace. All existing validation logic within the initialization block remains unchanged.
✨ **Result:** The `SparseVramBackend` initialization is now cleaner and follows better Rust configuration patterns.

---
*PR created automatically by Jules for task [9258747830438971936](https://jules.google.com/task/9258747830438971936) started by @emersonbusson*