### PR TITLE
🧹 [Code Health] Refactor drop guards to use underscore prefix

### DIFF
--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -257,8 +257,7 @@ pub struct UblkFetchRing {
     /// Data buffers per tag: the `addr` of each FETCH points to its corresponding
     /// buffer, which must remain alive while the command is parked in the kernel.
     /// Never read directly; exists to enforce the lifetime (drop guard).
-    #[allow(dead_code)]
-    buffers: Vec<Vec<u8>>,
+    _buffers: Vec<Vec<u8>>,
 }
 
 impl UblkFetchRing {
@@ -295,7 +294,10 @@ impl UblkFetchRing {
         // Does not block (want=0); the FETCH requests remain parked in the driver.
         ring.submit()?;
 
-        Ok(Self { ring, buffers })
+        Ok(Self {
+            ring,
+            _buffers: buffers,
+        })
     }
 
     /// Drains currently available CQEs without blocking.

--- a/crates/ramshared-wsl2d/src/ublk_queue.rs
+++ b/crates/ramshared-wsl2d/src/ublk_queue.rs
@@ -52,8 +52,7 @@ pub fn read_io_desc(
 pub struct FetchSession {
     ring: ramshared_uring::UblkFetchRing,
     /// Char device `File`, kept open while the ring lives (drop guard).
-    #[allow(dead_code)]
-    char_dev: File,
+    _char_dev: File,
 }
 
 impl FetchSession {
@@ -71,7 +70,10 @@ impl FetchSession {
             buf_size,
         )?;
 
-        Ok(Self { ring, char_dev })
+        Ok(Self {
+            ring,
+            _char_dev: char_dev,
+        })
     }
 
     /// Drains available CQEs (does not block).


### PR DESCRIPTION
## Resumo
Refactored drop guard fields in `FetchSession` and `UblkFetchRing` to use idiomatic underscore prefixes (`_char_dev`, `_buffers`) instead of `#[allow(dead_code)]`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `<commit-hash>` | Refactored drop guard fields. | To idiomatically suppress `dead_code` warnings without compiler attributes. | <details>Renamed `char_dev` to `_char_dev` in `FetchSession` and `buffers` to `_buffers` in `UblkFetchRing`, removing `#[allow(dead_code)]` and updating instantiations.</details> |

## Issue
N/A (Code Health Improvement)

## Responsavel
Agent

## Labels
refactor, cleanup

## Validacao
- Compiled both crates (`ramshared-wsl2d` and `ramshared-uring`) successfully.
- Verified drop guard behaviors remain functionally unchanged.
- Passed full `cargo test` workspace suite without regressions.

## Rollback trigger
Any build failures or regressions in ublk ring initialization logic.

---

🎯 **What:** The code health issue addressed
Removed `#[allow(dead_code)]` attributes from structurally necessary drop guards in `ublk_queue.rs` and `lib.rs` (ramshared-uring).

💡 **Why:** How this improves maintainability
Using an underscore prefix (e.g., `_char_dev`) is the idiomatic Rust way to signal to the compiler and future developers that a field is deliberately unread but must be kept alive (e.g., for RAII/Drop semantics). It reduces reliance on compiler attribute suppression.

✅ **Verification:** How you confirmed the change is safe
Ran the full test suite (`cargo test`) to ensure no logic or Drop behaviors were inadvertently altered.

✨ **Result:** The improvement achieved
Cleaner, more idiomatic Rust code without unnecessary compiler suppression attributes.

---
*PR created automatically by Jules for task [18433425636085299660](https://jules.google.com/task/18433425636085299660) started by @emersonbusson*