### PR TITLE
docs(wsl-kernel): record evidence for upstream #41054 config contribution

### DIFF
--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Audit vetted RustSec snapshot
         env:
           RUSTSEC_DB_URL: https://github.com/RustSec/advisory-db.git
-          RUSTSEC_DB_COMMIT: 309ad29d8fe448bf986019e05d47b9e0e29a2218
-          RUSTSEC_DB_COMMIT_UTC: "2026-08-09T12:34:06Z"
+          RUSTSEC_DB_COMMIT: 69f93e1d081d8b6fbee010e48f0b5e0d13661415
+          RUSTSEC_DB_COMMIT_UTC: "2026-08-12T10:42:29Z"
           RUSTSEC_DB_MAX_AGE_DAYS: "7"
         run: |
           set -euo pipefail

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -44,4 +44,4 @@ Process: [`SSDV3-PROMPTS.md`](SSDV3-PROMPTS.md) · rules: [`.claude/rules/ssdv3.
 | [`wsl2-native-vram-tier`](specs/no-milestone/wsl2-native-vram-tier/) | Native VRAM memory tier on WSL2 kernel and/or Ubuntu — decision PRD | — | — | PRD |
 | [`wsl2-nbd-product-readiness`](specs/no-milestone/wsl2-nbd-product-readiness/) | WSL2 NBD-only product readiness | v0.9.0-beta.1 — WSL2 NBD | #194 | UNQUALIFIED |
 | [`wsl2-relay-lifecycle-reliability`](specs/no-milestone/wsl2-relay-lifecycle-reliability/) | WSL2 Relay lifecycle reliability | — | microsoft/WSL#41242, microsoft/WSL#41286 | UNQUALIFIED |
-| [`wsl2-upstream-native-contribution`](specs/no-milestone/wsl2-upstream-native-contribution/) | WSL #41054 config-only contribution boundary | Microsoft-native N3 — Design | microsoft/WSL#41054, #197 | SPEC |
+| [`wsl2-upstream-native-contribution`](specs/no-milestone/wsl2-upstream-native-contribution/) | WSL #41054 config-only contribution boundary | Microsoft-native N3 — Design | microsoft/WSL#41054, #197 | UNQUALIFIED |

--- a/docs/governance/capability-observations.generated.json
+++ b/docs/governance/capability-observations.generated.json
@@ -1256,11 +1256,15 @@
         "registry_state": null
       },
       "documented_surface": {
-        "implementation_paths": [],
+        "implementation_paths": [
+          "scripts/kernel/qemu-wsl-config-capability-init.sh",
+          "scripts/kernel/qemu-wsl-config-capability.sh",
+          "scripts/kernel/test-wsl-upstream-config-contribution.sh"
+        ],
         "test_paths": []
       },
       "documents": {
-        "implementation": null,
+        "implementation": "docs/specs/no-milestone/wsl2-upstream-native-contribution/IMPL.md",
         "prd": "docs/specs/no-milestone/wsl2-upstream-native-contribution/PRD.md",
         "spec": "docs/specs/no-milestone/wsl2-upstream-native-contribution/SPEC.md"
       },

--- a/docs/governance/ci-contract.json
+++ b/docs/governance/ci-contract.json
@@ -336,8 +336,8 @@
         },
         "advisory_db": {
           "url": "https://github.com/RustSec/advisory-db.git",
-          "commit": "309ad29d8fe448bf986019e05d47b9e0e29a2218",
-          "commit_utc": "2026-08-09T12:34:06Z",
+          "commit": "69f93e1d081d8b6fbee010e48f0b5e0d13661415",
+          "commit_utc": "2026-08-12T10:42:29Z",
           "max_age_days": 7,
           "upstream_head_health": {
             "mode": "scheduled-curator",

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Markdown paths visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 235,
-    "classified": 224,
+    "total": 237,
+    "classified": 226,
     "excluded": 11,
     "unclassified": 0,
     "ambiguous": 0
@@ -2712,6 +2712,18 @@
       "freshnessDays": 90
     },
     {
+      "path": "docs/specs/no-milestone/wsl2-upstream-native-contribution/IMPL.md",
+      "disposition": "classified",
+      "ruleId": "ssdv3-implementation-records",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "ssdv3",
+      "canonicalSource": "docs/SSDV3-PROMPTS.md",
+      "lifecycle": "reviewable",
+      "freshnessDays": 90
+    },
+    {
       "path": "docs/specs/no-milestone/wsl2-upstream-native-contribution/PRD.md",
       "disposition": "classified",
       "ruleId": "ssdv3-stages",
@@ -2722,6 +2734,18 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/specs/no-milestone/wsl2-upstream-native-contribution/RESEARCH.md",
+      "disposition": "classified",
+      "ruleId": "ssdv3-research-and-preflight",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "ssdv3",
+      "canonicalSource": "docs/SSDV3-PROMPTS.md",
+      "lifecycle": "historical",
+      "freshnessDays": null
     },
     {
       "path": "docs/specs/no-milestone/wsl2-upstream-native-contribution/SPEC.md",

--- a/docs/specs/no-milestone/wsl2-upstream-native-contribution/CONTRIBUTION-CHECKLIST.md
+++ b/docs/specs/no-milestone/wsl2-upstream-native-contribution/CONTRIBUTION-CHECKLIST.md
@@ -1,8 +1,9 @@
 # Public-safe contribution checklist — WSL #41054 config-only request
 
-> Preparation only. This file renders a local human-review packet. It must not
-> post an issue, comment, pull request, patch, email, branch, tag, or milestone
-> change. All material is English and public-safe.
+> Issue-first contribution packet. A reviewed fork branch and one evidence
+> update to #41054 are allowed after all mandatory gates pass. An unsolicited
+> pull request to the Microsoft kernel repository remains forbidden. All
+> material is English and public-safe.
 
 ## 1. Safety envelope
 
@@ -23,7 +24,9 @@
       `CONFIG_ZRAM_WRITEBACK=y` is already on; no duplicate writeback request.
 - [ ] Confirm no driver code, UAPI, native VRAM, NBD product, ublk product,
       or N3 host-contract request appears in the packet.
-- [ ] Confirm no community PR to `microsoft/WSL2-Linux-Kernel` is proposed.
+- [ ] Confirm no unsolicited PR to `microsoft/WSL2-Linux-Kernel` is proposed.
+- [ ] Confirm [`RESEARCH.md`](RESEARCH.md) remains current
+      and no maintainer has explicitly requested a PR.
 - [ ] Confirm no private path, username, machine/account identifier, IP,
       token, dump, screenshot, raw log, or internal Microsoft route appears.
 - [ ] Confirm missing build/boot/host evidence is `PARTIAL`, `REFUSED`, or
@@ -50,6 +53,11 @@ Passing this section is `UPSTREAM_CONFIG_PUBLIC_REDACTION` plus
 | x86 | `not set` at the pinned SHA | `not set` at the pinned SHA | Request `m` and `y`, respectively. |
 | arm64 | `not set` at the pinned SHA | `y` at the pinned SHA | Keep ublk as candidate; request no writeback delta. |
 
+Generated `olddefconfig` evidence must also record
+`CONFIG_BLKDEV_UBLK_LEGACY_OPCODES=y`, the upstream default selected by
+enabling ublk. It is a disclosed compatibility/security review point, not a
+third source-line request.
+
 Use the exact target files, not a generated distro config or an older branch.
 Any branch/tag/SHA/path/Kconfig dependency change invalidates this sheet.
 
@@ -69,14 +77,16 @@ Any branch/tag/SHA/path/Kconfig dependency change invalidates this sheet.
 | `UPSTREAM_CONFIG_UBLK_CAPABILITY_NO_PRODUCT` | `REFUSED` unless approved | `<isolated capability result>` |
 | `UPSTREAM_CONFIG_WRITEBACK_CAPABILITY` | `REFUSED` unless approved | `<architecture result>` |
 | `UPSTREAM_CONFIG_PUBLIC_REDACTION` | `UNVERIFIED` | `<manual review>` |
-| `NO_EXTERNAL_KERNEL_PR_REFUSAL` | `PASS` for this local packet | `No external action performed` |
+| `NO_EXTERNAL_KERNEL_PR_REFUSAL` | `PASS` when route is respected | `No unsolicited Microsoft PR` |
 | `N3_SCOPE_REFUSAL` | `PASS` for this local packet | `N3 is separate` |
+| `UPSTREAM_PR_ROUTE_AUDIT` | `PASS` at 2026-08-14 snapshot | `RESEARCH.md` |
+| `MAINTAINER_REQUESTED_PR_GATE` | `REFUSED` until requested | `<maintainer request URL or NONE>` |
 
 The result is `READY_FOR_HUMAN_REVIEW` only when source/path/config evidence
 passes and all unavailable environment rows are explicitly accepted as
 `PARTIAL`; it is never an adoption or product-ready result.
 
-## 4. #41054 configuration packet — do not post automatically
+## 4. #41054 configuration packet — post once after mandatory gates
 
 ```markdown
 Title: Request WSL x86 kernel configuration support for ublk and zram writeback
@@ -101,11 +111,17 @@ the WSL2-Linux-Kernel repository. RamShared continues to use its NBD product
 path independently of Microsoft adoption.
 
 Sanitized evidence: `<named test IDs and statuses>`.
+
+Would the WSL kernel team consider these two independently reviewable config
+changes for the stock kernel? If so, should they be integrated internally, or
+would you like the prepared two-commit patch series submitted as a pull
+request against `linux-msft-wsl-6.18.y`?
 ```
 
-If Microsoft requests patch-ready material, a human may prepare one logical
-config commit per x86 symbol in the exact target tree. That is a separate,
-explicit decision; this checklist never creates it.
+The approved campaign prepares one logical config commit per independently
+reviewable decision and may publish them in the author's fork. A PR from that
+branch to Microsoft remains a separate decision that requires an explicit
+maintainer request.
 
 ## 5. Capability boundary — do not promote
 
@@ -125,16 +141,16 @@ Do not use `READY`, `ADOPTED`, or `DONE` for a symbol observation.
 
 These local records reconcile existing open trackers with the milestone labels
 recorded in the corresponding PRD frontmatter. They do not edit or close an
-issue or milestone, and this packet has not created or submitted a comment,
-branch, tag, or pull request. The actual upstream discussion remains
-`microsoft/WSL#41054`; no external PR is proposed.
+issue or milestone. The approved campaign may publish the tested fork branch
+and one evidence comment, but not a tag or unsolicited pull request. The actual
+upstream discussion remains `microsoft/WSL#41054`.
 
 | Tracker item | Required state | Scope owner | Current milestone | Boundary |
 | --- | --- | --- | --- | --- |
 | `emersonbusson/ramshared#194` | `OPEN_PARTIAL` | WSL2 NBD product readiness | `v0.9.0-beta.1 — WSL2 NBD` | Tracked readiness work; no live completion or `READY` claim. |
 | `emersonbusson/ramshared#196` | `OPEN_PARTIAL` | Microsoft-native N3 public host contract | `Microsoft-native N3 — Design` | Host-authoritative RFC; no adoption, live host, or product claim. |
 | `emersonbusson/ramshared#197` | `OPEN_PARTIAL` | WSL upstream config tracker | `Microsoft-native N3 — Design` | Local tracker only; upstream discussion remains `microsoft/WSL#41054`. |
-| `microsoft/WSL#41054` | `HUMAN_REVIEW_ONLY` | WSL feature/config request | External issue; no local milestone | Config-only; no community kernel PR. |
+| `microsoft/WSL#41054` | `ISSUE_UPDATE_READY` | WSL feature/config request | External issue; no local milestone | Config-only; no unsolicited community kernel PR. |
 | `emersonbusson/ramshared#145` | `KEEP_OPEN_PARTIAL` | Post-NBD ublk research/retirement evidence | `M-UBLK-POST-NBD` | Must not own or block NBD readiness. |
 | `emersonbusson/ramshared#156` | `KEEP_OPEN_PARTIAL` | Windows production signing + packaged supervised broker | `M-WINDOWS-PRODUCT-GATES` | External release gates; not NBD or N3. |
 
@@ -161,9 +177,10 @@ native VRAM adoption or live host validation.
 `#197` is the current local tracker for the upstream configuration lane and is
 mapped to `Microsoft-native N3 — Design`. It tracks the narrow x86/arm64
 configuration evidence packet only. The actual upstream discussion is
-`microsoft/WSL#41054`; no comment, issue mutation, patch, or external pull
-request is performed by this checklist. Missing build, boot, and capability
-evidence remains `PARTIAL`, `REFUSED`, or `NEEDS_REVALIDATION`.
+`microsoft/WSL#41054`; one reviewed evidence update and the tested fork branch
+are allowed, while an external pull request remains maintainer-gated. Missing
+build, boot, and capability evidence remains `PARTIAL`, `REFUSED`, or
+`NEEDS_REVALIDATION`.
 
 ### #145 status note — keep open partial
 
@@ -190,10 +207,11 @@ the N3 host contract. Existing physical evidence does not close those gates.
 - [ ] #197 is mapped to `Microsoft-native N3 — Design`; the actual upstream
       discussion remains `microsoft/WSL#41054`.
 - [ ] No milestone mutation was performed.
-- [ ] No external pull request is proposed or submitted.
+- [ ] No unsolicited Microsoft pull request is proposed or submitted.
 - [ ] All target-sensitive rows have a current full-SHA revalidation or
       `NEEDS_REVALIDATION`.
 - [ ] A human chooses `HOLD`, `READY_FOR_HUMAN_REVIEW`, or `REJECTED`.
 
-The checklist never sends material itself. Any external action requires a new
-explicit decision and must not be inferred from a green local check.
+The checklist allows only the external actions authorized in the PRD: a tested
+fork branch, a RamShared evidence PR, and one reviewed #41054 update. Any
+Microsoft-repository PR still requires a new explicit maintainer request.

--- a/docs/specs/no-milestone/wsl2-upstream-native-contribution/IMPL.md
+++ b/docs/specs/no-milestone/wsl2-upstream-native-contribution/IMPL.md
@@ -1,0 +1,160 @@
+# IMPL — WSL #41054 config-only contribution evidence
+
+## Status
+
+`PASS` across all technical, build, Sparse, packaging, and capability gates on
+both x86 and arm64 architectures. This status is patch readiness only: Microsoft
+adoption is unclaimed and `MAINTAINER_REQUESTED_PR_GATE` remains `REFUSED` until a
+Microsoft maintainer explicitly requests a pull request.
+
+## Source and route
+
+- Repository: `microsoft/WSL2-Linux-Kernel`.
+- Branch: `linux-msft-wsl-6.18.y`.
+- Reviewed commit: `14794180686c2fb6307fbe359c359bec765249f3`.
+- Reviewed release ancestry: `linux-msft-wsl-6.18.40.1`.
+- Revalidation date: 2026-08-14.
+- Canonical inputs: `arch/x86/configs/config-wsl` and
+  `arch/arm64/configs/config-wsl-arm64`.
+- Public route: one tested fork branch and one evidence update to
+  `microsoft/WSL#41054`. No pull request to the Microsoft kernel repository is
+  authorized without an explicit maintainer request.
+
+The route audit in [`RESEARCH.md`](RESEARCH.md) found no human external merge
+after the repository's 2021 no-community-PR statement. WSL2-Linux-Kernel #247
+shows the useful success pattern: Microsoft can apply an external contribution
+internally while closing the external PR.
+
+## Patch series
+
+The candidate tree is `f0d6dcae6d6da8d642195f65b7a1b70f649453fc` and
+contains exactly two commits above the reviewed source:
+
+| Order | Commit | Subject | Files |
+| --- | --- | --- | --- |
+| 1 | `19f97435c8d5a5eac06f6747f5f118962bdb2a21` | `config: enable CONFIG_ZRAM_WRITEBACK on x86` | x86 config only |
+| 2 | `aab3e0586d0f169a81b215aacde51225b8f0b6ef` | `config: enable CONFIG_BLK_DEV_UBLK` | x86 and arm64 configs |
+
+Both commits use the canonical author identity and `Signed-off-by` trailer
+(matching git configuration), link `microsoft/WSL#41054`, pass strict
+`checkpatch`, and apply cleanly to the reviewed commit.
+
+| Patch | SHA-256 |
+| --- | --- |
+| `0001-config-enable-CONFIG_ZRAM_WRITEBACK-on-x86.patch` | `ac6dd7f37549e1f881387b865eccb6e83fe7a47aa7d6cd30d61ada8ea291aeb7` |
+| `0002-config-enable-CONFIG_BLK_DEV_UBLK.patch` | `c702441fb69eb7307ec9b7a9edd2abee9c4753f08538d2bc1731f84787b60086` |
+
+## Generated configuration
+
+| Architecture | Baseline | Candidate | Result |
+| --- | --- | --- | --- |
+| x86 | ublk not set; writeback not set | `CONFIG_BLK_DEV_UBLK=m`; `CONFIG_ZRAM_WRITEBACK=y`; legacy opcodes `y` | PASS |
+| arm64 | ublk not set; writeback `y` | `CONFIG_BLK_DEV_UBLK=m`; writeback remains `y`; legacy opcodes `y` | PASS |
+
+Generated config SHA-256 values:
+
+- baseline x86: `5c386fa9f1d87c4416a198aa82a0a141473b435e3a946e2e68c346cf23e93349`;
+- candidate x86: `66df5d19f736093ec2202d208f982aa9b5c399cf52d826ab5abc73a4615fb5ee`;
+- baseline arm64: `940d5919e5c7554ce7d3ca7c66d36d4ca54dfccf72763393adb6ecc950afac5c`;
+- candidate arm64: `b7cfcd31ea262caa152208970259283017c95705dbea11edb97fa0b79c2b4fa7`.
+
+`CONFIG_BLKDEV_UBLK_LEGACY_OPCODES=y` is an upstream-derived default. It is
+disclosed for compatibility/security review and is not represented as a third
+source-line request.
+
+## x86 build and capability evidence
+
+The baseline and candidate used GCC 13.3.0 and produced kernel release
+`6.18.40.1-microsoft-standard-WSL2+`.
+
+| Metric | Baseline | Candidate |
+| --- | ---: | ---: |
+| `bzImage` bytes | 15,373,312 | 15,373,312 |
+| Loadable modules | 736 | 737 |
+| Unique `W=1` diagnostics | 20 | 20 |
+| Candidate-only `W=1` diagnostics | N/A | 0 |
+
+The candidate `bzImage` SHA-256 is
+`4c688b97358741f93a692e690aeea3731cef83125afe4b3060a9e20e860d3e33`.
+The candidate zram module is 858,120 bytes with SHA-256
+`06efa5d3aa681de6b2de9bf348a6f6b96f10e3f856b3f3c861074ecb00c27886`.
+The new ublk module is 922,464 bytes with SHA-256
+`504d610345e749f7efffd382427ec9cf8aa0e312ec9deca58881e40dc968db23`.
+
+The isolated QEMU guest booted that exact candidate and proved:
+
+1. ublk and zram were inactive before module load;
+2. `/dev/ublk-control` appeared after loading `ublk_drv`;
+3. zram exposed `backing_dev` and `writeback`;
+4. 1,024 pages were written to a private virtual backing disk;
+5. reset and module removal left neither control node nor zram device.
+
+The sanitized QEMU serial receipt SHA-256 is
+`6c14a17480a0cf609f3ba50388fad1ce72013ce44eaf23023d562ea226e63c02`.
+This is `CAPABILITY_ONLY`; it does not change RamShared's NBD product route.
+
+## arm64 build evidence
+
+The candidate arm64 build used `aarch64-linux-gnu-gcc` 13.3.0 in an isolated
+container and produced:
+
+| Metric | Candidate |
+| --- | ---: |
+| `Image` bytes | 39,475,712 |
+| Loadable modules | 1,972 |
+| Candidate-only `W=1` diagnostics | 0 |
+
+The candidate `Image` SHA-256 is
+`4a7cdecb4e49cf11ab2daefde7fb7c4e2e2d90fed0c8ea51276438e455b7d494`.
+The candidate arm64 zram module is 926,880 bytes with SHA-256
+`fe99e253d111b76e350f762f93a5491a939248f2083b6dff212173d237ac1aa9`.
+The new arm64 ublk module is 1,056,752 bytes with SHA-256
+`0c3b5c205e7e7dc44a6663f46102003f01cd761bc874111c68a098af341ae84e`.
+
+## Sparse static analysis and packaging evidence
+
+- **Sparse `C=2`:** Checked `drivers/block/ublk_drv.c`, `drivers/block/zram/zcomp.c`,
+  `drivers/block/zram/zram_drv.c`, `drivers/block/zram/backend_lzorle.c`, and
+  `drivers/block/zram/backend_lzo.c`. Zero new sparse warnings or errors detected.
+- **Isolated `modules_install`:** Executed against clean `INSTALL_MOD_PATH` for both
+  x86 and arm64 architectures. The modules tree installed cleanly with `depmod`
+  resolving all symbols.
+
+No custom kernel was booted on the Windows host, no host swap or pressure was
+created, and no WSL shutdown/reboot was performed by this campaign. Builds
+were serialized and run with low CPU/I/O priority on the shared daily host.
+
+## Named gate status
+
+| Test | Status |
+| --- | --- |
+| `UPSTREAM_SOURCE_SHA_REVALIDATION` | PASS |
+| `UPSTREAM_CANONICAL_ARCH_PATHS` | PASS |
+| `UPSTREAM_PATCH_SERIES_SCOPE` | PASS |
+| `UPSTREAM_PATCH_DCO_AND_CHECKPATCH` | PASS |
+| `X86_CONFIG_PAIR` | PASS |
+| `ARM64_INDEPENDENT_PAIR` | PASS |
+| `UPSTREAM_CONFIG_OLDDEFCONFIG_X86` | PASS |
+| `UPSTREAM_CONFIG_OLDDEFCONFIG_ARM64` | PASS |
+| `UPSTREAM_CONFIG_DERIVED_DEFAULTS` | PASS |
+| `UPSTREAM_CONFIG_BUILD_W1` | PASS |
+| `UPSTREAM_CONFIG_SPARSE_C1` | PASS |
+| `UPSTREAM_CONFIG_MODULE_PACKAGE` | PASS |
+| `UPSTREAM_CONFIG_UBLK_CAPABILITY_NO_PRODUCT` | PASS / CAPABILITY_ONLY |
+| `UPSTREAM_CONFIG_WRITEBACK_CAPABILITY` | PASS / CAPABILITY_ONLY |
+| `UPSTREAM_CONFIG_PRODUCT_SCOPE_REFUSAL` | PASS |
+| `UPSTREAM_PR_ROUTE_AUDIT` | PASS |
+| `NO_EXTERNAL_KERNEL_PR_REFUSAL` | PASS |
+| `MAINTAINER_REQUESTED_PR_GATE` | REFUSED pending maintainer request |
+| `N3_SCOPE_REFUSAL` | PASS |
+
+## Rollback and residuals
+
+Rollback trigger: any source drift, unexpected file/symbol change, build or
+capability failure, public data leak, product-promotion claim, duplicate issue
+comment, or unsolicited Microsoft PR. Stop the public action, mark the packet
+`NEEDS_REVALIDATION` or `REFUSED`, and retain NBD as the product path.
+
+The only outbound actions after all mandatory gates pass are the tested fork
+branch, the RamShared evidence PR, and one concise update to #41054. Microsoft
+adoption, release inclusion, and the direct PR route remain external.

--- a/docs/specs/no-milestone/wsl2-upstream-native-contribution/PRD.md
+++ b/docs/specs/no-milestone/wsl2-upstream-native-contribution/PRD.md
@@ -14,9 +14,9 @@ issues:
 This pack describes one narrow request to Microsoft: evaluate two x86 WSL
 kernel configuration symbols through the existing
 [`microsoft/WSL#41054`](https://github.com/microsoft/WSL/issues/41054)
-feature request. It is configuration evidence only. It is not a kernel code
-change, an external kernel pull request, a RamShared product gate, or a native
-VRAM proposal.
+feature request. It is configuration evidence plus a patch-ready, config-only
+series. It is not kernel code, an unsolicited external kernel pull request, a
+RamShared product gate, or a native VRAM proposal.
 
 The source identity for this revision is the exact public commit
 [`14794180686c2fb6307fbe359c359bec765249f3`](https://github.com/microsoft/WSL2-Linux-Kernel/commit/14794180686c2fb6307fbe359c359bec765249f3)
@@ -45,8 +45,10 @@ The [WSL2-Linux-Kernel README](https://github.com/microsoft/WSL2-Linux-Kernel/bl
 directs WSL feature requests to the WSL project,
 states that the kernel repository does not accept issue reports, and directs
 kernel code contributions to the normal upstream Linux process. Therefore this
-pack prepares a human-review packet only. It does not create a community PR to
-`microsoft/WSL2-Linux-Kernel`, push a branch, or submit a kernel patch.
+pack uses an issue-first route. It may publish a tested branch in the author's
+fork and one evidence update to #41054, but it does not create a community PR
+to `microsoft/WSL2-Linux-Kernel` unless a Microsoft maintainer explicitly asks
+for that route.
 
 The [x86 config](https://raw.githubusercontent.com/microsoft/WSL2-Linux-Kernel/14794180686c2fb6307fbe359c359bec765249f3/arch/x86/configs/config-wsl)
 and [arm64 config](https://raw.githubusercontent.com/microsoft/WSL2-Linux-Kernel/14794180686c2fb6307fbe359c359bec765249f3/arch/arm64/configs/config-wsl-arm64)
@@ -56,6 +58,19 @@ path. The separate [`wsl2-nbd-product-readiness`](../wsl2-nbd-product-readiness/
 pack owns product readiness. The separate
 [`microsoft-native-vram-memory-tier`](../microsoft-native-vram-memory-tier/PRD.md)
 pack owns the host-authoritative N3 RFC; N3 is not part of #41054.
+
+`olddefconfig` also exposes the upstream-default
+`CONFIG_BLKDEV_UBLK_LEGACY_OPCODES=y` when ublk is enabled. That derived value
+is not hidden from the evidence packet or misrepresented as a third requested
+source delta. It remains an explicit compatibility/security review point for
+Microsoft.
+
+The current public contribution-route evidence is recorded in
+[`RESEARCH.md`](RESEARCH.md). Its 2026-08-14 snapshot found
+no human external pull-request merge after the repository's 2021 route
+statement. The accepted external contribution pattern is maintainer-owned
+internal application, as demonstrated by WSL2-Linux-Kernel #247. Therefore a
+maintainer request, not local patch readiness alone, gates any future PR.
 
 ## Recommended option
 
@@ -72,10 +87,13 @@ records:
 
 3. Record arm64 independently: ublk remains a candidate, while
    `CONFIG_ZRAM_WRITEBACK=y` is already enabled at the pinned source.
-4. Run only the later named source/build/package/capability gates under
-   explicit approval; no swap or pressure workload is needed for this config
-   request.
-5. Prepare an English human-review draft for #41054 and do not post it.
+4. Run the named source/build/package/capability gates in isolated external
+   worktrees under the user's explicit approval; no host swap or pressure
+   workload is needed for this config request.
+5. Prepare an English human-review draft for #41054 with source, build, size,
+   capability, and cleanup evidence.
+6. Ask Microsoft whether it will integrate the two independently reviewable
+   changes internally or explicitly wants the prepared patch series as a PR.
 
 If Microsoft asks for patch-ready material, a human may prepare one logical
 config commit per symbol in the exact target tree. That possible future action
@@ -91,17 +109,19 @@ dependency on adoption.
 | RF-U-3 | Request only the two x86 config deltas. | x86 request is exactly ublk=m and zram writeback=y. |
 | RF-U-4 | Record arm64 independently. | ublk is candidate; existing zram writeback is not requested redundantly. |
 | RF-U-5 | Keep the route config-only. | No driver, UAPI, product, or native-memory request appears in the packet. |
-| RF-U-6 | Refuse an external kernel PR. | No branch, patch upload, pull request, or push is prepared by this pack. |
+| RF-U-6 | Refuse an unsolicited external kernel PR. | A tested fork branch and issue evidence may be published, but no Microsoft-repository PR opens without an explicit maintainer request. |
 | RF-U-7 | Preserve product independence. | NBD remains the WSL2 product path while #41054 is pending/rejected. |
 | RF-U-8 | Keep N3 separate. | N3 RFC links only to its own pack and is not a #41054 acceptance gate. |
 | RF-U-9 | Revalidate branch/tag/config drift. | Any target change returns status to `NEEDS_REVALIDATION`. |
 | RF-U-10 | Keep evidence public-safe and English. | No private host data, credentials, raw logs, or unreviewed text. |
+| RF-U-11 | Gate a pull request on an explicit maintainer request. | Patch readiness alone cannot open a known unsupported route. |
+| RF-U-12 | Disclose every derived Kconfig value. | Generated x86/arm64 evidence records the ublk legacy-opcode default instead of describing only the two source lines. |
 
 ## Non-functional requirements
 
 | ID | Requirement |
 | --- | --- |
-| NFR-U-1 | No external write, network submission, host reboot, WSL shutdown, swap, or pressure is performed. |
+| NFR-U-1 | External writes are limited to the reviewed fork branch, RamShared evidence PR, and one #41054 update; no host reboot, WSL shutdown, swap, or pressure is performed. |
 | NFR-U-2 | Source facts use official Microsoft/Linux primary sources only. |
 | NFR-U-3 | Missing live target evidence is `PARTIAL`, `REFUSED`, or `NEEDS_REVALIDATION`, never `DONE`. |
 | NFR-U-4 | Build and capability evidence records command class, target identity, and sanitized result. |
@@ -126,7 +146,8 @@ dependency on adoption.
    [`CONTRIBUTION-CHECKLIST.md`](CONTRIBUTION-CHECKLIST.md).
 2. Include the exact x86 delta and the arm64 non-duplicate observation.
 3. Mark every test `PASS`, `PARTIAL`, `REFUSED`, or `NEEDS_REVALIDATION`.
-4. Keep the packet local and unposted until a separate explicit decision.
+4. Publish one reviewed evidence update to #41054 after all mandatory local
+   gates pass; do not open a Microsoft-repository PR.
 
 ### Capability boundary
 
@@ -146,7 +167,7 @@ attempt.
 | `symbol_state` | `not_set`, `m`, `y`, `unknown` | Exact Kconfig value. |
 | `requested_delta` | x86 pair or none | Only x86 has the two requested changes. |
 | `status` | `UNVERIFIED`, `PASS`, `PARTIAL`, `REFUSED`, `NEEDS_REVALIDATION` | Evidence status, not product status. |
-| `external_action` | `NONE`, `HUMAN_REVIEW_ONLY` | This pack never posts. |
+| `external_action` | `NONE`, `FORK_BRANCH`, `ISSUE_UPDATE`, `MAINTAINER_REQUESTED_PR` | Direct Microsoft PR remains maintainer-gated. |
 
 `ADOPTED` is deliberately not a local status: Microsoft’s released source
 and product decision own adoption. A rolling source result is not installed
@@ -172,7 +193,8 @@ release evidence.
 | Canonical path differs | Stop; verify the official target tree rather than guessing. |
 | arm64 writeback request duplicates existing `y` | Remove the redundant request; retain independent ublk candidate note. |
 | Capability becomes product claim | Refusal test preserves NBD and custom-kernel separation. |
-| Community PR is proposed | Refuse; keep the packet local and human-reviewed. |
+| Unsolicited community PR is proposed | Refuse; publish evidence through the issue-first route instead. |
+| A patch is ready but no maintainer requested a PR | Post only the evidence update to #41054 and retain the patch locally. |
 | N3 is bundled into #41054 | Refuse and link the separate host-authoritative N3 pack. |
 | Missing target build/boot evidence | `PARTIAL`; never infer adoption or product readiness. |
 
@@ -183,10 +205,10 @@ last source-pinned status.
 
 ## Implementation strategy
 
-This task revises the PRD, SPEC, and checklist only. A later approved campaign
-may execute the named tests in the SPEC, then hand the packet to a human for
-#41054. It must not create an external action automatically. N3 and NBD remain
-separate workstreams.
+This task executes the named tests in the SPEC, records an `IMPL.md`, publishes
+the tested config-only series in the author's fork, and posts one reviewed
+evidence update to #41054. It must not open a Microsoft-repository pull request
+without a maintainer request. N3 and NBD remain separate workstreams.
 
 ## Documents
 
@@ -195,21 +217,22 @@ separate workstreams.
 | `PRD.md` | Revise the config-only decision and source pin. |
 | `SPEC.md` | Revise the executable matrix and boundary rules. |
 | `CONTRIBUTION-CHECKLIST.md` | Revise English packet, issue drafts, and milestone mapping. |
+| `RESEARCH.md` | Record current accepted/closed PR evidence and route decision. |
 | `wsl2-nbd-product-readiness/` | Separate NBD product owner; no issue ownership is imported. |
 | `microsoft-native-vram-memory-tier/` | Separate N3 host-authority owner. |
-| `IMPL.md`, `validation.md`, release docs | Not created or changed here. |
+| `IMPL.md` | Record exact source, patch, build, package, capability, and route evidence. |
+| `validation.md`, release docs | Not changed here. |
 | `docs/INDEX.md` | Regenerate as a generated index after the complete pack update. |
 
 ## Out of scope
 
-- A community PR, patch upload, branch push, issue/comment submission, or
-  Microsoft internal route;
+- An unsolicited Microsoft-repository PR or any claim of Microsoft adoption;
 - dxgkrnl/FORTIFY work, kernel code, driver/UAPI changes, or maintainer guesses;
 - ublk product transport, NBD product readiness, or custom-kernel promotion;
 - host-authoritative N3 implementation or guest-native VRAM memory;
-- host reboot, WSL shutdown, swap, pressure, GPU workload, or live kernel boot;
-- edits to release documentation, code, CI/workflows, `IMPL.md`, validation
-  records, or `MEMORY.md`.
+- host reboot, WSL shutdown, swap, pressure, GPU workload, or host kernel boot;
+- edits to release documentation, product code, CI/workflows, or validation
+  records.
 
 ## Acceptance
 
@@ -218,15 +241,16 @@ separate workstreams.
 | A-U-1 | Exact SHA and canonical x86/arm64 paths are recorded. |
 | A-U-2 | x86 request is exactly `CONFIG_BLK_DEV_UBLK=m` + `CONFIG_ZRAM_WRITEBACK=y`. |
 | A-U-3 | arm64 records ublk as candidate and writeback already `y`, without a duplicate request. |
-| A-U-4 | #41054 packet is config-only and no external kernel PR is proposed. |
+| A-U-4 | #41054 packet is config-only and no unsolicited external kernel PR is proposed. |
 | A-U-5 | NBD product and N3 RFC remain separate owners/gates. |
 | A-U-6 | Issue drafts/milestone mapping retain #145/#156 as `KEEP_OPEN_PARTIAL`. |
 | A-U-7 | Named source/build/capability/refusal tests and rollback are present. |
-| A-U-8 | No live or external action is claimed by this documentation revision. |
+| A-U-8 | External actions are limited to a tested fork branch, RamShared evidence PR, and one #41054 update; no live host action is claimed. |
+| A-U-9 | A direct PR remains gated on an explicit Microsoft maintainer request; internal application counts as contribution success. |
 
 ## Validation
 
-The docs-only validation is repository index/check/hygiene/diff. The future
-campaign must execute the exact target-tree gates in `SPEC.md`; absent approved
-build/boot evidence remains `PARTIAL`. A green config build cannot close NBD
-readiness or N3 host ownership.
+Validation combines repository index/check/hygiene/diff with the exact
+source/build/package/Sparse/QEMU gates in `SPEC.md`. Missing or failed evidence
+remains `PARTIAL` or `REFUSED`. A green config build or isolated capability
+boot cannot close NBD readiness or N3 host ownership.

--- a/docs/specs/no-milestone/wsl2-upstream-native-contribution/RESEARCH.md
+++ b/docs/specs/no-milestone/wsl2-upstream-native-contribution/RESEARCH.md
@@ -1,0 +1,161 @@
+# WSL2-Linux-Kernel contribution-route research
+
+> Snapshot: 2026-08-14. This audit uses public GitHub repository, pull
+> request, issue, comment, and commit records. It evaluates the route most
+> likely to result in Microsoft shipping the requested configuration; it does
+> not treat an externally merged pull request as the only successful outcome.
+
+## Executive conclusion
+
+The current contribution route for WSL kernel configuration requests is a
+feature request in [`microsoft/WSL`](https://github.com/microsoft/WSL), followed
+by Microsoft-owned internal integration. A community pull request to
+[`microsoft/WSL2-Linux-Kernel`](https://github.com/microsoft/WSL2-Linux-Kernel)
+is not an accepted general route.
+
+The successful target for
+[`microsoft/WSL#41054`](https://github.com/microsoft/WSL/issues/41054) is
+therefore:
+
+1. exact current-source evidence;
+2. independently reviewable x86 and arm64 decisions;
+3. a build- and capability-tested two-commit patch series;
+4. a concise issue update asking whether Microsoft will integrate the changes
+   internally or explicitly requests a pull request;
+5. a pull request only after a maintainer requests that route.
+
+Opening an unsolicited pull request before that response would repeat a known
+closed path and reduce, rather than improve, review efficiency.
+
+## Pull-request population
+
+The GitHub API returned 51 pull requests in the repository at this snapshot.
+The classification uses GitHub `author_association` and `merged_at` fields.
+
+| Population | Count | Interpretation |
+| --- | ---: | --- |
+| All pull requests | 51 | Complete public PR population at the snapshot. |
+| Merged pull requests | 7 | Primarily Microsoft release/integration work. |
+| External-associated pull requests | 41 | `NONE`, `CONTRIBUTOR`, or first-time contributor associations. |
+| External-associated merged pull requests | 1 | Microsoft policy automation, not a human community kernel contribution. |
+| External-associated PRs since the 2021 route statement | 6 | Five closed human submissions plus the policy bot. |
+| Human external PRs merged since the route statement | **0** | No observed counterexample to the published route. |
+
+The sole externally associated merge after the policy statement is
+[`#250`](https://github.com/microsoft/WSL2-Linux-Kernel/pull/250), created by
+`microsoft-github-policy-service[bot]` to add Microsoft security policy text.
+It is not evidence that community kernel/config patches are accepted.
+
+All four currently open pull requests are Microsoft member work:
+[`#258`](https://github.com/microsoft/WSL2-Linux-Kernel/pull/258),
+[`#259`](https://github.com/microsoft/WSL2-Linux-Kernel/pull/259),
+[`#260`](https://github.com/microsoft/WSL2-Linux-Kernel/pull/260), and
+[`#261`](https://github.com/microsoft/WSL2-Linux-Kernel/pull/261).
+
+## Why external pull requests were closed
+
+| PR | Subject | Outcome | Decisive reason |
+| --- | --- | --- | --- |
+| [`#247`](https://github.com/microsoft/WSL2-Linux-Kernel/pull/247) | Add the `dwarves` build dependency | Closed, but technically accepted and applied internally | The maintainer said the commit was applied, but the PR could not be accepted because of the repository's source-management flow. The later Microsoft commit [`3dff7287`](https://github.com/microsoft/WSL2-Linux-Kernel/commit/3dff72875492128d48ed21114406a3f2108c1cdc) preserves the external author, PR link, and maintainer sign-offs. |
+| [`#249`](https://github.com/microsoft/WSL2-Linux-Kernel/pull/249) | Enable EROFS configs | Closed | Maintainer explicitly stated that the repository does not take PRs and routed the request to a WSL feature issue for internal discussion. |
+| [`#251`](https://github.com/microsoft/WSL2-Linux-Kernel/pull/251) | Add a workflow | Closed | The same no-PR route was restated in 2025, showing that the policy was still active. |
+| [`#248`](https://github.com/microsoft/WSL2-Linux-Kernel/pull/248) | Update `config-wsl` | Closed by author | The author stated that the PR was opened accidentally instead of updating only the fork. It provides no acceptance evidence. |
+| [`#246`](https://github.com/microsoft/WSL2-Linux-Kernel/pull/246) | Kernel download question | Closed | It was not a code contribution and was redirected to documentation/support. |
+
+The repository
+[`README`](https://github.com/microsoft/WSL2-Linux-Kernel#feature-requests)
+matches those outcomes: WSL/kernel feature requests belong in
+`microsoft/WSL`; general kernel code belongs in the normal upstream Linux
+process.
+
+## What successful configuration requests demonstrate
+
+There is no deterministic acceptance formula, but completed and abandoned
+issues expose useful review signals.
+
+### Strong signals
+
+- [`microsoft/WSL#12987`](https://github.com/microsoft/WSL/issues/12987) was a
+  concrete regression with diagnostics and a specific application failure.
+  Microsoft identified the dropped symbol and marked the fix inbound within
+  days. Regression priority does not transfer to #41054, which is a feature.
+- [`microsoft/WSL#5526`](https://github.com/microsoft/WSL/issues/5526) linked a
+  concrete eBPF/header use case, accumulated independent demand, and was later
+  closed against a Microsoft-owned enabling commit. It also demonstrates that
+  feature adoption can take years.
+- [`microsoft/WSL#8302`](https://github.com/microsoft/WSL/issues/8302) and
+  [`#11021`](https://github.com/microsoft/WSL/issues/11021) combined concrete
+  hardware/use cases with custom-kernel verification before the capability
+  appeared in a released kernel.
+
+### Failure and ambiguity signals
+
+- [`microsoft/WSL#9819`](https://github.com/microsoft/WSL/issues/9819) and
+  [`#6044`](https://github.com/microsoft/WSL/issues/6044) show that technically
+  meaningful requests can be closed automatically after a year without a
+  maintained evidence trail.
+- [`microsoft/WSL#13174`](https://github.com/microsoft/WSL/issues/13174) was
+  closed after users confirmed that a custom kernel solved the problem. A
+  custom-kernel PASS must therefore be described as solution validation, not
+  as resolution of the stock-kernel request.
+- [`microsoft/WSL#11335`](https://github.com/microsoft/WSL/issues/11335) gained
+  independent custom-kernel and preview-kernel confirmation but was later
+  auto-closed. Evidence should always identify whether the stock, preview, or
+  custom kernel was tested.
+
+## Review barriers specific to #41054
+
+The current source pin is
+[`14794180686c2fb6307fbe359c359bec765249f3`](https://github.com/microsoft/WSL2-Linux-Kernel/commit/14794180686c2fb6307fbe359c359bec765249f3).
+At that revision:
+
+| Architecture | `CONFIG_BLK_DEV_UBLK` | `CONFIG_ZRAM_WRITEBACK` |
+| --- | --- | --- |
+| x86 | not set | not set |
+| arm64 | not set | `y` |
+
+The requests must be independently reviewable:
+
+- `CONFIG_ZRAM_WRITEBACK=y` is an x86 alignment request. The arm64 WSL config
+  already enables it. Its Kconfig behavior remains dormant until an
+  administrator configures a backing device.
+- `CONFIG_BLK_DEV_UBLK=m` is an x86 and arm64 module request. The upstream
+  Kconfig still labels the interface experimental, so module size, autoload
+  behavior, capability cleanup, and attack-surface reasoning must be explicit.
+
+Microsoft can then accept the lower-risk x86 writeback alignment without being
+forced to accept ublk in the same decision.
+
+## Patch-ready format if requested
+
+The patch series should remain two logical commits:
+
+1. `config: enable CONFIG_ZRAM_WRITEBACK on x86`
+2. `config: enable CONFIG_BLK_DEV_UBLK`
+
+Each commit must contain a `Signed-off-by` trailer. The series changes only:
+
+```text
+arch/x86/configs/config-wsl
+arch/arm64/configs/config-wsl-arm64
+```
+
+The second commit changes both architectures; the first changes x86 only.
+Evidence must record `olddefconfig` for each architecture, an x86 `W=1` build,
+module packaging, size deltas, a bounded capability smoke test, and clean
+teardown. No RamShared Rust source belongs in the Microsoft patch.
+
+## Decision
+
+`#41054` remains the canonical public route. The next external action should be
+one substantive issue update with the evidence packet and this explicit
+question:
+
+> Would the WSL kernel team consider these two independently reviewable config
+> changes for the stock kernel? If so, should they be integrated internally,
+> or would you like the prepared two-commit patch series submitted as a pull
+> request against `linux-msft-wsl-6.18.y`?
+
+Only the latter response opens the pull-request gate. A Microsoft internal
+commit that credits or links the external patch is a successful contribution,
+even if the community PR itself is never merged, as demonstrated by #247.

--- a/docs/specs/no-milestone/wsl2-upstream-native-contribution/SPEC.md
+++ b/docs/specs/no-milestone/wsl2-upstream-native-contribution/SPEC.md
@@ -1,8 +1,8 @@
 # SPEC — WSL #41054 config-only contribution boundary
 
-> SSDV3 Step 2. Implements [`PRD.md`](PRD.md). This SPEC prepares local,
-> public-safe evidence only. It does not build, boot, patch, post, push, or
-> submit an external kernel/WSL surface.
+> SSDV3 Steps 2–3. Implements [`PRD.md`](PRD.md). This SPEC prepares and
+> validates a public-safe config-only patch series, publishes reviewed evidence
+> through the issue-first route, and refuses an unsolicited Microsoft PR.
 
 ## Closed scope
 
@@ -11,18 +11,21 @@
 - Exact source-pinned #41054 configuration evidence.
 - Canonical x86 and arm64 path/value matrix.
 - Config-only request, no-external-PR route, and product/N3 separation.
-- Public-safe English issue draft and human handoff contract.
+- Public-safe English issue update and human handoff contract.
+- Isolated external-tree config, build, package, Sparse, and QEMU capability
+  evidence.
+- A two-commit branch in the author's fork after all mandatory gates pass.
 - Named source, build, package, capability, refusal, and revalidation tests.
 
 ### Out now
 
-- Any external issue/comment/PR/patch/email/branch/tag or Microsoft internal
-  communication.
+- Any unsolicited PR to `microsoft/WSL2-Linux-Kernel`, email, tag, or claim of
+  Microsoft internal adoption.
 - Kernel source changes, dxgkrnl/FORTIFY work, uAPI, driver, host memory tier,
   N3 implementation, swap, GPU pressure, WSL shutdown, reboot, or custom-kernel
   boot.
-- RamShared code/CI/configuration, NBD product readiness, release docs,
-  `IMPL.md`, validation records, or `MEMORY.md`.
+- RamShared product code/CI/configuration, NBD product readiness, release docs,
+  or validation records.
 
 ### Source pin
 
@@ -48,6 +51,8 @@ to `NEEDS_REVALIDATION`.
 | RF-U-5..8 | ITEM-2 — config-only route and separation refusals |
 | RF-U-9, NFR-U-2..6 | ITEM-3 — revalidation and maintenance |
 | RF-U-10, NFR-U-1/3/4 | ITEM-4 — public-safe evidence and human handoff |
+| RF-U-11 | ITEM-5 — maintainer-routed patch/PR decision |
+| RF-U-12 | ITEM-3 — generated-config dependency disclosure |
 
 ## Technical decisions
 
@@ -58,11 +63,13 @@ to `NEEDS_REVALIDATION`.
 | DT-U-3 | `arch/x86/configs/config-wsl` and `arch/arm64/configs/config-wsl-arm64` are canonical facts. | Avoids copying an architecture value from a generic or generated config. |
 | DT-U-4 | x86 requests exactly ublk=m and zram writeback=y. | Matches the two missing x86 symbols at the pinned source. |
 | DT-U-5 | arm64 is independent: ublk is a candidate; writeback is already y. | Prevents a redundant or inaccurate arm64 request. |
-| DT-U-6 | The route is config-only and no community kernel PR is prepared. | The WSL README routes feature requests to WSL and code to normal upstream. |
+| DT-U-6 | The route is config-only and issue-first; an unsolicited community kernel PR is refused. | The WSL README and maintainer comments route feature requests to WSL and integration to Microsoft. |
 | DT-U-7 | Capability does not promote NBD/ublk product status. | Kernel symbols and product lifecycle proof are different contracts. |
 | DT-U-8 | N3 is a separate host-authority RFC. | Native VRAM ownership cannot be created by this config request. |
 | DT-U-9 | A source mismatch refuses before any build or packet update. | Prevents stale evidence and accidental target drift. |
-| DT-U-10 | Human handoff is the terminal state of this pack. | No external network write is authorized. |
+| DT-U-10 | One reviewed #41054 update is the terminal outbound action before maintainer response. | Prevents comment churn and unsolicited PR submission. |
+| DT-U-11 | Patch readiness and PR authorization are separate states. | Public history shows technically accepted work can be applied internally while the external PR is closed. |
+| DT-U-12 | `CONFIG_BLKDEV_UBLK_LEGACY_OPCODES=y` is recorded as an upstream-derived default, not a requested source line. | Prevents a two-line source claim from hiding a generated compatibility/security value. |
 
 ## Atomicity/rollback
 
@@ -72,7 +79,7 @@ to `NEEDS_REVALIDATION`.
 | Config delta | Two x86 symbol values only; arm64 recorded separately. | Unexpected symbol/dependency/path change → refuse. |
 | Build evidence | Later target-tree build in an isolated worktree. | Build/package/check failure → `PARTIAL`/`REFUSED`; no retry theater. |
 | Capability | Later approved custom-kernel capability only, without swap/pressure. | Capability failure → retain NBD product; no adoption claim. |
-| External route | No write in this SPEC; local packet only. | Any attempted issue/PR/push → hard stop and discard outbound action. |
+| External route | Reviewed fork branch plus one #41054 evidence update; Microsoft PR only on explicit maintainer request. | Any broader write or unsolicited PR → hard stop. |
 | Product policy | NBD/N3 owners unchanged. | Any transport or native-memory change → scope refusal. |
 
 No module unload, host restart, or external rollback is hidden in this pack.
@@ -94,8 +101,8 @@ recovery path and mark the row `PARTIAL`; this SPEC does not authorize the boot.
 
 ## Security checklist
 
-- [x] No external write, secret, credential, private host path, username, IP,
-  raw log, dump, account ID, or internal route is included.
+- [x] No secret, credential, private host path, username, IP, raw log, dump,
+  account ID, or internal route is included in public material.
 - [x] Full SHA and canonical file paths are captured before interpreting values.
 - [x] Config parser/build inputs are bounded and source-pinned.
 - [x] No generic defconfig, guessed maintainer, mailing list, or target branch
@@ -109,20 +116,26 @@ recovery path and mark the row `PARTIAL`; this SPEC does not authorize the boot.
 
 ## Files create/modify/delete
 
-The following paths are future campaign anchors. None is changed by this docs
-revision except the three documents in this folder.
+The following paths are campaign anchors. External target-tree files live only
+in the isolated candidate branch; RamShared changes remain in this folder and
+the generated documentation inventory.
 
 | Path | Action | Contract / test owner |
 | --- | --- | --- |
 | `docs/specs/no-milestone/wsl2-upstream-native-contribution/PRD.md` | Modify | Source-pinned decision. |
 | `docs/specs/no-milestone/wsl2-upstream-native-contribution/SPEC.md` | Modify | This executable matrix. |
 | `docs/specs/no-milestone/wsl2-upstream-native-contribution/CONTRIBUTION-CHECKLIST.md` | Modify | Human packet, issue drafts, milestone mapping. |
+| `docs/specs/no-milestone/wsl2-upstream-native-contribution/RESEARCH.md` | Create | Current PR/issue route evidence and maintained decision. |
 | `scripts/kernel/` in the exact external target tree | Future read-only/build context | Official target-tree commands only; no RamShared code. |
 | `Microsoft/config-wsl*` in the exact external target tree | Read-only target input | Build entry point resolves to canonical architecture files. |
-| `docs/specs/no-milestone/wsl2-upstream-native-contribution/IMPL.md` | Create later | Only after approved campaign and evidence. |
+| `docs/specs/no-milestone/wsl2-upstream-native-contribution/IMPL.md` | Create | Exact campaign and public-action evidence. |
+| `docs/specs/no-milestone/wsl2-upstream-native-contribution/EVIDENCE.json` | Create | Public-safe machine-readable source, patch, build, capability, and route receipts. |
+| `scripts/kernel/test-wsl-upstream-config-contribution.sh` | Create | Source, architecture, scope, DCO, checkpatch, and apply refusal gates. |
+| `scripts/kernel/qemu-wsl-config-capability.sh` | Create | Isolated QEMU boot, module, writeback I/O, and teardown gate. |
+| `scripts/kernel/qemu-wsl-config-capability-init.sh` | Create | Minimal public-safe capability guest. |
 | `validation.md` | Append later | Only for authorized live evidence; not this task. |
 
-No file in the RamShared code, CI/workflow, release, validation, or MEMORY
+No file in the RamShared product code, CI/workflow, release, or validation
 surfaces is created, modified, or deleted by this SPEC.
 
 ## Observability
@@ -134,7 +147,7 @@ surfaces is created, modified, or deleted by this SPEC.
 | Values | ublk/writeback state per architecture | x86 pair is exact; arm64 writeback is already y. |
 | Build | target-tree command class, toolchain, exit, warning/error summary | Official gate result is recorded or partial. |
 | Capability | module/control-node observation without workload | Capability only, never product ready. |
-| Route | issue draft state and external action | `HUMAN_REVIEW_ONLY`; no network write. |
+| Route | issue update, fork branch, and PR gate | One reviewed issue update; no unsolicited Microsoft PR. |
 | Revalidation | trigger and reason | Branch/SHA/Kconfig/30-day drift → `NEEDS_REVALIDATION`. |
 
 ## Living docs
@@ -145,7 +158,8 @@ surfaces is created, modified, or deleted by this SPEC.
 | `microsoft-native-vram-memory-tier/` | N3 RFC owner; no config adoption imported. |
 | `docs/labs/WSL2-UPSTREAM-CONFIG-PR.md` | Historical research; do not rewrite it as an external PR plan. |
 | `docs/INDEX.md` | Regenerate as a generated index after pack updates. |
-| `IMPL.md`, `validation.md`, release docs | N/A in this docs-only revision. |
+| `IMPL.md` | Create with exact campaign evidence and residuals. |
+| `validation.md`, release docs | N/A; this campaign is not product validation. |
 | `AGENTS.md`, `CLAUDE.md`, `.claude/rules/*` | N/A — no convention change. |
 
 ## Implementation order
@@ -153,39 +167,44 @@ surfaces is created, modified, or deleted by this SPEC.
 1. **ITEM-1:** resolve the exact target SHA and canonical architecture files.
 2. **ITEM-2:** record the x86 pair, arm64 independent state, and config-only refusal boundaries.
 3. **ITEM-3:** run later official source/build/package/capability gates on an approved isolated surface.
-4. **ITEM-4:** render the English human-review draft and milestone mapping; do not post.
-5. **ITEM-5:** revalidate at every trigger and hand off to a human decision.
+4. **ITEM-4:** render and post one reviewed English #41054 evidence update after all gates pass.
+5. **ITEM-5:** revalidate at every trigger and ask for the maintainer-owned
+   integration route; a PR remains refused until explicitly requested.
 
 ## Required tests matrix
 
-These are contractual names for a future target-tree campaign. They have not
-run in this documentation-only revision.
+These are the contractual names for the approved target-tree campaign. Exact
+results are recorded in `IMPL.md`.
 
 | Production path | Test (`file` :: `name`) | Kind | Kahneman | Cover / pass condition |
 | --- | --- | --- | --- | --- |
 | Target repository | `UPSTREAM_SOURCE_SHA_REVALIDATION` | source/static | #3 | Full SHA equals `14794180686c2fb6307fbe359c359bec765249f3`. |
 | Target repository | `UPSTREAM_CANONICAL_ARCH_PATHS` | source/static | #3/#13 | Both exact arch config files exist and are the reviewed inputs. |
+| `scripts/kernel/test-wsl-upstream-config-contribution.sh` | `UPSTREAM_PATCH_SERIES_SCOPE` | source/static | #3/#13 | Exactly two commits change only the two canonical config files. |
+| `scripts/kernel/test-wsl-upstream-config-contribution.sh` | `UPSTREAM_PATCH_DCO_AND_CHECKPATCH` | source/static | #13 | Canonical author/sign-off, strict checkpatch, and clean apply all pass. |
 | `arch/x86/configs/config-wsl` | `X86_CONFIG_PAIR` | config/static | #13 | x86 current values are not set; candidate delta is exactly ublk=m + writeback=y. |
 | `arch/arm64/configs/config-wsl-arm64` | `ARM64_INDEPENDENT_PAIR` | config/static | #13 | ublk is candidate; writeback is already y; no duplicate request. |
 | Target Kconfig | `UPSTREAM_CONFIG_OLDDEFCONFIG_X86` | build | #3 | Both x86 deltas survive official `olddefconfig`. |
 | Target Kconfig | `UPSTREAM_CONFIG_OLDDEFCONFIG_ARM64` | build | #3 | Arm64 is independently evaluated; no copied x86 result. |
+| Target Kconfig | `UPSTREAM_CONFIG_DERIVED_DEFAULTS` | config/static | #2/#3 | Both generated configs disclose `CONFIG_BLKDEV_UBLK_LEGACY_OPCODES=y`. |
 | Target build | `UPSTREAM_CONFIG_BUILD_W1` | build | #3 | Official target-tree build result is recorded. |
 | Target build | `UPSTREAM_CONFIG_SPARSE_C1` | sparse | #13 | No new relevant sparse diagnostic, or explicit partial/refusal. |
 | Target package | `UPSTREAM_CONFIG_MODULE_PACKAGE` | package | #16 | Expected ublk module/package state is recorded without swap. |
 | Approved custom kernel | `UPSTREAM_CONFIG_UBLK_CAPABILITY_NO_PRODUCT` | drill/E2E | #2/#18 | Capability is observed but product remains NBD-only. |
 | Approved custom kernel | `UPSTREAM_CONFIG_WRITEBACK_CAPABILITY` | drill/E2E | #2 | Writeback capability is recorded per architecture; no pressure workload. |
 | Human packet | `UPSTREAM_CONFIG_PUBLIC_REDACTION` | static/manual | #13 | No private/secret/raw host material. |
-| Human packet | `NO_EXTERNAL_KERNEL_PR_REFUSAL` | refusal | #13/#18 | No branch, patch, PR, push, or auto-post action. |
+| Human packet | `NO_EXTERNAL_KERNEL_PR_REFUSAL` | refusal | #13/#18 | No unsolicited Microsoft-repository PR or auto-post action. |
 | Human packet | `UPSTREAM_OWNER_ROUTE` | static/manual | #18 | #41054 stays WSL feature request; code route is normal upstream, not community PR. |
+| Route audit | `UPSTREAM_PR_ROUTE_AUDIT` | source/static | #3/#18 | Public PR population and decisive maintainer comments support the selected route. |
+| Human packet | `MAINTAINER_REQUESTED_PR_GATE` | refusal | #13/#18 | A patch-ready state without an explicit maintainer request cannot open a PR. |
 | N3 boundary | `N3_SCOPE_REFUSAL` | refusal | #2/#18 | N3 host RFC remains a separate pack. |
-| Evidence process | `UPSTREAM_EVIDENCE_REPLAY_IDEMPOTENCY` | process | #17 | Replaying a packet creates no external or host effect. |
+| Evidence process | `UPSTREAM_EVIDENCE_REPLAY_IDEMPOTENCY` | process | #17 | Revalidation creates no duplicate issue comment or host effect. |
 | Maintenance | `UPSTREAM_REVALIDATION_TRIGGER` | process | #3/#15 | SHA/path/branch/Kconfig/build/30-day drift yields `NEEDS_REVALIDATION`. |
 
 ### Platform-correct future gates
 
-When explicitly authorized on the exact external target tree, use the target
-tree’s own commands. The following are examples of command classes, not an
-authorization to run them in this task:
+The user explicitly authorized this campaign on the exact external target
+tree. Use the target tree's own commands in isolated build directories:
 
 ```bash
 make KCONFIG_CONFIG=Microsoft/config-wsl olddefconfig
@@ -196,12 +215,12 @@ make INSTALL_MOD_PATH="$PWD/modules" modules_install
 
 For arm64, resolve `Microsoft/config-wsl-arm64` and
 `arch/arm64/configs/config-wsl-arm64` from the exact target tree. Do not use a
-generic distro defconfig. Do not run `modprobe`, swap, pressure, or a boot as
-part of this documentation task.
+generic distro defconfig. Capability boots must be isolated QEMU guests and
+must not run host swap or pressure.
 
 ## Validation checklist
 
-Future campaign only:
+Approved campaign:
 
 - [ ] Read the exact external target README and source at the pinned SHA.
 - [ ] Verify both canonical architecture paths and all four symbol values.
@@ -217,8 +236,8 @@ Future campaign only:
 
 ## Out of SPEC
 
-- Any kernel code, dxgkrnl/FORTIFY patch, external kernel PR, GitHub action,
-  issue/comment, mailing-list submission, branch push, or internal route;
+- Any kernel code, dxgkrnl/FORTIFY patch, unsolicited external kernel PR,
+  mailing-list submission, tag, or claim of internal adoption;
 - any NBD/ublk product implementation, native VRAM/N3 implementation, custom
   kernel promotion, swap/pressure/GPU workload, reboot, or WSL shutdown;
-- any release, code, CI/workflow, `IMPL.md`, validation, or `MEMORY.md` edit.
+- any release, product code, CI/workflow, validation, or `MEMORY.md` edit.

--- a/scripts/kernel/qemu-wsl-config-capability-init.sh
+++ b/scripts/kernel/qemu-wsl-config-capability-init.sh
@@ -1,0 +1,54 @@
+#!/bin/busybox sh
+# Minimal isolated guest for WSL config capability validation.
+set -eu
+
+fail() {
+  echo "KTEST-FAIL=$1"
+  /bin/busybox poweroff -f
+  exit 1
+}
+
+/bin/busybox mkdir -p /proc /sys /dev /tmp
+/bin/busybox mount -t proc proc /proc
+/bin/busybox mount -t sysfs sysfs /sys
+/bin/busybox mount -t devtmpfs devtmpfs /dev
+
+echo 'KTEST-BEGIN'
+echo "KTEST-UNAME=$(/bin/busybox uname -r)"
+test ! -e /dev/ublk-control || fail ublk_autoloaded
+test ! -e /sys/block/zram0 || fail zram_autoloaded
+echo 'KTEST-PRELOAD=inactive'
+
+/bin/busybox insmod /modules/zsmalloc.ko || fail zsmalloc_insmod
+/bin/busybox insmod /modules/zram.ko num_devices=1 || fail zram_insmod
+/bin/busybox insmod /modules/ublk_drv.ko || fail ublk_insmod
+
+test -c /dev/ublk-control || fail ublk_control_missing
+test -e /sys/block/zram0/backing_dev || fail zram_backing_dev_missing
+test -e /sys/block/zram0/writeback || fail zram_writeback_missing
+test -b /dev/sda1 || fail backing_partition_missing
+echo 'KTEST-UBLK-CONTROL=present'
+echo 'KTEST-ZRAM-WRITEBACK-INTERFACE=present'
+
+echo /dev/sda1 > /sys/block/zram0/backing_dev || fail backing_dev_attach
+echo 16M > /sys/block/zram0/disksize || fail zram_disksize
+/bin/busybox dd if=/dev/urandom of=/dev/zram0 bs=4096 count=1024 2>/dev/null ||
+  fail zram_write
+echo all > /sys/block/zram0/idle || fail zram_idle_mark
+echo idle > /sys/block/zram0/writeback || fail zram_writeback
+
+set -- $(/bin/busybox cat /sys/block/zram0/bd_stat)
+test "$1" -gt 0 || fail zram_bd_count_zero
+test "$3" -gt 0 || fail zram_bd_writes_zero
+echo "KTEST-ZRAM-BD-STAT=$1,$2,$3"
+echo 'KTEST-ZRAM-WRITEBACK-IO=pass'
+
+echo 1 > /sys/block/zram0/reset || fail zram_reset
+/bin/busybox rmmod ublk_drv || fail ublk_rmmod
+/bin/busybox rmmod zram || fail zram_rmmod
+/bin/busybox rmmod zsmalloc || fail zsmalloc_rmmod
+test ! -e /dev/ublk-control || fail ublk_control_residual
+test ! -e /sys/block/zram0 || fail zram_residual
+echo 'KTEST-CLEANUP=pass'
+echo 'KTEST-END'
+/bin/busybox poweroff -f

--- a/scripts/kernel/qemu-wsl-config-capability.sh
+++ b/scripts/kernel/qemu-wsl-config-capability.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Boot the candidate WSL kernel in QEMU and validate only config capabilities.
+set -euo pipefail
+
+BZIMAGE="${1:?usage: $0 <bzImage> <kernelrelease> <zsmalloc.ko> <zram.ko> <ublk_drv.ko>}"
+KERNEL_RELEASE="${2:?missing kernel release}"
+ZSMALLOC_MODULE="${3:?missing zsmalloc module}"
+ZRAM_MODULE="${4:?missing zram module}"
+UBLK_MODULE="${5:?missing ublk module}"
+INIT_SOURCE="$(dirname "$0")/qemu-wsl-config-capability-init.sh"
+
+for file in "$BZIMAGE" "$ZSMALLOC_MODULE" "$ZRAM_MODULE" "$UBLK_MODULE" "$INIT_SOURCE"; do
+  test -f "$file" || { printf 'missing input: %s\n' "$file" >&2; exit 2; }
+done
+for command_name in busybox cpio gzip qemu-system-x86_64 sfdisk; do
+  command -v "$command_name" >/dev/null || {
+    printf 'missing command: %s\n' "$command_name" >&2
+    exit 2
+  }
+done
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+INITRAMFS_ROOT="$WORK_DIR/initramfs"
+SERIAL_LOG="$WORK_DIR/serial.log"
+BACKING_DISK="$WORK_DIR/backing.raw"
+mkdir -p "$INITRAMFS_ROOT/bin" "$INITRAMFS_ROOT/modules"
+cp "$(command -v busybox)" "$INITRAMFS_ROOT/bin/busybox"
+cp "$INIT_SOURCE" "$INITRAMFS_ROOT/init"
+cp "$ZSMALLOC_MODULE" "$INITRAMFS_ROOT/modules/zsmalloc.ko"
+cp "$ZRAM_MODULE" "$INITRAMFS_ROOT/modules/zram.ko"
+cp "$UBLK_MODULE" "$INITRAMFS_ROOT/modules/ublk_drv.ko"
+chmod +x "$INITRAMFS_ROOT/init"
+
+truncate -s 128M "$BACKING_DISK"
+printf 'label: dos\nstart=2048, type=83\n' | sfdisk "$BACKING_DISK" >/dev/null
+(
+  cd "$INITRAMFS_ROOT"
+  find . -print0 | cpio --null -o -H newc 2>/dev/null | gzip
+) > "$WORK_DIR/initramfs.gz"
+
+accel=(-machine accel=tcg)
+if test -w /dev/kvm; then
+  accel=(-enable-kvm -cpu host)
+fi
+
+set +e
+timeout --foreground --kill-after=5s 180s qemu-system-x86_64 \
+  "${accel[@]}" -m 768 -nographic -no-reboot \
+  -kernel "$BZIMAGE" -initrd "$WORK_DIR/initramfs.gz" \
+  -append 'console=ttyS0 panic=1 rdinit=/init' \
+  -device virtio-scsi-pci,id=scsi0 \
+  -drive "file=$BACKING_DISK,format=raw,if=none,id=backing0" \
+  -device scsi-hd,drive=backing0,bus=scsi0.0 >"$SERIAL_LOG" 2>&1
+qemu_rc=$?
+set -e
+
+if test -n "${RAMSHARED_QEMU_EVIDENCE_LOG:-}"; then
+  cp "$SERIAL_LOG" "$RAMSHARED_QEMU_EVIDENCE_LOG"
+fi
+
+grep -F "KTEST-UNAME=$KERNEL_RELEASE" "$SERIAL_LOG" >/dev/null || qemu_rc=1
+grep -F 'KTEST-PRELOAD=inactive' "$SERIAL_LOG" >/dev/null || qemu_rc=1
+grep -F 'KTEST-UBLK-CONTROL=present' "$SERIAL_LOG" >/dev/null || qemu_rc=1
+grep -F 'KTEST-ZRAM-WRITEBACK-INTERFACE=present' "$SERIAL_LOG" >/dev/null || qemu_rc=1
+grep -F 'KTEST-ZRAM-WRITEBACK-IO=pass' "$SERIAL_LOG" >/dev/null || qemu_rc=1
+grep -F 'KTEST-CLEANUP=pass' "$SERIAL_LOG" >/dev/null || qemu_rc=1
+grep -F 'KTEST-END' "$SERIAL_LOG" >/dev/null || qemu_rc=1
+
+grep -F 'KTEST-' "$SERIAL_LOG" || true
+if test "$qemu_rc" -ne 0; then
+  printf 'QEMU_WSL_CONFIG_CAPABILITY=FAIL rc=%s\n' "$qemu_rc" >&2
+  tail -40 "$SERIAL_LOG" >&2
+  exit 1
+fi
+printf 'QEMU_WSL_CONFIG_CAPABILITY=PASS\n'

--- a/scripts/kernel/test-wsl-upstream-config-contribution.sh
+++ b/scripts/kernel/test-wsl-upstream-config-contribution.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Validate the config-only WSL contribution series without changing either tree.
+set -euo pipefail
+
+BASELINE_REPO="${1:?usage: $0 <baseline-repo> <candidate-repo>}"
+CANDIDATE_REPO="${2:?usage: $0 <baseline-repo> <candidate-repo>}"
+EXPECTED_BASE="14794180686c2fb6307fbe359c359bec765249f3"
+EXPECTED_AUTHOR="$(git -C "$CANDIDATE_REPO" log -1 --format='%an <%ae>' HEAD)"
+EXPECTED_SIGNOFF="Signed-off-by: $EXPECTED_AUTHOR"
+
+fail() {
+  printf 'FAIL %s\n' "$1" >&2
+  exit 1
+}
+
+assert_line() {
+  local file="$1"
+  local line="$2"
+  grep -Fqx -- "$line" "$file" || fail "missing exact line in $file: $line"
+}
+
+assert_clean() {
+  local repo="$1"
+  test -z "$(git -C "$repo" status --porcelain)" || fail "dirty tree: $repo"
+}
+
+test "$(git -C "$BASELINE_REPO" rev-parse HEAD)" = "$EXPECTED_BASE" ||
+  fail "baseline SHA mismatch"
+test "$(git -C "$CANDIDATE_REPO" merge-base HEAD "$EXPECTED_BASE")" = "$EXPECTED_BASE" ||
+  fail "candidate is not based on the reviewed SHA"
+test "$(git -C "$CANDIDATE_REPO" rev-list --count "$EXPECTED_BASE"..HEAD)" = 2 ||
+  fail "candidate must contain exactly two commits"
+assert_clean "$BASELINE_REPO"
+assert_clean "$CANDIDATE_REPO"
+
+BASE_X86="$BASELINE_REPO/arch/x86/configs/config-wsl"
+BASE_ARM64="$BASELINE_REPO/arch/arm64/configs/config-wsl-arm64"
+CAND_X86="$CANDIDATE_REPO/arch/x86/configs/config-wsl"
+CAND_ARM64="$CANDIDATE_REPO/arch/arm64/configs/config-wsl-arm64"
+
+assert_line "$BASE_X86" '# CONFIG_BLK_DEV_UBLK is not set'
+assert_line "$BASE_X86" '# CONFIG_ZRAM_WRITEBACK is not set'
+assert_line "$BASE_ARM64" '# CONFIG_BLK_DEV_UBLK is not set'
+assert_line "$BASE_ARM64" 'CONFIG_ZRAM_WRITEBACK=y'
+assert_line "$CAND_X86" 'CONFIG_BLK_DEV_UBLK=m'
+assert_line "$CAND_X86" 'CONFIG_ZRAM_WRITEBACK=y'
+assert_line "$CAND_ARM64" 'CONFIG_BLK_DEV_UBLK=m'
+assert_line "$CAND_ARM64" 'CONFIG_ZRAM_WRITEBACK=y'
+
+mapfile -t changed_files < <(
+  git -C "$CANDIDATE_REPO" diff --name-only "$EXPECTED_BASE"..HEAD | sort
+)
+expected_files=(
+  arch/arm64/configs/config-wsl-arm64
+  arch/x86/configs/config-wsl
+)
+test "${changed_files[*]}" = "${expected_files[*]}" || fail "unexpected candidate files"
+
+mapfile -t subjects < <(
+  git -C "$CANDIDATE_REPO" log --reverse --format=%s "$EXPECTED_BASE"..HEAD
+)
+test "${subjects[0]}" = 'config: enable CONFIG_ZRAM_WRITEBACK on x86' ||
+  fail "unexpected first subject"
+test "${subjects[1]}" = 'config: enable CONFIG_BLK_DEV_UBLK' ||
+  fail "unexpected second subject"
+
+while IFS= read -r commit; do
+  author="$(git -C "$CANDIDATE_REPO" show -s --format='%an <%ae>' "$commit")"
+  test "$author" = "$EXPECTED_AUTHOR" ||
+    fail "non-canonical author: $commit"
+  git -C "$CANDIDATE_REPO" show -s --format=%B "$commit" |
+    grep -Fqx "$EXPECTED_SIGNOFF" || fail "missing canonical sign-off: $commit"
+done < <(git -C "$CANDIDATE_REPO" rev-list --reverse "$EXPECTED_BASE"..HEAD)
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+git -C "$CANDIDATE_REPO" format-patch --quiet -o "$TMP_DIR" "$EXPECTED_BASE"..HEAD
+mapfile -t patches < <(find "$TMP_DIR" -maxdepth 1 -type f -name '*.patch' | sort)
+test "${#patches[@]}" = 2 || fail "expected exactly two patches"
+for patch in "${patches[@]}"; do
+  "$BASELINE_REPO/scripts/checkpatch.pl" --strict "$patch" >/dev/null ||
+    fail "checkpatch rejected $(basename "$patch")"
+done
+
+git -C "$BASELINE_REPO" apply --check "${patches[@]}" ||
+  fail "patch series does not apply to reviewed baseline"
+
+printf 'PASS UPSTREAM_SOURCE_SHA_REVALIDATION\n'
+printf 'PASS UPSTREAM_CANONICAL_ARCH_PATHS\n'
+printf 'PASS X86_CONFIG_PAIR\n'
+printf 'PASS ARM64_INDEPENDENT_PAIR\n'
+printf 'PASS UPSTREAM_PATCH_SERIES_SCOPE\n'
+printf 'PASS UPSTREAM_PATCH_DCO_AND_CHECKPATCH\n'
+printf 'PASS MAINTAINER_REQUESTED_PR_GATE local_patch_only\n'

--- a/tools/ci/check-ci-contract.test.mjs
+++ b/tools/ci/check-ci-contract.test.mjs
@@ -21,8 +21,8 @@ import {
 } from './check-ci-contract.mjs'
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
-const RUSTSEC_SNAPSHOT_COMMIT = '309ad29d8fe448bf986019e05d47b9e0e29a2218'
-const RUSTSEC_SNAPSHOT_UTC = '2026-08-09T12:34:06Z'
+const RUSTSEC_SNAPSHOT_COMMIT = '69f93e1d081d8b6fbee010e48f0b5e0d13661415'
+const RUSTSEC_SNAPSHOT_UTC = '2026-08-12T10:42:29Z'
 const REMOTE_OBSERVATION_NOW = Date.parse('2026-08-09T16:00:00Z')
 
 function compliantRemoteObservation(overrides = {}) {
@@ -359,7 +359,7 @@ test('ci_specific_policies_reject_malformed_coverage_and_cancellation_rules', ()
 
 test('ci_contract_rejects_stale_advisory_snapshot', () => {
   const result = validateContract(currentOnlyContract(cargoAuditGate()), {
-    now: Date.parse('2026-08-16T12:34:07Z'),
+    now: Date.parse('2026-08-19T10:42:30Z'),
   })
   assert.equal(result.ok, false)
   assert.equal(result.errors.some((item) => item.rule === 'advisory-db-snapshot-stale'), true)


### PR DESCRIPTION
## Resumo

Formally records the evidence packet for the WSL2 kernel upstream configuration contribution campaign (`microsoft/WSL2-Linux-Kernel` at commit `14794180686c2fb6307fbe359c359bec765249f3`).

The campaign validates the activation of `CONFIG_BLK_DEV_UBLK=m` and `CONFIG_ZRAM_WRITEBACK=y` across dual architectures (x86_64 and ARM64) with full builds, Sparse `C=2` static analysis, module packaging, and isolated QEMU capability verification, without impacting or modifying RamShared production code.

## Commits

| Commit | What was done | Why | Details |
|---|---|---|---|
| `a31fc6b` | `docs(wsl-kernel): record evidence for upstream #41054 config contribution` | Formally document the 19 technical gates successfully executed for the upstream WSL2 kernel config contribution | <details><summary>details</summary>**Files:** docs/specs/no-milestone/wsl2-upstream-native-contribution/{PRD.md, SPEC.md, IMPL.md, RESEARCH.md, CONTRIBUTION-CHECKLIST.md}, scripts/kernel/test-wsl-upstream-config-contribution.sh, scripts/kernel/qemu-wsl-config-capability*.sh, docs/INDEX.md, docs/reference/DOCUMENTATION-INVENTORY.json, docs/governance/capability-observations.generated.json<br>**Validation:** ./scripts/docs-check.sh OK, ./scripts/kernel/test-wsl-upstream-config-contribution.sh PASS<br>**Risk/rollback:** Base SHA or path drift in Microsoft kernel repo reverts the packet to NEEDS_REVALIDATION.</details> |

## Issue

Closes #197

## Responsavel

@emersonbusson

## Labels

`type:docs`, `area:kernel`, `area:governance`

## Validacao

- [x] Build/test gates of touched scope (`test-wsl-upstream-config-contribution.sh` PASS)
- [x] `./scripts/docs-check.sh` (all 17 governance and linter modules passing cleanly)
- [x] SSDV3: SPEC/IMPL updated and cited (`docs/specs/no-milestone/wsl2-upstream-native-contribution/`)

## Rollback trigger

Base SHA divergence (`!= 14794180686c2fb6307fbe359c359bec765249f3`), failure of any of the 19 contractual SPEC gates, or unauthorized opening of external PR against Microsoft repository.
