### PR TITLE
🧪 [testing improvement] Add missing edge cases to nearest_rank_percentile tests

### DIFF
--- a/crates/ramshared-winsvc/src/evidence.rs
+++ b/crates/ramshared-winsvc/src/evidence.rs
@@ -346,6 +346,12 @@ mod tests {
         assert_eq!(s.max_us, 50);
         assert_eq!(s.samples, 5);
         assert_eq!(nearest_rank_percentile(&[], 50.0), 0);
+
+        let edge_case_samples = [10, 20, 30, 40, 50];
+        assert_eq!(nearest_rank_percentile(&edge_case_samples, 0.0), 10);
+        assert_eq!(nearest_rank_percentile(&edge_case_samples, -10.0), 10);
+        assert_eq!(nearest_rank_percentile(&edge_case_samples, 100.0), 50);
+        assert_eq!(nearest_rank_percentile(&edge_case_samples, 150.0), 50);
     }
 
     #[test]


### PR DESCRIPTION
## Resumo
Added missing tests for edge cases (e.g., `percentile <= 0.0` and `percentile >= 100.0`) in the `nearest_rank_percentile` function to improve test coverage.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| Add missing edge cases to nearest_rank_percentile tests | Added missing tests for edge cases in `nearest_rank_percentile` | To improve test coverage | <details>Added missing tests for edge cases (e.g., `percentile <= 0.0` and `percentile >= 100.0`) in the `nearest_rank_percentile` function in `crates/ramshared-winsvc/src/evidence.rs`.</details> |

## Issue
None

## Responsavel
Agent

## Labels
testing

## Validacao
Ran `cargo test --package ramshared-winsvc --lib -- evidence::tests::nearest_rank_percentiles_are_deterministic` to verify the new test cases pass.
Ran `cargo test` to ensure no regressions were introduced.

## Rollback trigger
Revert this commit if it causes any issues.

🎯 **What:** The testing gap for edge cases in `nearest_rank_percentile` function is addressed.
📊 **Coverage:** The scenarios for `percentile <= 0.0` and `percentile >= 100.0` are now tested.
✨ **Result:** The test coverage for the `nearest_rank_percentile` function is improved.

---
*PR created automatically by Jules for task [14230292848454245070](https://jules.google.com/task/14230292848454245070) started by @emersonbusson*