### PR TITLE
fix(ci): accept stable module export projection

### DIFF
--- a/tools/ci/plan-rust-slice-coverage.mjs
+++ b/tools/ci/plan-rust-slice-coverage.mjs
@@ -840,6 +840,7 @@ export function isExactModuleExportGlueDifferential(
   const base = decodeUtf8(baseSource)
   const head = decodeUtf8(headSource)
   if (base === null || head === null || !isStructuralRustModule(base)) return false
+  if (base === head) return projectModuleExportGlue(head, declaration) !== null
   if (moduleExportGlueSpans(base, declaration)?.length !== 0) return false
   const projection = projectModuleExportGlue(head, declaration)
   return projection !== null && projection === base

--- a/tools/ci/plan-rust-slice-coverage.test.mjs
+++ b/tools/ci/plan-rust-slice-coverage.test.mjs
@@ -636,6 +636,36 @@ test('microsoft_native_vram_n3_module_export_glue_accepts_exact_projection_and_a
   }])
 })
 
+test('main_all_accepts_unchanged_exact_module_export_glue_projection', () => {
+  const entry = MICROSOFT_NATIVE_VRAM_N3_MODULE_EXPORT_GLUE_ENTRY
+  const stableSource = 'pub mod cascade;\npub mod priority;\npub mod n3_state;\npub mod nbd_readiness;\n'
+  const selected = selectCoverageEntries(
+    { schema_version: 2, entries: [entry] },
+    entry.files,
+    moduleExportGlueRoot(entry, stableSource),
+    {
+      baseRevision: 'e'.repeat(40),
+      readBaseFile: () => stableSource,
+    },
+  )
+  assert.equal(selected.ok, true)
+  assert.equal(selected.state, 'READY')
+  assert.deepEqual(selected.entries.map((item) => item.id), [entry.id])
+
+  const incompleteSource = 'pub mod cascade;\npub mod priority;\npub mod n3_state;\n'
+  const incomplete = selectCoverageEntries(
+    { schema_version: 2, entries: [entry] },
+    entry.files,
+    moduleExportGlueRoot(entry, incompleteSource),
+    {
+      baseRevision: 'f'.repeat(40),
+      readBaseFile: () => incompleteSource,
+    },
+  )
+  assert.equal(incomplete.ok, false)
+  assert.equal(incomplete.errors.some((item) => item.rule === 'module-export-glue-differential-not-proven'), true)
+})
+
 test('microsoft_native_vram_n3_module_export_glue_rejects_non_glue_changes_and_wrong_scope', () => {
   const entry = MICROSOFT_NATIVE_VRAM_N3_MODULE_EXPORT_GLUE_ENTRY
   const base = 'pub mod cascade;\npub mod priority;\n'


### PR DESCRIPTION
## Resumo

Corrige o falso bloqueio do `rust-slice-coverage` no push pós-merge para `main`. O modo `--all` agora aceita uma projeção estrutural N3 que permaneceu byte a byte inalterada e ainda contém exatamente as declarações canônicas; projeções incompletas ou mudanças semânticas continuam recusadas.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `65a7794` | Aceita projeção estrutural exata e inalterada no plano completo | O push para `main` revalidava uma alteração histórica como se tivesse ocorrido novamente | <details><summary>detalhes</summary>**Arquivos:** `tools/ci/plan-rust-slice-coverage.mjs`, `tools/ci/plan-rust-slice-coverage.test.mjs`<br>**Validação:** RED reproduzido; planner 30/30 e cobertura 88,46% linhas / 80,40% branches / 97,94% funções; plano `--all --run` completo PASS; CI contract/docs/diff PASS<br>**Risco/rollback:** reverter se uma projeção incompleta ou não estrutural for aceita</details> |

## Issue

Closes #203

## Responsavel

@emersonbusson

## Labels

`type:fix`, `area:core`

## Validacao

- [x] TDD RED: projeção estrutural exata e inalterada era recusada
- [x] Teste adversarial mantém recusa da projeção incompleta
- [x] Planner completo: 30/30; 88,46% linhas, 80,40% branches, 97,94% funções
- [x] Mesmo plano de `main`: `--all --base-revision 88077b1... --run` PASS
- [x] `node tools/ci/check-ci-contract.mjs --check` PASS
- [x] `./scripts/docs-check.sh` PASS
- [x] `git diff --check` PASS
- [x] SSDV3: N/A — correção no executor de gate; o contrato e o mapa existentes permanecem inalterados

## Rollback trigger

Reverter se o planner aceitar uma projeção sem uma das duas declarações canônicas N3 ou qualquer arquivo que deixe de ser um módulo Rust estritamente estrutural.