### PR TITLE
fix(crypto): format sha256 upper-hex explicitly by bytes

### DIFF
--- a/crates/ramshared-winbroker/src/service.rs
+++ b/crates/ramshared-winbroker/src/service.rs
@@ -103,7 +103,11 @@ fn verify_active_config(
     if std::fs::canonicalize(path)? != std::fs::canonicalize(expected)? {
         return Err("broker config does not match active manifest path".into());
     }
-    if format!("{:X}", Sha256::digest(bytes)) != artifact.sha256 {
+    let hash_hex: String = Sha256::digest(bytes)
+        .iter()
+        .map(|b| format!("{b:02X}"))
+        .collect();
+    if hash_hex != artifact.sha256 {
         return Err("broker config does not match active manifest hash".into());
     }
     Ok(())

--- a/crates/ramshared-winsvc/src/package.rs
+++ b/crates/ramshared-winsvc/src/package.rs
@@ -207,7 +207,12 @@ pub fn verify_staged_files(
             }
             digest.update(&buffer[..count]);
         }
-        if format!("{:X}", digest.finalize()) != artifact.sha256 {
+        let hash_hex: String = digest
+            .finalize()
+            .iter()
+            .map(|b| format!("{b:02X}"))
+            .collect();
+        if hash_hex != artifact.sha256 {
             return Err(format!("{} hash mismatch", path.display()));
         }
     }
@@ -376,7 +381,10 @@ mod tests {
         for artifact in &mut candidate.artifacts {
             let bytes = artifact.relative_path.as_bytes();
             std::fs::write(root.join(&artifact.relative_path), bytes).unwrap();
-            artifact.sha256 = format!("{:X}", Sha256::digest(bytes));
+            artifact.sha256 = Sha256::digest(bytes)
+                .iter()
+                .map(|b| format!("{b:02X}"))
+                .collect();
         }
         assert!(verify_staged_files(&root, &candidate).is_ok());
         std::fs::write(


### PR DESCRIPTION
## Resumo

Formats SHA-256 hash outputs explicitly via byte iteration with `{b:02X}` instead of relying on the `UpperHex` trait implementation on the digest output array type (`Array` / `GenericArray`).

This guarantees compile-time compatibility across legacy and newer versions of the `sha2` crate (such as `0.11` backed by `hybrid-array`) in Windows components (`ramshared-winbroker` and `ramshared-winsvc`).

## Commits

| Commit | What was done | Why | Details |
|---|---|---|---|
| `a5cd647` | `fix(crypto): format sha256 upper-hex explicitly by bytes` | Format SHA-256 digest bytes with `{b:02X}` | <details><summary>details</summary>**Files:** crates/ramshared-winbroker/src/service.rs, crates/ramshared-winsvc/src/package.rs<br>**Validation:** cargo test -p ramshared-winbroker, cargo test -p ramshared-winsvc, cargo clippy --workspace -- -D warnings, ./scripts/docs-check.sh OK<br>**Risk/rollback:** Revert commit if hash formatting causes output divergence.</details> |

## Issue

N/A / Internal CI build compatibility fix

## Responsavel

@emersonbusson

## Labels

`type:fix`, `area:core`

## Validacao

- [x] Build/test gates of touched scope (`cargo test -p ramshared-winbroker`, `cargo test -p ramshared-winsvc`, `cargo clippy`)
- [x] `./scripts/docs-check.sh`
- [x] SSDV3: N/A (surgical fix in hash formatting without architectural change)

## Rollback trigger

Runtime integrity hash divergence, manifest verification test failure, or break in `verify_staged_files`.
