### PR TITLE
fix(ci): delegate protected release publication

### DIFF
--- a/.github/workflows/release-publication.yml
+++ b/.github/workflows/release-publication.yml
@@ -15,6 +15,11 @@ on:
         description: Successful Release Integrity workflow run ID
         required: true
         type: string
+      authorization:
+        description: Internal GitHub App delegation stage
+        required: true
+        default: request
+        type: string
 
 permissions: {}
 
@@ -23,9 +28,97 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  release-publication-admission:
+    name: release-publication-admission
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    env:
+      AUTHORIZATION_STAGE: ${{ inputs.authorization }}
+      DISPATCH_ACTOR: ${{ github.actor }}
+    steps:
+      - name: Admit only maintainer request or exact App delegation
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$AUTHORIZATION_STAGE" in
+            request) ;;
+            app)
+              test "$DISPATCH_ACTOR" = 'emersonbusson-ramshared-release[bot]'
+              ;;
+            *) exit 1 ;;
+          esac
+
+  release-publication-request:
+    name: release-publication-request
+    needs: release-publication-admission
+    if: github.ref == 'refs/heads/main' && inputs.authorization == 'request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
+      SOURCE_SHA: ${{ inputs.source_sha }}
+      INTEGRITY_RUN_ID: ${{ inputs.integrity_run_id }}
+    steps:
+      - name: Checkout trusted policy tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+
+      - name: Validate exact publication request identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          node tools/ci/check-release-publication.mjs \
+            --policy docs/governance/release-promotion.json \
+            --tag "$RELEASE_TAG" \
+            --source-sha "$SOURCE_SHA" \
+            --integrity-run-id "$INTEGRITY_RUN_ID"
+
+      - name: Require publication GitHub App credentials
+        shell: bash
+        env:
+          RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+          RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$RELEASE_APP_ID"
+          test -n "$RELEASE_APP_PRIVATE_KEY"
+
+      - name: Create publication request GitHub App token
+        id: request-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ramshared
+          permission-actions: write
+          permission-metadata: read
+
+      - name: Delegate exact protected publication to GitHub App
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.request-app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run release-publication.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "${{ github.event.repository.default_branch }}" \
+            -f tag="$RELEASE_TAG" \
+            -f source_sha="$SOURCE_SHA" \
+            -f integrity_run_id="$INTEGRITY_RUN_ID" \
+            -f authorization=app
+
   release-publication:
     name: release-publication
-    if: github.ref == 'refs/heads/main'
+    needs: release-publication-admission
+    if: github.ref == 'refs/heads/main' && inputs.authorization == 'app' && github.actor == 'emersonbusson-ramshared-release[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     environment: protected-release

--- a/TASK.md
+++ b/TASK.md
@@ -281,9 +281,9 @@ not invalidate the completed environment-boundary correction.
 **Owner role:** `ci-governance`.
 **Date:** `2026-08-14`.
 **Registered time:** `09:18:00`.
-**Updated time:** `09:40:00`.
+**Updated time:** `09:57:00`.
 **Source revision:** `361427a63cbeb2a8b0ecafb224adeecb0539af9b`.
-**Destinations:** issues `#215` and `#217`,
+**Destinations:** issues `#215`, `#217`, and `#219`,
 `.github/workflows/release-integrity.yml`,
 `.github/workflows/release-publication.yml`, `docs/governance/ci-contract.json`,
 `docs/specs/no-milestone/{ci-trust-and-release-integrity,release-promotion-publication}/`,
@@ -301,7 +301,13 @@ file inside each of the 15 workspace crates. No artifact or asset was
 published. Follow-up issue `#217` and TDD now require a deterministic,
 path-free merge of exactly the two packaged roots (`ramshared-cli` and
 `ramshared-wsl2d`) and independent
-manifest validation of both roots plus tag/SHA properties. Local Green,
-hosted checks, merge, recovered four-file integrity artifact, protected
-publication, and removal of the temporary Release Please recovery key remain
-pending.
+manifest validation of both roots plus tag/SHA properties. PR `#218` merged
+the correction as `a1ca095`, and recovery run `31789473586` emitted the exact
+four-file artifact; independent download revalidation passed the archive
+checksum, manifest, source binding, and deterministic two-root SBOM contract.
+The protected environment correctly prevents self-review. Issue `#219` now
+tracks an exact two-stage publication request: the maintainer request validates
+tag/SHA/run before a GitHub App dispatch, and only the exact App actor can
+enter the unchanged `protected-release` approval boundary. Local Green, hosted
+checks, merge, protected publication, and removal of the temporary Release
+Please recovery key remain pending.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -29,7 +29,7 @@ Process: [`SSDV3-PROMPTS.md`](SSDV3-PROMPTS.md) · rules: [`.claude/rules/ssdv3.
 | [`memory-broker`](specs/no-milestone/memory-broker/) | RamShared Memory Broker (Unified Final) | — | — | UNQUALIFIED |
 | [`microsoft-native-vram-memory-tier`](specs/no-milestone/microsoft-native-vram-memory-tier/) | Microsoft-native VRAM memory tier — host-authoritative N3 RFC | Microsoft-native N3 — Design | #196 | UNQUALIFIED |
 | [`public-repository-hygiene`](specs/no-milestone/public-repository-hygiene/) | Public repository candidate integrity | — | — | DONE |
-| [`release-promotion-publication`](specs/no-milestone/release-promotion-publication/) | Protected beta release promotion and publication | v0.9.0-beta.1 — WSL2 NBD | #195 | SPEC |
+| [`release-promotion-publication`](specs/no-milestone/release-promotion-publication/) | Protected beta release promotion and publication | v0.9.0-beta.1 — WSL2 NBD | #195, #219 | SPEC |
 | [`vram-reclaim-pressure-matrix`](specs/no-milestone/vram-reclaim-pressure-matrix/) | PRD - VRAM reclaim pressure matrix | — | — | UNQUALIFIED |
 | [`windows-autonomous-broker-service`](specs/no-milestone/windows-autonomous-broker-service/) | Autonomous Windows broker service packaging and supervision | — | #156 | UNQUALIFIED |
 | [`windows-storport-cuda-vram`](specs/no-milestone/windows-storport-cuda-vram/) | Windows StorPort I/O backed by CUDA VRAM | — | #28 | UNQUALIFIED |

--- a/docs/governance/ci-contract.json
+++ b/docs/governance/ci-contract.json
@@ -815,7 +815,9 @@
           "target_tag": "v0.9.0-beta.1",
           "manual_only": true,
           "credential": "github-app-required",
-          "draft_only": true
+          "draft_only": true,
+          "request_stage": "github-app-dispatch",
+          "delegated_actor": "emersonbusson-ramshared-release[bot]"
         }
       },
       "required_commands": [

--- a/docs/specs/no-milestone/release-promotion-publication/PRD.md
+++ b/docs/specs/no-milestone/release-promotion-publication/PRD.md
@@ -4,6 +4,7 @@ title: Protected beta release promotion and publication
 milestone: v0.9.0-beta.1 — WSL2 NBD
 issues:
   - 195
+  - 219
 ---
 
 # PRD — Protected beta release promotion and publication
@@ -70,8 +71,10 @@ remain unchanged. This PRD authorizes no publication while it is implemented.
 
 ### Inference / proposal
 
-- A protected manual dispatch can receive a tag, full source SHA, and an
-  integrity-run identifier, then verify them before it mutates a draft release.
+- A maintainer request can receive a tag, full source SHA, and integrity-run
+  identifier, validate them, and delegate the same immutable tuple to the
+  GitHub App. Only the App-authored run can enter protected publication, so
+  `prevent_self_review` retains a distinct human approval boundary.
 - A pinned GitHub App installation token is the appropriate authority for
   Release Please tag production and for the explicitly protected publication
   job. A missing App credential must stop before either producer executes.
@@ -91,11 +94,16 @@ Use one Day-0 release path with three stages and no `workflow_run` handoff.
    `v0.9.0-beta.1`, resolves the tag to its full commit SHA, builds and verifies
    the four-file candidate set, and uploads a bounded integrity artifact. It
    cannot publish a release asset.
-3. **Publication:** a maintainer explicitly dispatches a protected workflow
-   with the exact target tag, exact 40-hex source SHA, and integrity run ID.
-   It downloads only that named integrity artifact, validates every binding,
-   requires the existing Release Please draft, uploads only missing matching
-   files, and publishes the beta only after the exact set is complete.
+3. **Publication:** a maintainer explicitly dispatches a bounded request with
+   the exact target tag, exact 40-hex source SHA, and integrity run ID. That
+   stage validates the tuple before minting an Actions-write App token and
+   delegates the tuple to the same workflow. An admission job rejects a direct
+   user-selected App stage; only the exact App bot actor reaches the unchanged
+   `protected-release` environment, where the human reviewer approves the
+   deployment. The protected job downloads only the named integrity artifact,
+   validates every binding, requires the existing Release Please draft,
+   uploads only missing matching files, and publishes the beta only after the
+   exact set is complete.
 
 The manual action is idempotent: a completed matching beta returns `NO_CHANGE`
 or `PASS`; a wrong tag, SHA, asset name, byte count, hash, release mode, or
@@ -176,7 +184,7 @@ accepted only after those stronger bindings pass.
 | RF-1 | Keep one canonical PR entrypoint. | `ci.yml` remains `workflow_call`-only, `ci-contract.yml` remains the only pull-request caller, and a manufactured direct-plus-reusable topology fails. |
 | RF-2 | Require a GitHub App for tag production. | The release producer fails before Release Please when App credentials/token output are absent; source contains no PAT or `GITHUB_TOKEN` fallback for that token. |
 | RF-3 | Define the beta candidate exactly. | The policy accepts only `v0.9.0-beta.1`, a full 40-hex source SHA, and exactly the four listed public filenames. |
-| RF-4 | Separate integrity from publication. | Tag integrity has read-only permissions and no publish command; publication is `workflow_dispatch`, protected, and has no `workflow_run` trigger. |
+| RF-4 | Separate integrity from publication. | Tag integrity has read-only permissions and no publish command; publication is `workflow_dispatch`, the request delegates only after tuple validation, only the exact App actor reaches the protected job, and there is no `workflow_run` trigger. |
 | RF-5 | Bind artifact bytes to the exact tag SHA. | The manifest, detached checksum, SBOM, archive, dispatch SHA, checked-out tag, and integrity artifact agree or the workflow exits before release mutation. |
 | RF-6 | Publish idempotently. | Empty/matching draft state can advance; an already complete matching beta does not overwrite; mismatched, missing, or extra assets fail closed. |
 | RF-7 | Keep public asset scope exact. | A public beta contains only the four contract names; an internal bundle `SHA256SUMS` never becomes a separate public upload. |
@@ -203,10 +211,13 @@ accepted only after those stronger bindings pass.
    one full commit SHA, checks out that revision, builds the archive/SBOM,
    writes the detached checksum and manifest, validates all four files, and
    stores the candidate as an integrity artifact.
-3. A maintainer explicitly dispatches publication with the target tag, the
-   source SHA, and that integrity run ID. The protected job fetches the exact
-   tag revision and named artifact, validates it, then requires and resumes
-   the matching beta draft created by Release Please.
+3. A maintainer explicitly dispatches publication with the target tag, source
+   SHA, and integrity run ID. The request validates that tuple, then delegates
+   it with an Actions-write App token. Only the App-authored run reaches
+   `protected-release`; the maintainer reviews that distinct run and approves
+   it there. The protected job fetches the exact tag revision and named
+   artifact, validates it, then requires and resumes the matching beta draft
+   created by Release Please.
 4. It uploads only absent verified assets, verifies the remote inventory equals
    the four-file contract, and changes the draft to the public beta state.
 5. A repeat sees the same full inventory and exits without replacement.
@@ -249,20 +260,20 @@ Only matching `draft-empty`/`draft-partial` can advance; a matching
 | `node tools/ci/check-release-integrity.mjs --check …` | Validates tag/SHA, detached checksum, four-file contract, hashes, SBOM, and manifest without publication. |
 | `node tools/ci/check-release-publication.mjs …` | Classifies local candidate and remote release inventory as advance, no-change, or refusal without network mutation. |
 | `.github/workflows/release-integrity.yml` | Tag-triggered read-only candidate producer; uploads only the bounded integrity artifact. |
-| `.github/workflows/release-publication.yml` | Protected `workflow_dispatch` consumer; requires target tag, source SHA, and integrity run ID. |
+| `.github/workflows/release-publication.yml` | Two-stage `workflow_dispatch` consumer; a read-only maintainer request validates and delegates the exact tuple, while only the App-authored run can enter protected publication. |
 | `.github/workflows/release.yml` | GitHub-App-only Release Please tag/draft producer. |
 
 ## 9. Dependencies and risks
 
 | Dependency or risk | Mitigation |
 | --- | --- |
-| App credentials are not configured | Fail before producer side effects and record no fallback. |
+| App credentials are absent, rotated, or lack requested permissions | Fail before delegation or producer side effects and record no fallback. |
 | Tag can move after integrity | Dispatch supplies full SHA; both tag resolution and manifest binding must match it. |
 | Artifact transfer can select another run | Require an explicit numeric run ID and deterministic artifact name containing tag/SHA. |
 | Remote release already contains unknown data | Refuse rather than overwrite or delete it. |
 | Bundle build has an internal checksum | Generate and validate a detached archive checksum separately; upload only the contract quartet. |
 | Protected environment is remote configuration | Local source validation remains partial if its dated remote observation is absent or unsafe. |
-| GitHub Actions selected-action allowlist excludes `actions/create-github-app-token@*` | Production producer/publication is an explicit NO-GO even if the App secrets later exist. A repository administrator must allow the pinned GitHub-owned action; this task does not mutate remote settings. |
+| GitHub Actions selected-action allowlist later excludes the pinned App-token action | Producer/delegation fails before mutation; there is no token or workflow fallback. |
 
 ## 10. Implementation strategy
 
@@ -304,7 +315,8 @@ Only matching `draft-empty`/`draft-partial` can advance; a matching
    topology regression.
 3. Release Please cannot use a PAT or repository-token fallback.
 4. Read-only integrity and manual protected publication are separate, use no
-   `workflow_run`, and bind exact tag/SHA/artifact identity.
+   `workflow_run`, bind exact tag/SHA/artifact identity, and admit the protected
+   stage only when the exact App bot authored the delegated run.
 5. Candidate and release inventory logic accept only the exact asset quartet
    and are idempotent without overwrite.
 6. The target policy refuses historical `v0.8.0` and targets

--- a/docs/specs/no-milestone/release-promotion-publication/SPEC.md
+++ b/docs/specs/no-milestone/release-promotion-publication/SPEC.md
@@ -23,15 +23,14 @@
 
 ### Assumed-ready dependencies
 
-- The configured GitHub App will eventually have an installation on this
-  repository with the exact repository permissions required by its workflows.
+- The configured GitHub App is installed on this repository, its public bot
+  identity is `emersonbusson-ramshared-release[bot]`, and encrypted Actions
+  secrets supply its App ID and private key without a source or log copy.
 - The existing protected release environment remains a human-controlled remote
   gate. Local source cannot prove reviewer settings.
-- A read-only remote audit reports that the selected Actions allowlist excludes
-  `actions/create-github-app-token@*`. Consequently source validation can pass
-  while actual producer/publication remains a production NO-GO until a
-  repository administrator admits the pinned GitHub-owned action. This task
-  does not modify that remote setting.
+- The selected Actions policy admits the pinned App-token action used by the
+  successful Release Please producer. A later permission or allowlist
+  regression must fail before delegation rather than select another token.
 - GitHub-hosted `gh`, checkout, upload-artifact, and download-artifact actions
   are available only when the workflows are later run.
 
@@ -63,7 +62,7 @@
 | DT-2a | Release Please uses schema-supported, deprecated `release-as: 0.9.0-beta.1` together with `include-v-in-tag: true`, `versioning: prerelease`, `prerelease-type: beta`, `draft: true`, `prerelease: true`, `force-tag-creation: true`, and `skip-github-release: false`. The contract declares baseline manifest `0.8.0` and admits exactly that baseline or the generated target manifest `0.9.0-beta.1`; every other version, malformed object, or extra package entry is refused. The producer exits `NO_CHANGE` before Release Please when `v0.9.0-beta.1` already exists. | The checked-in baseline and generated release PR are consecutive authorized states of one exact transition. Binding both endpoints avoids rejecting the release PR while preventing an intermediate or future manifest from widening the one-shot target. |
 | DT-2b | Recovery from a merged release PR whose body lost Release Please metadata uses top-level `last-release-sha` pinned to exact `v0.8.0` merge `568e7b42b78b3c9edb8ea390cb4297142a37e412`. The configured generated header contains all seven mandatory repository PR headings and an explicit instruction that the machine-readable release notes below Release Please's separator remain intact. The checker rejects any other recovery SHA or incomplete header. Remove the recovery key after the exact beta tag/draft is verified. Named test: `release_producer_preserves_machine_body_and_bounds_recovery`. | The upstream recovery control bounds changelog collection after an accidentally merged bad release PR. Keeping governance metadata inside the configured header lets Release Please parse its own body after merge; replacing the whole body produced a false successful workflow with no tag and an oversized successor PR. |
 | DT-3 | `docs/governance/release-promotion.json` is schema version 1 and pins `target_tag` to `v0.9.0-beta.1`, channel `beta`, and the exact ordered public filenames: archive, detached archive SHA-256, SBOM, manifest. `v0.8.0` is not accepted. A future target changes this policy deliberately. | One concrete beta prevents historic or future tags from entering a new unreviewed path. |
-| DT-4 | `.github/workflows/release-integrity.yml` normally runs from the exact target tag and also admits a bounded manual recovery from `main` with required exact tag and 40-hex source SHA inputs. Both paths have `contents: read`, declare no deployment environment, check out the tag SHA, prove tag/SHA equality, build the candidate, merge exactly the two packaged cargo-cyclonedx roots into one deterministic path-free SBOM, write/validate the detached checksum and manifest, and upload the same named integrity artifact. The recovery run has an exact display title that binds both inputs; its merger tooling is copied from trusted `main` into `RUNNER_TEMP` before the immutable tag checkout. Integrity has no `workflow_run`, `gh release`, release-creation action, asset-upload action, or write permission. `.github/workflows/release-publication.yml` is the only publication path: protected `workflow_dispatch`, `environment: protected-release`, and a GitHub App token scoped to that job. Publication accepts a successful normal tag run bound by `head_sha`, or the exact successful recovery title from `main`; the downloaded manifest and four assets are validated identically. | A deterministic defect in an immutable tag's workflow must be recoverable without deleting or moving the tag. The recovery remains read-only and exact, while publication still needs explicit protected approval. |
+| DT-4 | `.github/workflows/release-integrity.yml` normally runs from the exact target tag and also admits a bounded manual recovery from `main` with required exact tag and 40-hex source SHA inputs. Both paths have `contents: read`, declare no deployment environment, check out the tag SHA, prove tag/SHA equality, build the candidate, merge exactly the two packaged cargo-cyclonedx roots into one deterministic path-free SBOM, write/validate the detached checksum and manifest, and upload the same named integrity artifact. The recovery run has an exact display title that binds both inputs; its merger tooling is copied from trusted `main` into `RUNNER_TEMP` before the immutable tag checkout. Integrity has no `workflow_run`, `gh release`, release-creation action, asset-upload action, or write permission. `.github/workflows/release-publication.yml` is the only publication path. A maintainer-authored `request` stage validates the exact tag/SHA/run tuple before using an Actions-write GitHub App token to dispatch the same workflow with `authorization=app`. A dedicated admission job fails a direct user-selected App stage; only actor `emersonbusson-ramshared-release[bot]` can reach `environment: protected-release`, preserving required human review with `prevent_self_review`. Publication accepts a successful normal tag run bound by `head_sha`, or the exact successful recovery title from `main`; the downloaded manifest and four assets are validated identically. Named test: `release_publication_request_delegates_only_to_exact_app_actor`. | A deterministic defect in an immutable tag's workflow must be recoverable without deleting or moving the tag. App-authored delegation separates the run initiator from the human environment reviewer without weakening the protected boundary or exposing the private key. |
 | DT-5 | Publication inputs are exact `tag`, 40-lowercase-hex `source_sha`, and decimal `integrity_run_id`. It downloads only `release-integrity-<tag>-<sha>`, verifies the Git tag resolves to `source_sha`, and requires the selected successful run to come from `.github/workflows/release-integrity.yml`. A normal push run must bind `head_sha` directly; a recovery run must be a `workflow_dispatch` from `main` whose exact display title binds the tag and source SHA. It then checks the manifest and all four local assets before classifying the remote release inventory. An exact published beta returns `NO_CHANGE`; an exact draft can advance; any wrong tag/SHA/channel/draft mode, missing/mismatched/extra asset, or ambiguous inventory is a refusal before mutation. It never deletes or overwrites assets. GitHub's release response `target_commitish` is not used as a SHA because it can be a branch name; a manufactured branch-value fixture proves it does not false-refuse. | Replay safety (#17) requires explicit matching, not an overwrite shortcut or a mutable branch field. |
 | DT-6 | The detached checksum file contains exactly one GNU `sha256sum` record for the archive, uses the archive basename, and is independently validated against the archive hash. The bundle’s internal `SHA256SUMS` is neither modeled nor uploaded as a public asset. | The public checksum must be independently consumable and cardinality must stay bounded. |
 
@@ -159,13 +158,17 @@
 
 **`.github/workflows/release-publication.yml`**
 
-- Purpose: protected manual beta publication consumer. It checks out the exact
-  dispatch SHA, downloads only the named integrity candidate, reruns the local
-  validators, requires the existing Release Please draft, asks the planner for
-  advance/no-change/refusal, and only then uses the App token to upload/publish
-  the release. It never creates a release.
+- Purpose: two-stage manual beta publication consumer. Its request stage
+  validates the exact tuple and delegates with Actions-write App authority; an
+  admission job rejects every non-App attempt to select the internal stage.
+  The App-authored protected job checks out the exact dispatch SHA, downloads
+  only the named integrity candidate, reruns the local validators, requires the
+  existing Release Please draft, asks the planner for
+  advance/no-change/refusal, and only then uses a contents-write App token to
+  upload/publish the release. It never creates a release.
 - RF / DT: RF-4 through RF-8; DT-2 through DT-6.
-- Required tests: `publication_workflow_is_protected_manual_exact_sha_only`.
+- Required tests: `publication_workflow_is_protected_manual_exact_sha_only`
+  and `release_publication_request_delegates_only_to_exact_app_actor`.
 - Cover target: N/A — protected orchestration; live dispatch remains
   environment-bound.
 - Kahneman: #16/#17.
@@ -307,6 +310,7 @@ retained.
 | same | same :: `release_integrity_recovery_is_exact_tag_sha_read_only` | static/refusal | #13/#16/#17 | N/A — workflow |
 | `tools/ci/merge-release-sboms.mjs` | `tools/ci/merge-release-sboms.test.mjs` :: `release_workspace_sbom_is_deterministic_path_free_and_binds_both_binaries` | unit/refusal | #9/#13/#17 | ≥80% Node |
 | `.github/workflows/release-publication.yml` | `tools/ci/check-ci-contract.test.mjs` :: `publication_workflow_is_protected_manual_exact_sha_only` | static | #16/#17 | N/A — protected E2E |
+| same | same :: `release_publication_request_delegates_only_to_exact_app_actor` | static/refusal | #13/#16/#17 | N/A — protected E2E |
 
 ## Validation checklist
 
@@ -322,11 +326,10 @@ retained.
   advancement and matching completed replay.
 - [x] `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/*.yml`
   exits zero.
-- [ ] `node tools/generate-docs-index.mjs --check` and `./scripts/docs-check.sh`
-  await the documentation owner's index/inventory reconciliation; this slice
-  does not modify those files. `git diff --check` remains local validation.
+- [x] `node tools/generate-docs-index.mjs --check`, `./scripts/docs-check.sh`,
+  and `git diff --check` admit the synchronized issue/frontmatter index and
+  current contract documentation.
 - [ ] No workflow dispatch, tag, draft/release, asset upload, remote setting,
   host action, or `IMPL.md` is claimed as complete from local source checks.
-- [ ] Production App-token execution remains NO-GO until the repository
-  selected-action allowlist admits `actions/create-github-app-token@*` and the
-  required App secrets exist; neither remote change is authorized here.
+- [x] The pinned App-token action and required encrypted App secrets are
+  configured; secret contents were not copied into source, logs, or artifacts.

--- a/tools/ci/check-ci-contract.mjs
+++ b/tools/ci/check-ci-contract.mjs
@@ -257,7 +257,8 @@ function validateReleasePublicationPolicy(gate, policy, errors) {
   if (!isObject(publication) || publication.environment !== RELEASE_ENVIRONMENT ||
       publication.promotion_policy !== RELEASE_PROMOTION_POLICY || publication.target_tag !== RELEASE_TARGET_TAG ||
       publication.manual_only !== true || publication.credential !== 'github-app-required' ||
-      publication.draft_only !== true) {
+      publication.draft_only !== true || publication.request_stage !== 'github-app-dispatch' ||
+      publication.delegated_actor !== 'emersonbusson-ramshared-release[bot]') {
     errors.push(finding(gate.id, 'release-publication-policy-invalid'))
   }
 }
@@ -1092,11 +1093,14 @@ function releasePublicationWorkflowFindings(gate, text, block) {
     observed.push('release-publication-runner-invalid')
   }
   if (fieldValue(block, 'environment') !== policy.environment) observed.push('release-publication-environment-mismatch')
-  if (!['tag', 'source_sha', 'integrity_run_id'].every((input) => workflowDispatchStringInput(text, input))) {
+  if (!['tag', 'source_sha', 'integrity_run_id', 'authorization']
+    .every((input) => workflowDispatchStringInput(text, input))) {
     observed.push('release-publication-dispatch-input-invalid')
   }
   const markers = [
     "if: github.ref == 'refs/heads/main'",
+    "inputs.authorization == 'app'",
+    `github.actor == '${policy.delegated_actor}'`,
     'ref: ${{ github.event.repository.default_branch }}',
     'RELEASE_TAG: ${{ inputs.tag }}',
     'SOURCE_SHA: ${{ inputs.source_sha }}',
@@ -1120,7 +1124,21 @@ function releasePublicationWorkflowFindings(gate, text, block) {
     'gh release upload "$RELEASE_TAG" "artifacts/release/$asset"',
     'gh release edit "$RELEASE_TAG" --draft=false --prerelease',
   ]
+  const delegationMarkers = [
+    'release-publication-admission:',
+    'needs: release-publication-admission',
+    'case "$AUTHORIZATION_STAGE" in',
+    '*) exit 1 ;;',
+    "test \"$DISPATCH_ACTOR\" = 'emersonbusson-ramshared-release[bot]'",
+    'release-publication-request:',
+    "inputs.authorization == 'request'",
+    'default: request',
+    'permission-actions: write',
+    'gh workflow run release-publication.yml',
+    '-f authorization=app',
+  ]
   if (!markers.every((marker) => joined.includes(marker)) ||
+      !delegationMarkers.every((marker) => text.includes(marker)) ||
       joined.indexOf('Validate exact protected dispatch identity') > joined.indexOf('Create publication GitHub App token')) {
     observed.push('release-publication-command-mismatch')
   }

--- a/tools/ci/check-ci-contract.test.mjs
+++ b/tools/ci/check-ci-contract.test.mjs
@@ -950,6 +950,26 @@ test('publication_workflow_is_protected_manual_exact_sha_only', () => {
   assert.doesNotMatch(workflow, /workflow_run|pull_request|^  push:|--clobber/i)
 })
 
+test('release_publication_request_delegates_only_to_exact_app_actor', () => {
+  const publicationPath = path.join(ROOT, '.github', 'workflows', 'release-publication.yml')
+  const workflow = readFileSync(publicationPath, 'utf8')
+  assert.match(workflow, /^      authorization:\s*$/m)
+  assert.match(workflow, /^        default: request\s*$/m)
+  assert.match(workflow, /^  release-publication-admission:\s*$/m)
+  assert.match(workflow, /case "\$AUTHORIZATION_STAGE" in/)
+  assert.match(workflow, /\*\) exit 1 ;;/)
+  assert.match(workflow, /test "\$DISPATCH_ACTOR" = 'emersonbusson-ramshared-release\[bot\]'/)
+  assert.match(workflow, /^  release-publication-request:\s*$/m)
+  assert.equal(workflow.match(/needs: release-publication-admission/g)?.length, 2)
+  assert.match(workflow, /inputs\.authorization == 'request'/)
+  assert.match(workflow, /permission-actions: write/)
+  assert.match(workflow, /gh workflow run release-publication\.yml/)
+  assert.match(workflow, /-f authorization=app/)
+  assert.match(workflow, /inputs\.authorization == 'app'/)
+  assert.match(workflow, /github\.actor == 'emersonbusson-ramshared-release\[bot\]'/)
+  assert.equal(workflow.match(/environment: protected-release/g)?.length, 1)
+})
+
 test('release_promotion_node_coverage_is_wired_into_the_canonical_pr_caller', () => {
   const workflow = readFileSync(path.join(ROOT, '.github', 'workflows', 'ci-contract.yml'), 'utf8')
   for (const module of [


### PR DESCRIPTION
## Resumo

Delega a solicitação de publicação protegida para a GitHub App somente após validar a tupla exata de tag, SHA e execução de integridade. A execução delegada só entra em `protected-release` quando o ator é `emersonbusson-ramshared-release[bot]`, preservando o revisor humano e `prevent_self_review` sem expor a chave privada.

## Commits

| Commit | What was done | Why it was done | Details |
| --- | --- | --- | --- |
| [`73b9a9a`](https://github.com/emersonbusson/ramshared/commit/73b9a9a) | Added exact App-authored publication delegation and synchronized its executable contract. | The maintainer cannot approve a run they initiated while `prevent_self_review` is enabled. | <details><summary>Context, impact, validation, and rollback</summary><br>Introduces a bounded admission job, validates the immutable publication tuple before minting an Actions-write App token, refuses unknown stages and non-App delegated actors, retains the single protected environment, updates PRD/SPEC/TASK/index/contract, and adds the named TDD refusal. Local validation: 65/65 contract tests; 91.97% lines, 85.33% branches, 98.69% functions; strict contract PASS; actionlint PASS; docs-check PASS; diff-check PASS. Risk is limited to publication orchestration. Roll back if a non-App actor reaches the protected job or invalid authorization succeeds.</details> |

## Issue

Closes #219

## Responsavel

@emersonbusson

## Labels

`type:fix`, `area:docs`

## Validacao

- [x] Named TDD delegation/admission test
- [x] Full CI-contract suite: 65/65
- [x] Node coverage: 91.97% lines, 85.33% branches, 98.69% functions
- [x] `node tools/ci/check-ci-contract.mjs --check-local`
- [x] actionlint 1.7.7 over all workflows
- [x] `node tools/generate-docs-index.mjs --check`
- [x] `./scripts/docs-check.sh`
- [x] `git diff --check`

## Rollback trigger

Revert if any actor other than `emersonbusson-ramshared-release[bot]` reaches the `protected-release` publication job, an unknown authorization stage exits successfully, or the request can dispatch before exact tag/SHA/run validation.