### PR TITLE
fix(scripts): migrate legacy cascade unit safely

### DIFF
--- a/docs/specs/no-milestone/wsl2-nbd-product-readiness/AUDIT-2.5.md
+++ b/docs/specs/no-milestone/wsl2-nbd-product-readiness/AUDIT-2.5.md
@@ -51,7 +51,7 @@ readiness from a mock.
 | Ordered size/benchmark matrix | PASS — DT-NBD-7 and ITEM-5 |
 | Approval/no-reboot boundary | PASS — DT-NBD-8/9 and ITEM-6 |
 | Relay ownership boundary | PASS — DT-NBD-10 and paired refusal |
-| Swapoff-first and layer rollback | PASS locally — injected `swapoff_completes_before_nbd_disconnect`, `failed_swapoff_keeps_daemon_and_device_alive`, and all 17 manufactured installer post-write rollback phases |
+| Swapoff-first and layer rollback | PASS locally — injected `swapoff_completes_before_nbd_disconnect`, `failed_swapoff_keeps_daemon_and_device_alive`, and all 20 manufactured installer post-write rollback phases |
 | Security/public-hygiene boundary | PASS — checklist and ITEM-7 |
 | Live WSL, GPU, and host evidence | NOT RUN — environment-bound; no claim made |
 

--- a/docs/specs/no-milestone/wsl2-nbd-product-readiness/IMPL.md
+++ b/docs/specs/no-milestone/wsl2-nbd-product-readiness/IMPL.md
@@ -11,7 +11,7 @@ host operation was run for this record.
 | `cargo test -p ramshared-tier --all-targets` | 52 passed (shared package suite) |
 | `cargo test -p ramshared-cli --all-targets` | 95 passed (90 unit + 5 integration) |
 | Exact CLI lifecycle contracts | 2 passed: `swapoff_completes_before_nbd_disconnect`, `failed_swapoff_keeps_daemon_and_device_alive` |
-| `bash scripts/safety/test-nbd-product-preflight.sh` | 17 passed, including all 17 post-write rollback phases |
+| `bash scripts/safety/test-nbd-product-preflight.sh` | 22 named suites passed, including one aggregate that injects all 20 post-write rollback phases and exact legacy-unit migration/backup refusal coverage |
 | `cargo clippy -p ramshared-tier --all-targets -- -D warnings` | pass |
 | `cargo clippy -p ramshared-cli --all-targets -- -D warnings` | pass |
 | `cargo fmt --all -- --check` | pass |
@@ -26,8 +26,9 @@ host operation was run for this record.
 | NBD transport integration | `crates/ramshared-tier/src/cascade.rs`; covered by the shared tier suite |
 | Real teardown executor | `crates/ramshared-cli/src/cascade/cascade_io.rs`; injected `NbdLifecyclePlan` / `NbdLifecycleExecutor` proves every `swapoff` precedes NBD disconnect and daemon stop |
 | Failed swapoff refusal | `failed_swapoff_keeps_daemon_and_device_alive` records only `swapoff`; it records neither disconnect nor daemon stop |
-| Installer rollback | `scripts/safety/install-cascade-boot.sh` has 17 named post-write markers; `scripts/safety/test-nbd-product-preflight.sh` injects a failure after each marker in a temporary fixture |
-| Read-only product preflight | `scripts/safety/nbd-product-preflight.sh` and the same 17-pass manufactured harness |
+| Installer rollback | `scripts/safety/install-cascade-boot.sh` has 20 named post-write markers; `scripts/safety/test-nbd-product-preflight.sh` injects a failure after each marker in a temporary fixture |
+| Legacy unit migration | A conflicting unit remains a refusal unless a second approval supplies its exact SHA-256. The manufactured migration test proves absent/stale approvals do not mutate it; an injected final-phase failure restores the old unit from a sealed backup. |
+| Read-only product preflight | `scripts/safety/nbd-product-preflight.sh` and the same 22-suite manufactured harness |
 
 ## Evidence matrix and open gaps
 
@@ -37,7 +38,7 @@ host operation was run for this record.
 | `relay_gate_before_action_after` | Read-only manufactured refusal only | Not run | `PARTIAL` / environment-bound |
 | `NBD_BENCHMARK_MATRIX` | Schema only | No 1/2/4 GiB cells or n≥3 statistics | `PARTIAL` / environment-bound |
 | `BINARY_MATCH` | Static stale/deleted daemon refusal only | **N/A / not run**; no live daemon or selected release | `PARTIAL` |
-| Sealed installer transaction | Temporary-fixture rollback only | No `/opt/ramshared` install | `PARTIAL` |
+| Sealed installer transaction | 20-phase rollback and legacy-unit migration manufactured tests | A first attended install on 2026-08-12 correctly refused `PRODUCT_UNIT_CONFLICT`; the legacy migration is not yet installed or live-verified | `PARTIAL` |
 
 Open gaps are an approved WSL2 NBD surface, a named sealed release and live
 daemon for `BINARY_MATCH`, Relay before/action/after evidence, and the ordered
@@ -48,12 +49,13 @@ there is no live before → action → after evidence.
 
 Rollback/refusal is mandatory when **any one** (`>= 1`) of these occurs:
 `swapoff` returns an error; an active NBD/ublk swap entry remains; any one of
-the **17/17** manufactured post-write rollback phases fails to restore prior
-selector/unit state and remove the destination; or lower-tier capacity is
+the **20/20** manufactured post-write rollback phases fails to restore prior
+selector/unit state and remove the destination; a legacy-unit migration hash,
+metadata, backup, or restoration check fails; or lower-tier capacity is
 `L < V + max(ceil(0.10 × V), 512 MiB)`. The local executor returns before NBD
 disconnect and daemon stop after a failed `swapoff`; a live operator must not
 infer that this source evidence authorizes teardown.
 
 ## Traceability
 
-`PRD.md` RF-NBD-1..12 → `SPEC.md` ITEM-1..7 → this explicit partial record.
+`PRD.md` RF-NBD-1..13 → `SPEC.md` ITEM-1..8 → this explicit partial record.

--- a/docs/specs/no-milestone/wsl2-nbd-product-readiness/PRD.md
+++ b/docs/specs/no-milestone/wsl2-nbd-product-readiness/PRD.md
@@ -62,6 +62,7 @@ Ship one NBD-only WSL2 path with these decisions:
 | Transport | NBD is the only supported WSL2 product transport. |
 | Release root | Sealed `/opt/ramshared/releases/<version>` artifacts; no in-place mutation. |
 | Legacy ublk | Retire product service/autostart/control-plane references; never unload `ublk_drv`. |
+| Legacy unit migration | Replace an inactive, disabled legacy `ramshared-cascade.service` only with a current approval bound to its observed SHA-256; preserve an immutable backup before the atomic replacement. |
 | Status | `PRODUCT_OFF`, `READY`, or `BLOCKED`, with an independent readiness reason. |
 | Capacity | Enforce `L >= V + max(ceil(10% of V), 512 MiB)` before activation and demotion. |
 | Sizes | Promote in order: 1 GiB pilot, then 2 GiB, then 4 GiB. No skipped size. |
@@ -90,6 +91,7 @@ to an external communication.
 | RF-NBD-10 | Retain swapoff-first teardown. | NBD swap is absent before daemon stop or device disconnect. |
 | RF-NBD-11 | Publish public-safe evidence. | Reports contain no host identity, secret, private path, or raw log. |
 | RF-NBD-12 | Make the actual cascade teardown executor fail closed after an injected `swapoff` failure. | Local action tracing proves `swapoff` completes before NBD disconnect/daemon stop and emits neither later action after refusal. |
+| RF-NBD-13 | Migrate the conflicting legacy cascade unit without a blind overwrite. | The installer refuses an absent, mismatched, stale, active, enabled, symlinked, or unapproved legacy unit; an approved exact SHA-256 creates an immutable backup and atomically replaces only that unit. |
 
 ## Non-functional requirements
 
@@ -190,6 +192,7 @@ stable reason code.
 | Legacy ublk service remains active | Active unit/device or unknown ownership → do not activate NBD; retire only after explicit approval. |
 | Relay is stranded or unreadable | Non-zero/ambiguous check → `BLOCKED`; do not reap automatically. |
 | Daemon identity is stale/deleted | `BINARY_MATCH` fail → no readiness claim; stop only after swapoff-first. |
+| Legacy cascade unit conflicts with the sealed unit | Refuse by default. A separately approved SHA-256-bound migration backs up the inactive root-owned regular legacy unit before atomic replacement; any mismatch or replacement failure restores it. |
 | WSL asks for reboot/shutdown | Refuse before mutation; status remains `BLOCKED` or `PRODUCT_OFF`. |
 | Large size causes host pressure | Stop the cell, preserve evidence, and do not promote; no shared-host pressure is inferred. |
 | Operator retries a deterministic failure | One bounded attempt; #15 refusal prevents blind retry. |

--- a/docs/specs/no-milestone/wsl2-nbd-product-readiness/SPEC.md
+++ b/docs/specs/no-milestone/wsl2-nbd-product-readiness/SPEC.md
@@ -38,6 +38,7 @@
 | RF-NBD-5, RF-NBD-10, RF-NBD-12 | ITEM-4 — capacity and swapoff-first lifecycle |
 | RF-NBD-6, NFR-NBD-4 | ITEM-5 — size promotion and benchmark matrix |
 | RF-NBD-7, RF-NBD-8 | ITEM-6 — approval, no reboot, and Relay gates |
+| RF-NBD-13 | ITEM-8 — exact legacy unit migration |
 | RF-NBD-11, NFR-NBD-1..6 | ITEM-7 — safety, observability, and evidence |
 
 ## Technical decisions
@@ -57,6 +58,7 @@
 | DT-NBD-11 | A live daemon must resolve to the selected sealed release. | Presence of a binary is not deployment identity. |
 | DT-NBD-12 | A failure is a stable refusal, not a retry loop. | Deterministic identity/capacity/lifecycle failures are not transient. |
 | DT-NBD-13 | `crates/ramshared-cli/src/cascade/cascade_io.rs` owns the NBD teardown effects; `cascade/lifecycle.rs` only derives a read-only status view. | The executor must prove `swapoff` before NBD disconnect or daemon stop through an injected local seam; status derivation cannot own lifecycle effects. |
+| DT-NBD-14 | A conflicting `ramshared-cascade.service` is never overwritten by the normal installer. Replacement is allowed only with both the named release approval and a second current SHA-256 approval for one inactive, disabled, root-owned regular legacy file; the installer copies it to a sealed immutable backup before atomic replacement. | The exact observed legacy artifact, rather than a path or name alone, is the authority boundary. A wrong hash, a symlink, unknown metadata, activity, enablement, backup mismatch, or any failed replacement refuses or restores the prior unit. |
 
 ## Atomicity/rollback
 
@@ -66,6 +68,7 @@
 | Product state | `PRODUCT_OFF → READY` only after all preconditions; no partial ready. | Any failed gate leaves `BLOCKED` or the prior `PRODUCT_OFF` state. |
 | NBD lifecycle | Attach, verify identity, then publish swap; teardown does swapoff before disconnect. | If swapoff fails, keep daemon/NBD alive; do not disconnect or kill. |
 | ublk retirement | Stop/disable only an identified legacy service under approval. | If ownership or active device is ambiguous, make no service mutation; leave `BLOCKED`. Never unload module. |
+| Legacy cascade unit migration | Hash-bind one inactive legacy unit, seal its backup, then atomically replace the unit. | Missing/stale/mismatched approval, non-regular metadata, backup mismatch, or a failed replacement leaves or restores the prior unit and removes the new release selection. |
 | Host/WSL | No reboot, shutdown, termination, or host configuration change. | A request for any such action is a refusal before mutation. |
 | Evidence | Write one sanitized result after each bounded phase. | A failed write invalidates the gate; do not infer success from process exit alone. |
 
@@ -90,6 +93,9 @@ test metadata only; production code has no test environment switch.
 | `unit-staged` | New unit file staged when prior unit was absent. | Remove unit staging and new destination; absent prior unit remains absent. |
 | `unit-linked` | New unit hard link published and ownership flag set. | Remove only the owned new unit and destination. |
 | `unit-staging-removed` | Unit staging path removed after successful link. | Remove only the owned new unit and destination. |
+| `legacy-unit-backed-up` | Exact legacy unit backup was sealed before replacement. | Retain the old unit; remove the staged release and leave the backup as immutable forensic evidence. |
+| `legacy-unit-staged` | Replacement unit was staged after the sealed backup. | Retain the old unit and remove staging/release; do not publish the replacement. |
+| `legacy-unit-replaced` | Replacement unit was atomically published. | Restore only the root-owned immutable backup whose SHA-256 still equals the approved legacy hash; otherwise report rollback failure without inferring recovery. |
 | `selector-staged` | New selector symlink staged. | Remove selector staging and new destination; prior selector remains. |
 | `selector-owner-normalized` | Staged selector ownership normalized. | Remove selector staging and new destination; prior selector remains. |
 | `selector-published` | Atomic selector replacement completed. | Restore prior selector, then remove new destination. |
@@ -195,6 +201,8 @@ No gaps are permitted between items:
 7. **ITEM-7:** run local source/static/manufactured tests and record an explicit
    `partial` `IMPL.md`; run approved live E2E before any root validation record
    or readiness claim.
+8. **ITEM-8:** add an exact SHA-256-bound legacy-unit migration with backup and
+   rollback tests; retain normal conflict refusal when that separate approval is absent.
 
 ## Required tests matrix
 
@@ -221,7 +229,11 @@ environment-bound and are not inferred from a manufactured test.
 | `scripts/safety/test-nbd-product-preflight.sh` | `product_off_ready_blocked_state_matrix` | manufactured | #13 | All state distinctions and reason codes match. |
 | `scripts/safety/test-nbd-product-preflight.sh` | `capacity_sink_identity_and_alignment_refusals` | manufactured refusal | #13/#16 | Wrong/ambiguous sink and alignment refuse. |
 | `scripts/safety/test-nbd-product-preflight.sh` | `n3_or_ublk_capability_does_not_promote_nbd_product` | manufactured refusal | #2 | Capability is not product readiness. |
-| `scripts/safety/install-cascade-boot.sh` + `scripts/safety/test-nbd-product-preflight.sh` | `installer_every_post_write_phase_rolls_back` | manufactured rollback | #13/#17 | Inject after each of the 17 named post-write markers; preserve prior selector/unit state and remove the new destination. |
+| `scripts/safety/install-cascade-boot.sh` + `scripts/safety/test-nbd-product-preflight.sh` | `installer_every_post_write_phase_rolls_back` | manufactured rollback | #13/#17 | Inject after each of the 20 named post-write markers; preserve prior selector/unit state and remove the new destination. |
+| `scripts/safety/install-cascade-boot.sh` + `scripts/safety/test-nbd-product-preflight.sh` | `legacy_unit_migration_requires_exact_hash_and_restores_on_failure` | manufactured approval/rollback | #3/#13/#17 | Default conflict refusal; only an inactive root-owned regular unit matching the supplied SHA-256 is backed up and atomically replaced; stale/mismatched metadata or injected failure retains/restores it. |
+| `scripts/safety/install-cascade-boot.sh` + `scripts/safety/test-nbd-product-preflight.sh` | `corrupt_published_legacy_backup_refuses_before_replacement` | manufactured refusal | #3/#13 | A post-publish backup hash mismatch refuses before replacement staging and leaves the legacy unit unchanged. |
+| `scripts/safety/install-cascade-boot.sh` + `scripts/safety/test-nbd-product-preflight.sh` | `legacy_backup_root_symlink_is_refused` | manufactured refusal | #3/#13 | A pre-existing backup-root symlink refuses before any backup write. |
+| `scripts/safety/install-cascade-boot.sh` + `scripts/safety/test-nbd-product-preflight.sh` | `legacy_restore_reloads_systemd_after_daemon_reload` | manufactured rollback | #13/#16 | A failure after daemon reload restores the old unit and reloads systemd again. |
 | `scripts/safety/cascade-up.sh` + `cascade-down.sh` | `nbd_lifecycle_before_action_after` | live E2E | #16/#17 | Approved NBD run, swapoff-first teardown, no ghost. |
 | `scripts/safety/nbd-product-preflight.sh` | `relay_gate_before_action_after` | live E2E | #18 | Relay check is clean before and after; no automatic reap. |
 | release/cascade surface | `NBD_BENCHMARK_MATRIX` | live benchmark | #9 | 1/2/4 GiB cells, n≥3, median/p99/deviation/integrity. |
@@ -278,7 +290,7 @@ node tools/ci/check-rust-slice-coverage.mjs -p ramshared-tier --files crates/ram
 - [ ] Static/manufactured tests cover legitimate and refusal pairs in the
   matrix.
 - [ ] Manufactured release install proves owner/mode/hash immutability and all
-  17 named post-write selector/unit/destination rollback frontiers.
+  20 named post-write selector/unit/destination rollback frontiers.
 - [ ] Readiness proves NBD-only, no active ublk service/device, and no module
   unload.
 - [ ] `BINARY_MATCH` proves the live daemon resolves to the sealed version

--- a/scripts/safety/install-cascade-boot.sh
+++ b/scripts/safety/install-cascade-boot.sh
@@ -9,15 +9,22 @@ RELEASE_ROOT="$PRODUCT_ROOT/releases"
 UNIT_PATH=/etc/systemd/system/ramshared-cascade.service
 CURRENT_SELECTOR="$PRODUCT_ROOT/current"
 APPROVED_VERSION=
+LEGACY_UNIT_APPROVED_HASH=
 declare -A INSTALL_MANIFEST_HASHES=()
 DESTINATION=
 STAGING=
 SELECTOR_STAGING=
 UNIT_STAGING=
+ROLLBACK_UNIT_STAGING=
+LEGACY_BACKUP_ROOT=
+LEGACY_BACKUP=
+LEGACY_BACKUP_STAGING=
 ROLLBACK_SELECTOR_STAGING=
 PRIOR_SELECTOR_TARGET=
 PUBLISHED_DESTINATION=0
 UNIT_CREATED=0
+LEGACY_UNIT_REPLACED=0
+LEGACY_UNIT_RELOAD_REQUIRED=0
 
 refuse() {
   printf 'NBD_INSTALL_STATE=REFUSED\n'
@@ -30,6 +37,8 @@ usage() {
 Usage:
   install-cascade-boot.sh [--plan]
   install-cascade-boot.sh --approve-nbd-product-install <version>
+  install-cascade-boot.sh --approve-nbd-product-install <version> \\
+    --approve-legacy-unit-replacement <sha256>
 
 The default is a read-only plan. Approval must name exactly the sealed release
 version in this bundle. This source-only slice installs its unit disabled: a
@@ -125,6 +134,10 @@ systemctl_status() {
   printf '%s\n' "$status"
 }
 
+is_sha256() {
+  [[ $1 =~ ^[[:xdigit:]]{64}$ ]]
+}
+
 check_unit_inert() {
   local unit=$1 active enabled
   active=$(systemctl_status is-active "$unit")
@@ -146,8 +159,58 @@ check_existing_unit_file() {
   [[ ! -L $UNIT_PATH ]] || refuse PRODUCT_UNIT_CONFLICT
   if [[ -e $UNIT_PATH ]]; then
     [[ -f $UNIT_PATH ]] || refuse PRODUCT_UNIT_CONFLICT
-    cmp -s "$expected_unit" "$UNIT_PATH" || refuse PRODUCT_UNIT_CONFLICT
+    if ! cmp -s "$expected_unit" "$UNIT_PATH"; then
+      [[ -n $LEGACY_UNIT_APPROVED_HASH ]] || refuse LEGACY_UNIT_APPROVAL_MISSING
+      is_sha256 "$LEGACY_UNIT_APPROVED_HASH" || refuse LEGACY_UNIT_APPROVAL_INVALID
+      [[ $(stat -c '%u:%g:%a' -- "$UNIT_PATH" 2>/dev/null || true) == '0:0:644' ]] || refuse LEGACY_UNIT_METADATA_INVALID
+      [[ $(sha256sum -- "$UNIT_PATH" | awk '{print $1}') == "${LEGACY_UNIT_APPROVED_HASH,,}" ]] || refuse LEGACY_UNIT_HASH_MISMATCH
+    fi
   fi
+}
+
+legacy_unit_replacement_required() {
+  [[ -f $UNIT_PATH && ! -L $UNIT_PATH ]] && ! cmp -s "$DESTINATION/systemd/ramshared-cascade.service" "$UNIT_PATH"
+}
+
+verify_legacy_backup_or_refuse() {
+  [[ -n $LEGACY_BACKUP && -f $LEGACY_BACKUP && ! -L $LEGACY_BACKUP ]] || refuse LEGACY_UNIT_BACKUP_CONFLICT
+  [[ $(stat -c '%u:%g:%a' -- "$LEGACY_BACKUP" 2>/dev/null || true) == '0:0:444' ]] || refuse LEGACY_UNIT_BACKUP_CONFLICT
+  [[ $(sha256sum -- "$LEGACY_BACKUP" | awk '{print $1}') == "${LEGACY_UNIT_APPROVED_HASH,,}" ]] || refuse LEGACY_UNIT_BACKUP_HASH_MISMATCH
+}
+
+prepare_legacy_backup_root_or_refuse() {
+  if [[ -e $LEGACY_BACKUP_ROOT || -L $LEGACY_BACKUP_ROOT ]]; then
+    [[ -d $LEGACY_BACKUP_ROOT && ! -L $LEGACY_BACKUP_ROOT ]] || refuse LEGACY_BACKUP_ROOT_INVALID
+    [[ $(stat -c '%u:%g:%a' -- "$LEGACY_BACKUP_ROOT" 2>/dev/null || true) == '0:0:755' ]] || refuse LEGACY_BACKUP_ROOT_INVALID
+  else
+    install -d -m 0755 "$LEGACY_BACKUP_ROOT"
+  fi
+  [[ -d $LEGACY_BACKUP_ROOT && ! -L $LEGACY_BACKUP_ROOT ]] || refuse LEGACY_BACKUP_ROOT_INVALID
+  [[ $(stat -c '%u:%g:%a' -- "$LEGACY_BACKUP_ROOT" 2>/dev/null || true) == '0:0:755' ]] || refuse LEGACY_BACKUP_ROOT_INVALID
+}
+
+backup_legacy_unit_if_required() {
+  local observed_hash
+  legacy_unit_replacement_required || return 0
+  observed_hash=$(sha256sum -- "$UNIT_PATH" | awk '{print $1}')
+  [[ $observed_hash == "${LEGACY_UNIT_APPROVED_HASH,,}" ]] || refuse LEGACY_UNIT_HASH_MISMATCH
+  [[ $(stat -c '%u:%g:%a' -- "$UNIT_PATH" 2>/dev/null || true) == '0:0:644' ]] || refuse LEGACY_UNIT_METADATA_INVALID
+
+  LEGACY_BACKUP_ROOT="$PRODUCT_ROOT/legacy-units"
+  LEGACY_BACKUP="$LEGACY_BACKUP_ROOT/ramshared-cascade.service.$observed_hash.bak"
+  LEGACY_BACKUP_STAGING="$LEGACY_BACKUP_ROOT/.ramshared-cascade.service.$observed_hash.$$.staging"
+  prepare_legacy_backup_root_or_refuse
+  if [[ -e $LEGACY_BACKUP || -L $LEGACY_BACKUP ]]; then
+    verify_legacy_backup_or_refuse
+    return 0
+  fi
+
+  install -m 0444 "$UNIT_PATH" "$LEGACY_BACKUP_STAGING"
+  chown root:root "$LEGACY_BACKUP_STAGING"
+  [[ $(sha256sum -- "$LEGACY_BACKUP_STAGING" | awk '{print $1}') == "$observed_hash" ]] || refuse LEGACY_UNIT_BACKUP_HASH_MISMATCH
+  mv -T "$LEGACY_BACKUP_STAGING" "$LEGACY_BACKUP"
+  verify_legacy_backup_or_refuse
+  # NBD_INSTALL_POST_WRITE_PHASE=legacy-unit-backed-up
 }
 
 path_exists_or_link() {
@@ -202,6 +265,23 @@ remove_created_unit_if_owned() {
   UNIT_CREATED=0
 }
 
+restore_legacy_unit_if_replaced() {
+  (( LEGACY_UNIT_REPLACED )) || return 0
+  [[ -n $LEGACY_BACKUP && -f $LEGACY_BACKUP && ! -L $LEGACY_BACKUP ]] || return 1
+  [[ $(stat -c '%u:%g:%a' -- "$LEGACY_BACKUP" 2>/dev/null || true) == '0:0:444' ]] || return 1
+  [[ $(sha256sum -- "$LEGACY_BACKUP" | awk '{print $1}') == "${LEGACY_UNIT_APPROVED_HASH,,}" ]] || return 1
+  ROLLBACK_UNIT_STAGING="$(dirname -- "$UNIT_PATH")/.ramshared-cascade.rollback.$$"
+  install -m 0644 "$LEGACY_BACKUP" "$ROLLBACK_UNIT_STAGING" || return 1
+  chown root:root "$ROLLBACK_UNIT_STAGING" || return 1
+  [[ $(sha256sum -- "$ROLLBACK_UNIT_STAGING" | awk '{print $1}') == "${LEGACY_UNIT_APPROVED_HASH,,}" ]] || return 1
+  mv -Tf "$ROLLBACK_UNIT_STAGING" "$UNIT_PATH" || return 1
+  if (( LEGACY_UNIT_RELOAD_REQUIRED )); then
+    systemctl daemon-reload || return 1
+    LEGACY_UNIT_RELOAD_REQUIRED=0
+  fi
+  LEGACY_UNIT_REPLACED=0
+}
+
 rollback_after_failure() {
   local status=$?
   trap - EXIT
@@ -212,8 +292,11 @@ rollback_after_failure() {
     if selector_points_to_destination; then
       restore_prior_selector || printf 'NBD_INSTALL_ROLLBACK=SELECTOR_RESTORE_FAILED\n' >&2
     fi
+    restore_legacy_unit_if_replaced || printf 'NBD_INSTALL_ROLLBACK=LEGACY_UNIT_RESTORE_FAILED\n' >&2
     remove_created_unit_if_owned
     remove_path_if_present "$UNIT_STAGING"
+    remove_path_if_present "$ROLLBACK_UNIT_STAGING"
+    remove_path_if_present "$LEGACY_BACKUP_STAGING"
     if (( PUBLISHED_DESTINATION )) && ! selector_points_to_destination; then
       remove_path_if_present "$DESTINATION"
       PUBLISHED_DESTINATION=0
@@ -225,7 +308,19 @@ rollback_after_failure() {
 
 install_unit_if_absent() {
   if path_exists_or_link "$UNIT_PATH"; then
-    check_existing_unit_file "$DESTINATION/systemd/ramshared-cascade.service"
+    if ! legacy_unit_replacement_required; then
+      check_existing_unit_file "$DESTINATION/systemd/ramshared-cascade.service"
+      return
+    fi
+    backup_legacy_unit_if_required
+    verify_legacy_backup_or_refuse
+    path_exists_or_link "$UNIT_STAGING" && refuse INSTALL_STAGING_EXISTS
+    install -m 0644 "$DESTINATION/systemd/ramshared-cascade.service" "$UNIT_STAGING"
+    # NBD_INSTALL_POST_WRITE_PHASE=legacy-unit-staged
+    chown root:root "$UNIT_STAGING"
+    mv -Tf "$UNIT_STAGING" "$UNIT_PATH"
+    LEGACY_UNIT_REPLACED=1
+    # NBD_INSTALL_POST_WRITE_PHASE=legacy-unit-replaced
     return
   fi
 
@@ -247,6 +342,11 @@ while (($# > 0)); do
     --approve-nbd-product-install)
       (($# >= 2)) || refuse APPROVAL_SCOPE_MISSING
       APPROVED_VERSION=$2
+      shift 2
+      ;;
+    --approve-legacy-unit-replacement)
+      (($# >= 2)) || refuse LEGACY_UNIT_APPROVAL_MISSING
+      LEGACY_UNIT_APPROVED_HASH=$2
       shift 2
       ;;
     --enable)
@@ -272,6 +372,7 @@ if [[ -z $APPROVED_VERSION ]]; then
 fi
 
 [[ $APPROVED_VERSION == "$RELEASE_VERSION" ]] || refuse APPROVAL_SCOPE_INVALID
+[[ -z $LEGACY_UNIT_APPROVED_HASH || $LEGACY_UNIT_APPROVED_HASH =~ ^[[:xdigit:]]{64}$ ]] || refuse LEGACY_UNIT_APPROVAL_INVALID
 [[ $(id -u) -eq 0 ]] || refuse ROOT_REQUIRED
 command -v systemctl >/dev/null 2>&1 || refuse SYSTEMD_UNAVAILABLE
 check_unit_inert ramshared-cascade.service
@@ -321,6 +422,9 @@ chown -h root:root "$SELECTOR_STAGING"
 # NBD_INSTALL_POST_WRITE_PHASE=selector-owner-normalized
 mv -Tf "$SELECTOR_STAGING" "$CURRENT_SELECTOR"
 # NBD_INSTALL_POST_WRITE_PHASE=selector-published
+if (( LEGACY_UNIT_REPLACED )); then
+  LEGACY_UNIT_RELOAD_REQUIRED=1
+fi
 systemctl daemon-reload
 # NBD_INSTALL_POST_WRITE_PHASE=daemon-reloaded
 

--- a/scripts/safety/test-nbd-product-preflight.sh
+++ b/scripts/safety/test-nbd-product-preflight.sh
@@ -32,6 +32,9 @@ readonly ROLLBACK_POST_WRITE_PHASES=(
   unit-staged
   unit-linked
   unit-staging-removed
+  legacy-unit-backed-up
+  legacy-unit-staged
+  legacy-unit-replaced
   selector-staged
   selector-owner-normalized
   selector-published
@@ -602,13 +605,13 @@ EOF
 }
 
 inject_rollback_failure_after_phase() {
-  local phase=$1 install=$2 temporary="$2.manufactured"
-  if ! awk -v phase="$phase" '
+  local phase=$1 install=$2 injection=${3:-"false # manufactured rollback failure after $phase"} temporary="$2.manufactured"
+  if ! awk -v phase="$phase" -v injection="$injection" '
     {
       print
       if ($0 ~ "^[[:space:]]*# NBD_INSTALL_POST_WRITE_PHASE=" phase "$" ) {
         matches += 1
-        print "false # manufactured rollback failure after " phase
+        print injection
       }
     }
     END { exit(matches == 1 ? 0 : 91) }
@@ -620,7 +623,7 @@ inject_rollback_failure_after_phase() {
 }
 
 new_rollback_installer_fixture() {
-  local name=$1 phase=$2 unit_mode=${3:-existing} root source target unit
+  local name=$1 phase=$2 unit_mode=${3:-existing} injection=${4:-} root source target unit
   root=$(new_fixture "rollback-$name")
   source="$root/opt/ramshared/releases/v1.2.3"
   target="$root/product"
@@ -631,7 +634,7 @@ new_rollback_installer_fixture() {
     -e "s|^PRODUCT_ROOT=/opt/ramshared$|PRODUCT_ROOT=$target|" \
     -e "s|^UNIT_PATH=/etc/systemd/system/ramshared-cascade.service$|UNIT_PATH=$unit|" \
     "$REPO_ROOT/scripts/safety/install-cascade-boot.sh" >"$source/scripts/safety/install-cascade-boot.sh"
-  inject_rollback_failure_after_phase "$phase" "$source/scripts/safety/install-cascade-boot.sh" || return 1
+  inject_rollback_failure_after_phase "$phase" "$source/scripts/safety/install-cascade-boot.sh" "$injection" || return 1
   chmod 0755 "$source/scripts/safety/install-cascade-boot.sh"
   printf 'v1.2.3\n' >"$source/RELEASE_VERSION"
   chmod 0644 "$source/RELEASE_VERSION"
@@ -643,6 +646,9 @@ new_rollback_installer_fixture() {
   ln -s releases/v0.0.1 "$target/current"
   if [[ $unit_mode == existing ]]; then
     install -m 0644 "$source/systemd/ramshared-cascade.service" "$unit"
+  elif [[ $unit_mode == legacy ]]; then
+    printf '[Unit]\nDescription=legacy fixture for exact migration\n' >"$unit"
+    chmod 0644 "$unit"
   fi
 
   cat >"$root/bin/id" <<'EOF'
@@ -650,9 +656,10 @@ new_rollback_installer_fixture() {
 [[ ${1:-} == -u ]] && { printf '0\n'; exit 0; }
 exec /usr/bin/id "$@"
 EOF
-  cat >"$root/bin/systemctl" <<'EOF'
+cat >"$root/bin/systemctl" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+printf '%s\n' "$*" >>"${RAMSHARED_SYSTEMCTL_LOG:-/dev/null}"
 case "${1:-}" in
   is-active) exit 3 ;;
   is-enabled) exit 1 ;;
@@ -669,7 +676,7 @@ EOF
 set -euo pipefail
 if [[ ${1:-} == -c && ${2:-} == %u:%g:%a ]]; then
   path=${4:-}
-  if [[ $path == "${RAMSHARED_ROLLBACK_PRODUCT_ROOT:?}"/releases/* ]]; then
+  if [[ $path == "${RAMSHARED_ROLLBACK_PRODUCT_ROOT:?}"/* || $path == "${RAMSHARED_ROLLBACK_UNIT_PATH:?}" ]]; then
     mode=$(/usr/bin/stat -c '%a' -- "$path")
     printf '0:0:%s\n' "$mode"
     exit 0
@@ -701,13 +708,19 @@ EOF
 }
 
 run_rollback_installer() {
-  local root=$1 phase=$2 source="$1/opt/ramshared/releases/v1.2.3"
+  local root=$1 phase=$2 migration_hash=${3:-} source="$1/opt/ramshared/releases/v1.2.3"
+  local -a arguments=(--approve-nbd-product-install v1.2.3)
+  if [[ -n $migration_hash ]]; then
+    arguments+=(--approve-legacy-unit-replacement "$migration_hash")
+  fi
   set +e
   RUN_OUTPUT=$(env \
     "PATH=$root/bin:$PATH" \
     "RAMSHARED_ROLLBACK_PHASE=$phase" \
     "RAMSHARED_ROLLBACK_PRODUCT_ROOT=$root/product" \
-    "$source/scripts/safety/install-cascade-boot.sh" --approve-nbd-product-install v1.2.3 2>&1)
+    "RAMSHARED_ROLLBACK_UNIT_PATH=$root/systemd/ramshared-cascade.service" \
+    "RAMSHARED_SYSTEMCTL_LOG=$root/state/systemctl.log" \
+    "$source/scripts/safety/install-cascade-boot.sh" "${arguments[@]}" 2>&1)
   RUN_EXIT=$?
   set -e
 }
@@ -734,10 +747,11 @@ assert_rollback_preserves_prior_selector_and_unit() {
 }
 
 test_installer_every_post_write_phase_rolls_back() {
-  local root selector_before unit_before unit_mode failures=0 phase
+  local root selector_before unit_before unit_mode migration_hash failures=0 phase
   for phase in "${ROLLBACK_POST_WRITE_PHASES[@]}"; do
     case $phase in
       unit-staged|unit-linked|unit-staging-removed) unit_mode=absent ;;
+      legacy-unit-backed-up|legacy-unit-staged|legacy-unit-replaced) unit_mode=legacy ;;
       *) unit_mode=existing ;;
     esac
     if ! root=$(new_rollback_installer_fixture "$phase" "$phase" "$unit_mode"); then
@@ -751,7 +765,11 @@ test_installer_every_post_write_phase_rolls_back() {
     else
       unit_before=absent
     fi
-    run_rollback_installer "$root" "$phase"
+    migration_hash=
+    if [[ $unit_mode == legacy ]]; then
+      migration_hash=$(sha256sum -- "$root/systemd/ramshared-cascade.service" | awk '{print $1}')
+    fi
+    run_rollback_installer "$root" "$phase" "$migration_hash"
     if ! assert_exit "installer_rollback_$phase" 1 || ! assert_rollback_preserves_prior_selector_and_unit "installer_rollback_$phase" "$root" "$selector_before" "$unit_before"; then
       failures=1
     fi
@@ -824,6 +842,131 @@ test_installer_active_enabled_or_unknown_units_refuse_without_writes() {
   pass installer_active_enabled_or_unknown_units_refuse_without_writes
 }
 
+test_legacy_unit_migration_requires_exact_hash_and_restores_on_failure() {
+  local root source unit old_hash backup_hash
+  root=$(new_rollback_installer_fixture legacy-unit-migration daemon-reloaded existing)
+  source="$root/opt/ramshared/releases/v1.2.3"
+  unit="$root/systemd/ramshared-cascade.service"
+  printf '[Unit]\nDescription=legacy exact migration fixture\n' >"$unit"
+  chmod 0644 "$unit"
+  old_hash=$(sha256sum -- "$unit" | awk '{print $1}')
+
+  run_rollback_installer "$root" daemon-reloaded
+  if ! assert_exit legacy_unit_migration_requires_exact_hash_and_restores_on_failure 1 ||
+    ! assert_contains legacy_unit_migration_requires_exact_hash_and_restores_on_failure 'NBD_INSTALL_REASON=LEGACY_UNIT_APPROVAL_MISSING'; then
+    return
+  fi
+
+  set +e
+  RUN_OUTPUT=$(env \
+    "PATH=$root/bin:$PATH" \
+    "RAMSHARED_ROLLBACK_PRODUCT_ROOT=$root/product" \
+    "RAMSHARED_ROLLBACK_UNIT_PATH=$unit" \
+    "$source/scripts/safety/install-cascade-boot.sh" \
+    --approve-nbd-product-install v1.2.3 \
+    --approve-legacy-unit-replacement "${old_hash/a/b}" 2>&1)
+  RUN_EXIT=$?
+  set -e
+  if ! assert_exit legacy_unit_migration_requires_exact_hash_and_restores_on_failure 1 ||
+    ! assert_contains legacy_unit_migration_requires_exact_hash_and_restores_on_failure 'NBD_INSTALL_REASON=LEGACY_UNIT_HASH_MISMATCH' ||
+    [[ $(sha256sum -- "$unit" | awk '{print $1}') != "$old_hash" ]]; then
+    fail 'legacy_unit_migration_requires_exact_hash_and_restores_on_failure stale approval mutated the legacy unit'
+    return
+  fi
+
+  set +e
+  RUN_OUTPUT=$(env \
+    "PATH=$root/bin:$PATH" \
+    "RAMSHARED_ROLLBACK_PRODUCT_ROOT=$root/product" \
+    "RAMSHARED_ROLLBACK_UNIT_PATH=$unit" \
+    "$source/scripts/safety/install-cascade-boot.sh" \
+    --approve-nbd-product-install v1.2.3 \
+    --approve-legacy-unit-replacement "$old_hash" 2>&1)
+  RUN_EXIT=$?
+  set -e
+  if ! assert_exit legacy_unit_migration_requires_exact_hash_and_restores_on_failure 1 ||
+    [[ $(sha256sum -- "$unit" | awk '{print $1}') != "$old_hash" ]]; then
+    fail 'legacy_unit_migration_requires_exact_hash_and_restores_on_failure old unit was not restored'
+    return
+  fi
+  backup_hash=$(sha256sum -- "$root/product/legacy-units/ramshared-cascade.service.$old_hash.bak" | awk '{print $1}')
+  if [[ $backup_hash != "$old_hash" ]]; then
+    fail 'legacy_unit_migration_requires_exact_hash_and_restores_on_failure immutable backup mismatch'
+    return
+  fi
+
+  pass legacy_unit_migration_requires_exact_hash_and_restores_on_failure
+}
+
+test_corrupt_legacy_backup_is_never_restored() {
+  local root source unit old_hash injection
+  injection='chmod u+w "$LEGACY_BACKUP"; printf corrupt >"$LEGACY_BACKUP"; chmod 0444 "$LEGACY_BACKUP"; false # manufactured corrupt-backup rollback'
+  root=$(new_rollback_installer_fixture corrupt-legacy-backup legacy-unit-replaced legacy "$injection")
+  source="$root/opt/ramshared/releases/v1.2.3"
+  unit="$root/systemd/ramshared-cascade.service"
+  old_hash=$(sha256sum -- "$unit" | awk '{print $1}')
+  run_rollback_installer "$root" legacy-unit-replaced "$old_hash"
+  if ! assert_exit corrupt_legacy_backup_is_never_restored 1 ||
+    ! assert_contains corrupt_legacy_backup_is_never_restored 'NBD_INSTALL_ROLLBACK=LEGACY_UNIT_RESTORE_FAILED'; then
+    return
+  fi
+  if [[ $(sha256sum -- "$unit" | awk '{print $1}') == "$old_hash" ]]; then
+    fail 'corrupt_legacy_backup_is_never_restored silently restored a corrupted backup'
+    return
+  fi
+  pass corrupt_legacy_backup_is_never_restored
+}
+
+test_corrupt_published_legacy_backup_refuses_before_replacement() {
+  local root unit old_hash injection
+  injection='chmod u+w "$LEGACY_BACKUP"; printf corrupt >"$LEGACY_BACKUP"; chmod 0444 "$LEGACY_BACKUP" # manufactured pre-replacement backup corruption'
+  root=$(new_rollback_installer_fixture corrupt-published-legacy-backup legacy-unit-backed-up legacy "$injection")
+  unit="$root/systemd/ramshared-cascade.service"
+  old_hash=$(sha256sum -- "$unit" | awk '{print $1}')
+  run_rollback_installer "$root" legacy-unit-backed-up "$old_hash"
+  if ! assert_exit corrupt_published_legacy_backup_refuses_before_replacement 1 ||
+    ! assert_contains corrupt_published_legacy_backup_refuses_before_replacement 'NBD_INSTALL_REASON=LEGACY_UNIT_BACKUP_HASH_MISMATCH' ||
+    [[ $(sha256sum -- "$unit" | awk '{print $1}') != "$old_hash" ]]; then
+    fail 'corrupt_published_legacy_backup_refuses_before_replacement replaced the legacy unit after backup corruption'
+    return
+  fi
+  pass corrupt_published_legacy_backup_refuses_before_replacement
+}
+
+test_legacy_backup_root_symlink_is_refused() {
+  local root unit old_hash redirect
+  root=$(new_rollback_installer_fixture legacy-backup-root-symlink legacy-unit-backed-up legacy)
+  unit="$root/systemd/ramshared-cascade.service"
+  old_hash=$(sha256sum -- "$unit" | awk '{print $1}')
+  redirect="$root/redirected-legacy-backups"
+  mkdir -p "$redirect"
+  ln -s "$redirect" "$root/product/legacy-units"
+  run_rollback_installer "$root" legacy-unit-backed-up "$old_hash"
+  if ! assert_exit legacy_backup_root_symlink_is_refused 1 ||
+    ! assert_contains legacy_backup_root_symlink_is_refused 'NBD_INSTALL_REASON=LEGACY_BACKUP_ROOT_INVALID' ||
+    [[ -n $(find "$redirect" -mindepth 1 -print -quit) ]]; then
+    fail 'legacy_backup_root_symlink_is_refused followed a redirected backup root'
+    return
+  fi
+  pass legacy_backup_root_symlink_is_refused
+}
+
+test_legacy_restore_reloads_systemd_after_daemon_reload() {
+  local root unit old_hash reloads
+  root=$(new_rollback_installer_fixture legacy-restore-reload daemon-reloaded legacy)
+  unit="$root/systemd/ramshared-cascade.service"
+  old_hash=$(sha256sum -- "$unit" | awk '{print $1}')
+  run_rollback_installer "$root" daemon-reloaded "$old_hash"
+  reloads=$(grep -cx 'daemon-reload' "$root/state/systemctl.log" || true)
+  if ! assert_exit legacy_restore_reloads_systemd_after_daemon_reload 1 ||
+    [[ $reloads != 2 ]] ||
+    [[ $(sha256sum -- "$unit" | awk '{print $1}') != "$old_hash" ]]; then
+    fail "legacy_restore_reloads_systemd_after_daemon_reload reloads=$reloads"
+    return
+  fi
+  pass legacy_restore_reloads_systemd_after_daemon_reload
+}
+
 test_release_manifest_and_modes_are_verified || true
 test_binary_match_rejects_stale_or_deleted_daemon || true
 test_relay_check_failure_blocks_readiness || true
@@ -841,6 +984,11 @@ test_sealed_nbd_bundle_and_lifecycle_wiring || true
 test_installer_manifest_and_unit_refusals_are_prewrite || true
 test_installer_active_enabled_or_unknown_units_refuse_without_writes || true
 test_installer_every_post_write_phase_rolls_back || true
+test_legacy_unit_migration_requires_exact_hash_and_restores_on_failure || true
+test_corrupt_legacy_backup_is_never_restored || true
+test_corrupt_published_legacy_backup_refuses_before_replacement || true
+test_legacy_backup_root_symlink_is_refused || true
+test_legacy_restore_reloads_systemd_after_daemon_reload || true
 
 if [[ $fail_count -ne 0 ]]; then
   printf 'FAIL Test-NbdProductPreflight passed=%s failed=%s\n' "$pass_count" "$fail_count" >&2


### PR DESCRIPTION
## Resumo

The NBD installer correctly refused the inactive legacy unit rather than
overwriting it. This patch adds an opt-in migration bound to that unit's exact
SHA-256.

The installer accepts only an inactive root-owned regular unit, writes its
immutable backup beneath a non-symlink root, rechecks that backup before both
replacement and restoration, and reloads systemd after rollback.

## Commits

| Commit | What | Why | Evidence |
| --- | --- | --- | --- |
| be78d2a | Safe legacy-unit migration | Unblock the sealed NBD install without blind overwrite | <details><summary>Validation and rollback</summary><br>22 named manufactured suites pass. One aggregate injects all 20 post-write frontiers. The suite covers backup corruption before replacement, backup-root symlink refusal, and post-daemon-reload restoration. Rollback trigger: any unit, backup, selector, or replacement mismatch.</details> |

## Issue

Closes #200

Refs #194

## Responsavel

@emersonbusson

## Labels

`bug`, `type:fix`, `area:mm`

## Validacao

- `bash scripts/safety/test-nbd-product-preflight.sh` — 22 suites, including 20 injected post-write frontiers.
- `bash -n scripts/safety/install-cascade-boot.sh scripts/safety/test-nbd-product-preflight.sh`.
- `./scripts/docs-check.sh`.
- `git diff --check`.

## Rollback trigger

Any legacy-unit hash, metadata, backup-root, backup, selector, replacement, or
systemd reload mismatch.
