### PR TITLE
fix: prevent resource leaks and kernel stall in ublk teardown

### DIFF
--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -1656,9 +1656,18 @@ fn run_ublk(
     // Orderly teardown: STOP_DEV aborts FETCHes -> worker exits loop (and zeroes
     // VRAM at the end, in VRAM path) -> join -> DEL_DEV. (Whoever did swapon must swapoff
     // before: del_gendisk waits for the openers of the block device.)
-    ublk_control::stop_dev(UBLK_CONTROL, report.dev_id)?;
-    server.join()?;
-    ublk_control::delete_device(UBLK_CONTROL, report.dev_id)?;
+
+    // We collect the results to ensure that all teardown steps (importantly `delete_device`)
+    // are attempted even if one of the prior steps fails, avoiding early return via `?`
+    // which would skip deletion and leave a D-state stall.
+    let stop_res = ublk_control::stop_dev(UBLK_CONTROL, report.dev_id);
+    let join_res = server.join();
+    let delete_res = ublk_control::delete_device(UBLK_CONTROL, report.dev_id);
+
+    stop_res?;
+    join_res?;
+    delete_res?;
+
     eprintln!("[ramsharedd] ublk device removido");
     Ok(())
 }

--- a/crates/ramshared-wsl2d/src/ublk_server.rs
+++ b/crates/ramshared-wsl2d/src/ublk_server.rs
@@ -214,10 +214,14 @@ pub struct ServerHandleDt3<B> {
 
 impl<B> ServerHandleDt3<B> {
     pub fn join(self) -> io::Result<B> {
-        self.ring
+        let r_ring = self
+            .ring
             .join()
-            .map_err(|_| io::Error::other("ring owner panicked"))??;
-        self.worker.join()
+            .unwrap_or_else(|_| Err(io::Error::other("ring owner panicked")));
+        let r_worker = self.worker.join();
+
+        r_ring?;
+        r_worker
     }
 }
 
@@ -385,12 +389,17 @@ pub struct ServerHandleDt3Vram {
 
 impl ServerHandleDt3Vram {
     pub fn join(self) -> io::Result<()> {
-        self.ring
+        let r_ring = self
+            .ring
             .join()
-            .map_err(|_| io::Error::other("ring owner panicked"))??;
-        self.worker
+            .unwrap_or_else(|_| Err(io::Error::other("ring owner panicked")));
+        let r_worker = self
+            .worker
             .join()
-            .map_err(|_| io::Error::other("vram worker panicked"))?
+            .unwrap_or_else(|_| Err(io::Error::other("vram worker panicked")));
+
+        r_ring?;
+        r_worker
     }
 }
 
@@ -448,12 +457,17 @@ impl ServerHandleDt3VramResidency {
     }
 
     pub fn join(self) -> io::Result<()> {
-        self.ring
+        let r_ring = self
+            .ring
             .join()
-            .map_err(|_| io::Error::other("ring owner panicked"))??;
-        self.worker
+            .unwrap_or_else(|_| Err(io::Error::other("ring owner panicked")));
+        let r_worker = self
+            .worker
             .join()
-            .map_err(|_| io::Error::other("vram residency worker panicked"))?
+            .unwrap_or_else(|_| Err(io::Error::other("vram residency worker panicked")));
+
+        r_ring?;
+        r_worker
     }
 }
 


### PR DESCRIPTION
## Resumo
Fixes critical `STOP_DEV/join` teardown race and resource leaks in `ramshared-wsl2d`. Unconditionally executes all cleanup actions (including `delete_device`) and fully joins all server threads.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `<hash>` | Fixed teardown sequence in `main.rs` | Prevent WSL2 freezes caused by skipped `delete_device` calls on `?` early returns. | <details>Collected `Result`s for `stop_dev`, `join`, and `delete_device` before applying `?`.</details> |
| `<hash>` | Unconditionally joined server threads | Avoid leaving orphaned worker threads if the ring thread panics during shutdown. | <details>Updated `join` in `ServerHandleDt3`, `ServerHandleDt3Vram`, and `ServerHandleDt3VramResidency` in `ublk_server.rs`.</details> |

## Issue
Fixes BUG in `main.rs` (STOP_DEV/join).

## Responsavel
@Jules

## Labels
bug, wsl2d

## Validacao
Ran `cargo test --workspace --all-targets` and verified compilation with `cargo check`. No regressions were found.

## Rollback trigger
Revert this PR.

---
*PR created automatically by Jules for task [8654707228978851215](https://jules.google.com/task/8654707228978851215) started by @emersonbusson*