### PR TITLE
🔒 [security fix] Use strict allowlist for error redaction to prevent secret leakage

### DIFF
--- a/crates/ramshared-winsvc/src/evidence.rs
+++ b/crates/ramshared-winsvc/src/evidence.rs
@@ -209,40 +209,8 @@ pub fn summarize_latencies(samples_us: &[u64]) -> LatencySummary {
 }
 
 /// Redact free-form error text: drop hex addresses and truncate payload-like blobs.
-pub fn redacted_error(class: &str, code: &str, detail: &str) -> (String, String, String) {
-    let mut out = String::with_capacity(detail.len().min(256));
-    for token in detail.split_whitespace() {
-        if looks_like_pointer(token) {
-            if !out.is_empty() {
-                out.push(' ');
-            }
-            out.push_str("<redacted>");
-            continue;
-        }
-        if !out.is_empty() {
-            out.push(' ');
-        }
-        // Cap individual tokens that look like payload dumps.
-        if token.len() > 64 {
-            out.push_str(&token[..16]);
-            out.push('…');
-        } else {
-            out.push_str(token);
-        }
-        if out.len() >= 200 {
-            out.push('…');
-            break;
-        }
-    }
-    (class.to_string(), code.to_string(), out)
-}
-
-fn looks_like_pointer(token: &str) -> bool {
-    let t = token.trim_end_matches([',', ')', ']']);
-    if let Some(rest) = t.strip_prefix("0x").or_else(|| t.strip_prefix("0X")) {
-        return rest.len() >= 8 && rest.chars().all(|c| c.is_ascii_hexdigit());
-    }
-    false
+pub fn redacted_error(class: &str, code: &str, _detail: &str) -> (String, String, String) {
+    (class.to_string(), code.to_string(), String::new())
 }
 
 pub fn utc_ms() -> u64 {
@@ -357,11 +325,7 @@ mod tests {
         );
         assert_eq!(c, "cuda");
         assert_eq!(code, "CUDA_ERROR");
-        assert!(!detail.contains("0x7ffabcd12345"));
-        assert!(detail.contains("<redacted>"));
-        assert!(
-            !detail.contains("ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789XX")
-        );
+        assert!(detail.is_empty());
     }
 
     #[test]

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,15 @@
+1. **Understand the Vulnerability**:
+   The `redacted_error` function in `crates/ramshared-winsvc/src/evidence.rs` uses a heuristic approach to redact error details (`looks_like_pointer` and length caps). This is vulnerable to false negatives, which could lead to exposing sensitive information (e.g. API keys, secrets) in the `detail` string, which is then written to the JSONL evidence file.
+2. **Strict Allowlist Solution**:
+   Instead of trying to heuristically redact the `detail` string, we should strictly enforce that no sensitive information is leaked. Since `error_class` and `error_code` are stable and safe enum-like values or predefined strings, we can just return an empty string for `detail`, thereby guaranteeing no secrets are leaked.
+3. **Change to `redacted_error`**:
+   Modify `redacted_error` to ignore the `detail` argument completely:
+   ```rust
+   pub fn redacted_error(class: &str, code: &str, _detail: &str) -> (String, String, String) {
+       (class.to_string(), code.to_string(), String::new())
+   }
+   ```
+4. **Update the test `stable_error_redacts_payload`**:
+   The test expects `detail.contains("<redacted>")` and `!detail.contains(...)`. We will update it to verify that `detail` is exactly empty.
+5. **Run Tests**: Use `cargo test --package ramshared-winsvc` to verify the fix works.
+6. **Pre-commit Checks**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cargo test --package ramshared-winsvc --lib -- evidence::tests::stable_error_redacts_payload


### PR DESCRIPTION
## Resumo
Implemented a strict allowlist approach for error redaction to prevent potential secret leakage in evidence files.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix: use strict allowlist for redacted error to prevent secret leakage | Modified `redacted_error` in `evidence.rs` to return an empty string for the free-form `detail` instead of using heuristic redaction. | Heuristic redaction is prone to false negatives, which could lead to exposing API keys or secrets in telemetry/evidence files. | <details>Updated `redacted_error` implementation and its corresponding test.</details> |

## Issue
Fixes potential API Key / Secrets Leakage vulnerability in `evidence.rs`.

## Responsavel
Agent

## Labels
security, bug

## Validacao
Ran unit tests in `ramshared-winsvc`, including the updated `stable_error_redacts_payload` test which now verifies an empty string is returned for error details.

## Rollback trigger
Revert this PR if evidence files require the full free-form error detail string despite the security risks, or if downstream telemetry parsing strictly relies on non-empty detail fields.

🎯 **What:** The vulnerability fixed is the potential leakage of API keys or secrets in evidence files due to heuristic-based redaction.
⚠️ **Risk:** If left unfixed, false negatives in the heuristic redaction could expose sensitive tenant credentials or system secrets in diagnostic logs.
🛡️ **Solution:** Implemented a strict allowlist by returning an empty string for the free-form error `detail`, guaranteeing that no secrets can be leaked through this field.

---
*PR created automatically by Jules for task [16828815728775321531](https://jules.google.com/task/16828815728775321531) started by @emersonbusson*