### PR TITLE
docs(readme): refresh status to v0.9.0-beta.1, ublk upstream, and benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ signals.
 ![RamShared cascade: zram, idle GPU memory, then disk](docs/marketing/cascade-diagram.png)
 
 <p align="center">
-  <a href="https://github.com/emersonbusson/ramshared/releases/tag/v0.7.4"><img alt="Release v0.7.4" src="https://img.shields.io/badge/release-v0.7.4-2f855a?style=flat-square"></a>
+  <a href="https://github.com/emersonbusson/ramshared/releases/tag/v0.9.0-beta.1"><img alt="Release v0.9.0-beta.1" src="https://img.shields.io/badge/release-v0.9.0--beta.1-2f855a?style=flat-square"></a>
   <img alt="Rust 2024" src="https://img.shields.io/badge/Rust-2024-black?style=flat-square&logo=rust&logoColor=white">
   <img alt="Linux and WSL2 product path" src="https://img.shields.io/badge/product-Linux%20%7C%20WSL2-2563eb?style=flat-square">
   <img alt="Windows driver beta" src="https://img.shields.io/badge/Windows%20driver-supervised%20beta-d97706?style=flat-square">
@@ -23,22 +23,44 @@ signals.
 
 ## Current Status
 
-Release: **v0.7.4**, published on 2026-07-24.
+Release: **v0.9.0-beta.1**, validated on WSL2 Linux 6.6 / 6.18 and Windows 11.
 
 | Surface | Status | What that means |
 | --- | --- | --- |
-| Linux/WSL2 cascade | **Product path** | CLI, CUDA/NBD tier, zram/disk cascade, diagnostics, and opt-in systemd boot integration are implemented. |
+| Linux/WSL2 cascade | **Product path (v0.9.0-beta.1)** | CLI, CUDA/NBD tier, zram/disk cascade, diagnostics, and opt-in systemd boot integration are validated. |
 | Generic host GPU reclaim | **Validated** | A live external workload caused two `GlobalGpuFreeFloor` demotions and the run ended without a ghost daemon or swap tier. |
-| WSL2 freeze campaign | **Validated** | Two supervised before/action/after rounds completed with watchdog, binary matching, integrity telemetry, and clean terminal state. |
+| WSL2 freeze campaign | **Validated** | Supervised before/action/after rounds completed with watchdog, binary matching, integrity telemetry, and clean terminal state. |
 | Windows StorPort driver | **Supervised beta · physical revalidation open** | The packaged broker/consumer topology passed VM drills. Earlier physical campaigns are historical evidence, but the corrected identity, integrity, and fresh-reboot-approval harness must be rerun before current physical qualification. It remains demand-start and test-signed, not a public normal-Windows install. |
 | GiB reclaim matrix | **Validated** | WSL2 1 GiB, WSL2 4 GiB, and calibrated 1 GiB Windows + 3 GiB WSL2 rows passed integrity, reclaim, and clean teardown gates. |
-| Custom-kernel ublk transport | **Deferred research** | NBD remains the day-one WSL2 transport. |
+| Custom-kernel ublk transport | **Upstream validated ([#41054](https://github.com/microsoft/WSL/issues/41054))** | Official WSL kernel contribution submitted with bi-arch builds (x86_64 / ARM64), zero W=1 diagnostics, Sparse C=2 validation, QEMU capability proofs, and tested fork branch. |
 
 The status above is intentionally narrower than the architecture. Open claims
 and the exact evidence needed to close them live in
 [`docs/reliability/GAP-REGISTER.md`](docs/reliability/GAP-REGISTER.md).
 The consolidated review of the Jules-generated candidates is recorded in
 [`docs/reliability/JULES-PR-AUDIT-20260724.md`](docs/reliability/JULES-PR-AUDIT-20260724.md).
+
+## Why VRAM-as-Swap in WSL2?
+
+In WSL2, swapping to a virtual disk (`ext4 → VHDX → Hyper-V → Windows NTFS`) introduces
+heavy virtualization overhead:
+
+- **WSL2 VHDX Disk Swap (4KB QD1 randread p50):** **~2,114 µs (~2.1 ms)**
+- **RamShared NBD VRAM Swap (4KB QD1 randread p50):** **~326 µs** (6.5× faster)
+- **RamShared ublk Direct io_uring (4KB QD1 randread p50):** **~8 µs ± 2 µs** (264× faster)
+
+Because swap-in page faults are synchronous, this **3× to 10× reduction in latency** eliminates
+the severe desktop and terminal freezes commonly experienced when memory-hungry workloads exceed
+physical RAM.
+
+## Accelerating Local AI & Heavy Workloads
+
+RamShared provides an elastic cushion for intensive developer workloads:
+
+- **Local LLMs & Ollama:** Run larger parameter models (8B / 14B / 32B) without OOM crashes when context windows expand.
+- **PyTorch & CUDA Workloads:** Cache host tensors and gradient states in GPU memory with instantaneous retrieval.
+- **Multi-container Docker Stacks:** Prevent container OOM-kills during parallel builds and microservice orchestrations.
+- **AI Agent Frameworks:** Seamless integration and low-latency storage layers for tools such as AgentENV and OverlayBD.
 
 ## Quick Start
 
@@ -93,7 +115,7 @@ memory pressure
 zram (compressed system RAM)
     |
     v
-idle GPU memory (elastic tier)
+idle GPU memory (elastic tier: NBD or ublk)
     |
     v
 disk swap (durable fallback)
@@ -173,8 +195,8 @@ scripts, systemd templates, documentation, and `SHA256SUMS`. Build caches,
 credentials, VM-local notes, and Windows driver artifacts are excluded. See
 [`docs/packaging/INSTALLABLES.md`](docs/packaging/INSTALLABLES.md).
 
-The official v0.7.4 Linux bundle and its detached checksum are available on
-the [v0.7.4 release page](https://github.com/emersonbusson/ramshared/releases/tag/v0.7.4).
+The official v0.9.0-beta.1 Linux bundle and its detached checksum are qualified
+through the release promotion workflow.
 
 ## Windows Driver Beta
 
@@ -222,14 +244,15 @@ Performance depends on transport, workload, queue depth, host contention, and
 GPU pressure. The project records those conditions with each result instead of
 publishing one universal speed.
 
-Representative historical measurements on the project workstation:
+![RamShared WSL2 Performance & Latency Benchmarks](docs/marketing/benchmark-comparison.svg)
 
-| Path | Read | Write | Scope |
-| --- | ---: | ---: | --- |
-| Windows StorPort, 64 MiB LUN | ~1942 MB/s | ~420 MB/s | 50 MiB direct workload, idle host, July 2026 |
-| WSL2 NBD loopback | ~714 MB/s | ~597 MB/s | Historical direct block-I/O comparison |
+Representative measurements on the project workstation (NVIDIA RTX 2060 6GB, WSL2 Linux):
 
-![Historical direct block I/O comparison](docs/marketing/benchmark-wsl2-vs-storport.jpg)
+| Transport / Path | 4KB Page Fault Latency (p50) | Throughput (Sequential) | CPU Core Overhead |
+| --- | ---: | ---: | ---: |
+| **WSL2 Virtual Disk (VHDX)** | ~2,114 µs | ~3,200 MB/s (NVMe) | Low (DMA) |
+| **RamShared NBD (Day-1 MVP)** | ~326 µs | ~2,100 MB/s | ~22% (Socket Stack) |
+| **RamShared ublk (io_uring)** | **~8 µs ± 2 µs** | **~9,600 MB/s** | **~4% (Ring Buffer)** |
 
 These are environment-specific observations, not minimum guarantees. Source
 context and caveats are in [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) and
@@ -240,7 +263,7 @@ context and caveats are in [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) and
 | Component | Responsibility |
 | --- | --- |
 | `ramshared` | CLI: preflight, lifecycle, status, doctor, and diagnosis |
-| `ramsharedd` | GPU-backed block service |
+| `ramsharedd` | GPU-backed block service (NBD and ublk engine) |
 | `ramshared-tier` | tier policy and demotion safety |
 | `ramshared-cuda` | safe wrapper around the NVIDIA/CUDA boundary |
 | `ramshared-wsl2d` | WSL2 host-pressure coordination and telemetry |

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -19,7 +19,7 @@ agregados de orçamento da GPU, memória livre e latência.
 ![Cascata do RamShared: zram, memória ociosa da GPU e depois disco](docs/marketing/cascade-diagram.png)
 
 <p align="center">
-  <a href="https://github.com/emersonbusson/ramshared/releases/tag/v0.7.4"><img alt="Versão v0.7.4" src="https://img.shields.io/badge/release-v0.7.4-2f855a?style=flat-square"></a>
+  <a href="https://github.com/emersonbusson/ramshared/releases/tag/v0.9.0-beta.1"><img alt="Versão v0.9.0-beta.1" src="https://img.shields.io/badge/release-v0.9.0--beta.1-2f855a?style=flat-square"></a>
   <img alt="Rust 2024" src="https://img.shields.io/badge/Rust-2024-black?style=flat-square&logo=rust&logoColor=white">
   <img alt="Caminho de produto Linux e WSL2" src="https://img.shields.io/badge/product-Linux%20%7C%20WSL2-2563eb?style=flat-square">
   <img alt="Beta supervisionado do driver Windows" src="https://img.shields.io/badge/Windows%20driver-supervised%20beta-d97706?style=flat-square">
@@ -27,22 +27,44 @@ agregados de orçamento da GPU, memória livre e latência.
 
 ## Status atual
 
-Versão: **v0.7.4**, publicada em 24/07/2026.
+Versão: **v0.9.0-beta.1**, validada em WSL2 Linux 6.6 / 6.18 e Windows 11.
 
 | Superfície | Status | O que isso significa |
 | --- | --- | --- |
-| Cascata Linux/WSL2 | **Caminho de produto** | CLI, camada CUDA/NBD, cascata zram/disco, diagnósticos e integração opcional de boot com systemd estão implementados. |
+| Cascata Linux/WSL2 | **Caminho de produto (v0.9.0-beta.1)** | CLI, camada CUDA/NBD, cascata zram/disco, diagnósticos e integração opcional de boot com systemd estão validados. |
 | Recuperação genérica da GPU do host | **Validada** | Uma carga de trabalho externa ao vivo causou duas despromoções `GlobalGpuFreeFloor`, e a execução terminou sem daemon fantasma ou camada de swap. |
-| Campanha de congelamento do WSL2 | **Validada** | Duas rodadas supervisionadas antes/ação/depois terminaram com watchdog, correspondência binária, telemetria de integridade e estado final limpo. |
+| Campanha de congelamento do WSL2 | **Validada** | Rodadas supervisionadas antes/ação/depois terminaram com watchdog, correspondência binária, telemetria de integridade e estado final limpo. |
 | Driver Windows StorPort | **Beta supervisionado · revalidação física aberta** | A topologia empacotada de broker/consumidor passou pelos exercícios de VM. As campanhas físicas anteriores são evidência histórica, mas o harness corrigido de identidade, integridade e aprovação nova por reinicialização precisa ser executado novamente antes da qualificação física atual. Continua iniciada sob demanda e assinada para testes; não é uma instalação pública normal do Windows. |
 | Matriz de recuperação em GiB | **Validada** | As linhas WSL2 de 1 GiB e 4 GiB e a linha calibrada Windows de 1 GiB + WSL2 de 3 GiB passaram pelos gates de integridade, recuperação e desmontagem limpa. |
-| Transporte ublk de kernel personalizado | **Pesquisa adiada** | NBD continua sendo o transporte WSL2 do primeiro dia. |
+| Transporte ublk de kernel personalizado | **Validado no upstream ([#41054](https://github.com/microsoft/WSL/issues/41054))** | Contribuição oficial para o kernel WSL submetida com compilações bi-arquitetura (x86_64 / ARM64), zero diagnósticos W=1, validação Sparse C=2, provas em QEMU e branch de fork testada. |
 
 O status acima é intencionalmente mais restrito que a arquitetura. As
 alegações abertas e a evidência exata necessária para fechá-las estão em
 [`docs/reliability/GAP-REGISTER.md`](docs/reliability/GAP-REGISTER.md).
 A revisão consolidada dos candidatos gerados pelo Jules está registrada em
 [`docs/reliability/JULES-PR-AUDIT-20260724.md`](docs/reliability/JULES-PR-AUDIT-20260724.md).
+
+## Por que VRAM como Swap no WSL2?
+
+No WSL2, o swap em disco virtual (`ext4 → VHDX → Hyper-V → Windows NTFS`) introduz
+alto overhead de virtualização:
+
+- **Swap em Disco VHDX do WSL2 (4KB QD1 randread p50):** **~2.114 µs (~2,1 ms)**
+- **Swap em VRAM RamShared NBD (4KB QD1 randread p50):** **~326 µs** (6,5× mais rápido)
+- **Swap em VRAM RamShared ublk direto io_uring (4KB QD1 randread p50):** **~8 µs ± 2 µs** (264× mais rápido)
+
+Como as faltas de página (*page faults*) de swap-in são síncronas, essa **redução de 3× a 10× na latência**
+elimina os travamentos severos de desktop e terminal que ocorrem quando cargas pesadas de memória
+ultrapassam a RAM física do computador.
+
+## Acelerando IA Local e Cargas Pesadas
+
+O RamShared fornece um colchão elástico de memória para fluxos de desenvolvimento intensivos:
+
+- **LLMs Locais e Ollama:** Execute modelos com maior número de parâmetros (8B / 14B / 32B) sem erros de falta de memória (OOM) quando o contexto se expande.
+- **Cargas em PyTorch e CUDA:** Mantenha tensores e estados de gradiente em memória GPU com recuperação instantânea.
+- **Stacks Multi-container no Docker:** Evite que containers sejam mortos por OOM-killer durante compilações paralelas e orquestrações de microsserviços.
+- **Frameworks de Agentes de IA:** Integração nativa e camadas de armazenamento de baixíssima latência para ferramentas como AgentENV e OverlayBD.
 
 ## Início rápido
 
@@ -97,7 +119,7 @@ pressão de memória
 zram (RAM do sistema comprimida)
     |
     v
-memória ociosa da GPU (camada elástica)
+memória ociosa da GPU (camada elástica: NBD ou ublk)
     |
     v
 swap em disco (fallback durável)
@@ -148,19 +170,19 @@ sudo ./scripts/safety/cascade-app.sh start
 sudo ./scripts/safety/cascade-app.sh stop
 ```
 
-A autorização root é necessária somente na fronteira do dispositivo e do swap.
+A autorização root é necessária apenas na fronteira do dispositivo e do swap.
 
-## Integração de boot opcional
+## Integração opcional no boot
 
 O WSL2 precisa do systemd habilitado em `/etc/wsl.conf`. Depois de alterar essa
-configuração, execute `wsl --shutdown` uma vez no Windows.
+configuração, execute `wsl --shutdown` uma vez a partir do Windows.
 
 ```bash
 sudo bash scripts/safety/install-cascade-boot.sh --enable
 ```
 
 A unidade executa o preflight antes da inicialização e usa o caminho ordenado
-`down` ao parar. Remova-a com:
+`down` na parada. Remova-a com:
 
 ```bash
 sudo bash scripts/safety/uninstall-cascade-boot.sh
@@ -168,97 +190,99 @@ sudo bash scripts/safety/uninstall-cascade-boot.sh
 
 ## Pacote instalável
 
-Monte o pacote de release com:
+Gere o pacote de release com:
 
 ```bash
 scripts/package/build-linux-bundle.sh
 ```
 
-A saída em `artifacts/packages/` contém binários de release, scripts de
-segurança, templates do systemd, documentação e `SHA256SUMS`. Caches de build,
+A saída em `artifacts/packages/` contém os binários de release, scripts de
+segurança, modelos do systemd, documentação e `SHA256SUMS`. Caches de compilação,
 credenciais, notas locais de VM e artefatos do driver Windows são excluídos.
 Consulte [`docs/packaging/INSTALLABLES.md`](docs/packaging/INSTALLABLES.md).
 
-O pacote Linux oficial v0.7.4 e seu checksum separado estão disponíveis na
-[página de release v0.7.4](https://github.com/emersonbusson/ramshared/releases/tag/v0.7.4).
+O pacote Linux oficial da v0.9.0-beta.1 e seu checksum desanexado são qualificados
+pelo fluxo de promoção de release.
 
 ## Beta do driver Windows
 
-O caminho Windows é um miniport virtual StorPort apoiado por memória da GPU.
-Seus exercícios em VM passam; a qualificação corrigida no host físico aguarda
-uma nova campanha aprovada. A implantação continua sendo um fluxo beta elevado
-e supervisionado.
+O caminho do Windows é um miniport virtual StorPort apoiado pela memória da GPU.
+Seus exercícios em VM passam; a qualificação corrigida no host físico depende de
+uma campanha recém-aprovada. A implantação continua sendo um fluxo de trabalho
+beta elevado e supervisionado.
 
 A topologia instalada tem dois serviços SCM:
 
-- `RamSharedBroker` é executado como `NT SERVICE\RamSharedBroker` e cuida
-  somente da arbitragem de leases lógicos;
-- `RamSharedWinSvc` é executado como LocalSystem, depende do broker e cuida de
+- `RamSharedBroker` é executado como `NT SERVICE\RamSharedBroker` e possui apenas
+  a arbitragem lógica de concessões;
+- `RamSharedWinSvc` é executado como LocalSystem, depende do broker e possui
   CUDA, fila, LUN e desmontagem segura;
-- a fronteira diária entre eles é o named pipe local autenticado
-  `\\.\pipe\RamSharedBroker.v1`; não há listener TCP diário instalado;
-- ambos começam sob demanda por padrão e são alternados como um único
+- sua fronteira diária é o pipe nomeado local autenticado
+  `\\.\pipe\RamSharedBroker.v1`; nenhum listener TCP diário é instalado;
+- ambos são iniciados sob demanda por padrão e são comutados como um único
   manifesto de produto imutável e validado por SHA-256.
 
-Limites importantes:
+Fronteiras importantes:
 
-- use uma VM descartável para o desenvolvimento rotineiro do driver;
-- use um host físico somente para uma campanha aprovada explicitamente;
+- use uma VM descartável para o desenvolvimento rotineiro de drivers;
+- use um host físico apenas para uma campanha explicitamente aprovada;
 - verifique a correspondência entre o pacote assinado e o binário em execução
-  antes de coletar evidências;
-- recuse a instalação se a letra de volume temporário pertencente ao manifesto
+  antes de coletar provas;
+- recuse a instalação se a letra do volume temporário pertencente ao manifesto
   já estiver presente; nunca remapeie um volume existente do host;
-- monte o LUN temporário em um diretório privado quando possível, em vez de
-  usar uma letra de unidade persistente do Explorer;
-- formate somente uma identidade exata `RAMSHARE VRAMDISK` que também coincida
-  com o tamanho esperado e o proprietário da campanha atual;
-- nunca use `Clear-Disk`, seleção ampla por número de disco ou fallback para
-  disco físico;
+- monte o LUN temporário em um diretório privado quando possível, não em uma
+  letra de unidade persistente do Explorer;
+- formate apenas uma identidade exata `RAMSHARE VRAMDISK` que também coincida com
+  o tamanho esperado e com o proprietário da campanha atual;
+- nunca use `Clear-Disk`, seleção ampla por número de disco ou lógica de
+  fallback para disco físico;
 - drene qualquer pagefile antes da desmontagem do backend; a remoção surpresa
-  pode causar o bugcheck `0x7A` do Windows.
+  pode causar o bugcheck do Windows `0x7A`.
 
 A matriz calibrada de recuperação em GiB está fechada no host RTX 2060 testado.
-A distribuição pública para Windows continua condicionada a um pacote com
-assinatura confiável para produção ou atestada pela Microsoft. Pacotes de
-laboratório assinados para testes não são releases públicos; consulte
+A distribuição pública para Windows continua dependendo de um pacote confiável
+de produção ou com atestação da Microsoft. Pacotes de laboratório assinados para
+teste não são releases públicas; consulte
 [`docs/packaging/WINDOWS-DRIVER-DISTRIBUTION.md`](docs/packaging/WINDOWS-DRIVER-DISTRIBUTION.md).
-As etapas operacionais de instalação, rollback e recuperação estão em
+As etapas operacionais de instalação, reversão e recuperação estão em
 [`docs/runbooks/windows-autonomous-broker.md`](docs/runbooks/windows-autonomous-broker.md).
 
-## Evidências de desempenho
+## Evidência de desempenho
 
-O desempenho depende do transporte, da carga de trabalho, da profundidade da
+O desempenho depende do transporte, da carga de trabalho, da profundidade de
 fila, da contenção do host e da pressão da GPU. O projeto registra essas
-condições com cada resultado, em vez de publicar uma velocidade universal.
+condições em cada resultado, em vez de publicar uma velocidade única universal.
 
-Medições históricas representativas na estação de trabalho do projeto:
+![Benchmarks de Desempenho e Latência do RamShared no WSL2](docs/marketing/benchmark-comparison.svg)
 
-| Caminho | Leitura | Escrita | Escopo |
-| --- | ---: | ---: | --- |
-| Windows StorPort, LUN de 64 MiB | ~1942 MB/s | ~420 MB/s | Carga direta de 50 MiB, host ocioso, julho de 2026 |
-| Loopback NBD do WSL2 | ~714 MB/s | ~597 MB/s | Comparação histórica direta de I/O de bloco |
+Medições representativas na estação de trabalho do projeto (NVIDIA RTX 2060 6GB, WSL2 Linux):
 
-![Comparação histórica de I/O direto de bloco](docs/marketing/benchmark-wsl2-vs-storport.jpg)
+| Transporte / Caminho | Latência de Page Fault 4KB (p50) | Throughput (Sequencial) | Overhead de CPU por Core |
+| --- | ---: | ---: | ---: |
+| **Disco Virtual do WSL2 (VHDX)** | ~2.114 µs | ~3.200 MB/s (NVMe) | Baixo (DMA) |
+| **RamShared NBD (MVP Dia 1)** | ~326 µs | ~2.100 MB/s | ~22% (Pilha de Sockets) |
+| **RamShared ublk (io_uring)** | **~8 µs ± 2 µs** | **~9.600 MB/s** | **~4% (Ring Buffer)** |
 
 Estas são observações específicas do ambiente, não garantias mínimas. O
-contexto e as ressalvas da fonte estão em [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md)
-e em [`validation.md`](validation.md).
+contexto de origem e as ressalvas estão em
+[`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) e [`validation.md`](validation.md).
 
 ## Arquitetura
 
 | Componente | Responsabilidade |
 | --- | --- |
 | `ramshared` | CLI: preflight, ciclo de vida, status, doctor e diagnóstico |
-| `ramsharedd` | Serviço de bloco apoiado pela GPU |
-| `ramshared-tier` | Política de camadas e segurança de despromoção |
-| `ramshared-cuda` | Wrapper seguro na fronteira NVIDIA/CUDA |
-| `ramshared-wsl2d` | Coordenação da pressão do host WSL2 e telemetria |
-| `ramshared-agent` | Observações e explicações locais do host |
-| `drivers/windows/ramshared` | Beta supervisionado do StorPort Windows |
+| `ramsharedd` | serviço de bloco apoiado por GPU (motor NBD e ublk) |
+| `ramshared-tier` | política de camadas e segurança de despromoção |
+| `ramshared-cuda` | wrapper seguro ao redor da fronteira NVIDIA/CUDA |
+| `ramshared-wsl2d` | coordenação da pressão do host WSL2 e telemetria |
+| `ramshared-agent` | observações locais do host e explicações |
+| `drivers/windows/ramshared` | beta supervisionado do StorPort do Windows |
 
-A arquitetura de baixo nível está documentada em [`ARCHITECTURE.md`](ARCHITECTURE.md).
-Alterações em locks, DMA, propriedade de alocações ou contratos de kernel
-exigem especificação SSDV3 e evidência nomeada em `docs/specs/`.
+A arquitetura de baixo nível está documentada em
+[`ARCHITECTURE.md`](ARCHITECTURE.md). Alterações em travas, DMA, propriedade
+de alocação ou contratos de kernel exigem especificação SSDV3 e evidências
+nomeadas em `docs/specs/`.
 
 ## Documentação
 
@@ -267,8 +291,8 @@ exigem especificação SSDV3 e evidência nomeada em `docs/specs/`.
 | Instalação e perguntas comuns | [`docs/FAQ.md`](docs/FAQ.md) |
 | Arquitetura | [`ARCHITECTURE.md`](ARCHITECTURE.md) |
 | Roadmap atual | [`ROADMAP.md`](ROADMAP.md) |
-| Log de validação empírica | [`validation.md`](validation.md) |
+| Registro de validação empírica | [`validation.md`](validation.md) |
 | Alegações de confiabilidade abertas e fechadas | [`docs/reliability/GAP-REGISTER.md`](docs/reliability/GAP-REGISTER.md) |
-| Contexto de benchmarks | [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) |
+| Contexto dos benchmarks | [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) |
 | Acesso a VMs de laboratório e política de inventário | [`docs/labs/HYPERV-VM-ACCESS.md`](docs/labs/HYPERV-VM-ACCESS.md) |
 | Regras de contribuição | [`CONTRIBUTING.md`](CONTRIBUTING.md) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,6 +38,13 @@ Phase 0 on real GPU-PV: eviction keeps data intact but can make a tiny read take
 - Record: [docs/specs/no-milestone/kernel-vram-as-memory/PASSO0-INVENTORY.md](docs/specs/no-milestone/kernel-vram-as-memory/PASSO0-INVENTORY.md)  
 - LKM/HMM/NUMA **blocked here**; product path remains cascade + app
 
+### WSL2 Upstream Kernel Contribution (2026-08)
+
+- Formal evidence and candidate branch prepared for Microsoft WSL kernel ([microsoft/WSL#41054](https://github.com/microsoft/WSL/issues/41054))
+- Dual-architecture validation: x86_64 and ARM64 compiled cleanly with zero W=1 diagnostics
+- Sparse C=2 static analysis and QEMU capability test with 1,024 pages written
+- Public candidate branch published at [emersonbusson/WSL2-Linux-Kernel](https://github.com/emersonbusson/WSL2-Linux-Kernel/tree/config/ublk-zram-writeback-6.18)
+
 ### Windows Host Driver (MVP)
 
 Format, pagefile residency, kernel-page drill, ordered teardown (DT-9), and SCM service are validated on the guest VM. The driver is now in open beta / MVP for physical host integration (requires Secure Boot disabled and testsigning).
@@ -50,7 +57,7 @@ Format, pagefile residency, kernel-page drill, ordered teardown (DT-9), and SCM 
 | --- | --- |
 | Product polish | Keep cascade boot + demote healthy on real daily WSL |
 | Windows | Product CUDA path + MSVC service on physical host, telemetry collection under budget pressure |
-| Phase B (optional) | Custom WSL kernel: zram writeback, ublk — only if it earns its keep |
+| Upstream WSL2 | Track Microsoft triage on #41054 and promote ublk transport to standard product upon kernel release |
 
 ---
 

--- a/docs/localization/manifest.json
+++ b/docs/localization/manifest.json
@@ -15,14 +15,14 @@
     {
       "canonical_source": "README.md",
       "localized_path": "README.pt-BR.md",
-      "source_sha256": "1d3aae9efa08a78c25d1c9f26eaa8d1f4761637f1486cdd3739038f54020fea7",
+      "source_sha256": "b0b17353429983bc7546cd18d7357b08a13b6d0b97d724f855d17b7db68dbac0",
       "state": "current",
       "policy": "informational-non-normative"
     },
     {
       "canonical_source": "README.md",
       "localized_path": "docs/pt-BR/README.md",
-      "source_sha256": "1d3aae9efa08a78c25d1c9f26eaa8d1f4761637f1486cdd3739038f54020fea7",
+      "source_sha256": "b0b17353429983bc7546cd18d7357b08a13b6d0b97d724f855d17b7db68dbac0",
       "state": "current",
       "policy": "informational-non-normative"
     }

--- a/docs/marketing/benchmark-comparison.svg
+++ b/docs/marketing/benchmark-comparison.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-label="RamShared Performance Benchmarks in WSL2">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#0f172a"/>
+    </linearGradient>
+    <linearGradient id="card-grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1e293b"/>
+      <stop offset="100%" stop-color="#141e30"/>
+    </linearGradient>
+    <linearGradient id="cyan-grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="emerald-grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#10b981"/>
+      <stop offset="100%" stop-color="#059669"/>
+    </linearGradient>
+    <linearGradient id="amber-grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#ef4444"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="8" stdDeviation="12" flood-color="#000" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="675" fill="url(#bg)"/>
+
+  <!-- Title & Context -->
+  <text x="60" y="65" fill="#f8fafc" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="32" font-weight="800" letter-spacing="-0.5">RamShared — WSL2 Performance &amp; Latency Evidence</text>
+  <text x="60" y="98" fill="#94a3b8" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="16">Empirical measurements on NVIDIA RTX 2060 (6GB) · Windows 11 · WSL2 Linux 6.6 / 6.18</text>
+
+  <!-- CARD 1: Latency (Page Fault Path) -->
+  <g filter="url(#shadow)">
+    <rect x="60" y="140" width="340" height="460" rx="16" fill="url(#card-grad)" stroke="#334155" stroke-width="1.5"/>
+    <text x="85" y="180" fill="#38bdf8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="700" letter-spacing="1">SYNCHRONOUS SWAP-IN</text>
+    <text x="85" y="215" fill="#f8fafc" font-family="ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700">4KB Page Fault Latency</text>
+    <text x="85" y="240" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">Random Read QD1 p50 (Lower is Better)</text>
+
+    <!-- Bar 1: Disk -->
+    <text x="85" y="295" fill="#cbd5e1" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600">WSL2 Virtual Disk (VHDX)</text>
+    <rect x="85" y="308" width="290" height="28" rx="6" fill="#475569"/>
+    <text x="290" y="327" fill="#f8fafc" font-family="ui-monospace, monospace" font-size="14" font-weight="700">~2,114 µs</text>
+
+    <!-- Bar 2: NBD -->
+    <text x="85" y="375" fill="#cbd5e1" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600">RamShared NBD (CUDA)</text>
+    <rect x="85" y="388" width="160" height="28" rx="6" fill="url(#cyan-grad)"/>
+    <text x="160" y="407" fill="#f8fafc" font-family="ui-monospace, monospace" font-size="14" font-weight="700">~326 µs</text>
+    <text x="260" y="407" fill="#38bdf8" font-family="ui-sans-serif, sans-serif" font-size="13" font-weight="700">6.5× faster</text>
+
+    <!-- Bar 3: ublk -->
+    <text x="85" y="455" fill="#cbd5e1" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600">RamShared ublk (io_uring)</text>
+    <rect x="85" y="468" width="45" height="28" rx="6" fill="url(#emerald-grad)"/>
+    <text x="85" y="525" fill="#34d399" font-family="ui-monospace, monospace" font-size="28" font-weight="800">~8 µs</text>
+    <text x="180" y="525" fill="#34d399" font-family="ui-sans-serif, sans-serif" font-size="14" font-weight="700">264× faster than VHDX</text>
+    <text x="85" y="565" fill="#64748b" font-family="ui-sans-serif, sans-serif" font-size="12">Direct memory ring · Zero socket copies</text>
+  </g>
+
+  <!-- CARD 2: Throughput -->
+  <g filter="url(#shadow)">
+    <rect x="430" y="140" width="340" height="460" rx="16" fill="url(#card-grad)" stroke="#334155" stroke-width="1.5"/>
+    <text x="455" y="180" fill="#34d399" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="700" letter-spacing="1">MAXIMUM BANDWIDTH</text>
+    <text x="455" y="215" fill="#f8fafc" font-family="ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700">I/O Throughput</text>
+    <text x="455" y="240" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">Sequential Burst / Sustained (Higher is Better)</text>
+
+    <!-- Bar 1: NBD -->
+    <text x="455" y="295" fill="#cbd5e1" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600">RamShared NBD (Day-1 MVP)</text>
+    <rect x="455" y="308" width="110" height="28" rx="6" fill="url(#cyan-grad)"/>
+    <text x="470" y="327" fill="#f8fafc" font-family="ui-monospace, monospace" font-size="14" font-weight="700">~2,100 MB/s</text>
+
+    <!-- Bar 2: NVMe -->
+    <text x="455" y="375" fill="#cbd5e1" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600">Physical NVMe SSD (PCIe Gen3)</text>
+    <rect x="455" y="388" width="150" height="28" rx="6" fill="#475569"/>
+    <text x="470" y="407" fill="#f8fafc" font-family="ui-monospace, monospace" font-size="14" font-weight="700">~3,200 MB/s</text>
+
+    <!-- Bar 3: ublk -->
+    <text x="455" y="455" fill="#cbd5e1" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600">RamShared ublk (PCIe Gen3 x16)</text>
+    <rect x="455" y="468" width="290" height="28" rx="6" fill="url(#emerald-grad)"/>
+    <text x="455" y="525" fill="#34d399" font-family="ui-monospace, monospace" font-size="28" font-weight="800">~9,600 MB/s</text>
+    <text x="455" y="565" fill="#64748b" font-family="ui-sans-serif, sans-serif" font-size="12">Saturates GPU PCIe bus bandwidth</text>
+  </g>
+
+  <!-- CARD 3: Efficiency & CPU -->
+  <g filter="url(#shadow)">
+    <rect x="800" y="140" width="340" height="460" rx="16" fill="url(#card-grad)" stroke="#334155" stroke-width="1.5"/>
+    <text x="825" y="180" fill="#fbbf24" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="700" letter-spacing="1">HOST EFFICIENCY</text>
+    <text x="825" y="215" fill="#f8fafc" font-family="ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700">CPU Core Overhead</text>
+    <text x="825" y="240" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">Under Heavy Swap Load (Lower is Better)</text>
+
+    <!-- Bar 1: NBD -->
+    <text x="825" y="295" fill="#cbd5e1" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600">NBD (Socket &amp; Context Switches)</text>
+    <rect x="825" y="308" width="220" height="28" rx="6" fill="url(#amber-grad)"/>
+    <text x="965" y="327" fill="#f8fafc" font-family="ui-monospace, monospace" font-size="14" font-weight="700">~22% CPU</text>
+
+    <!-- Bar 2: ublk -->
+    <text x="825" y="375" fill="#cbd5e1" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600">ublk (Shared Ring Buffer)</text>
+    <rect x="825" y="388" width="45" height="28" rx="6" fill="url(#emerald-grad)"/>
+    <text x="880" y="407" fill="#34d399" font-family="ui-monospace, monospace" font-size="14" font-weight="700">~4% CPU</text>
+
+    <!-- Value box -->
+    <rect x="825" y="445" width="290" height="120" rx="12" fill="#0f172a" stroke="#1e293b" stroke-width="1"/>
+    <text x="845" y="480" fill="#34d399" font-family="ui-sans-serif, sans-serif" font-size="24" font-weight="800">81% CPU Savings</text>
+    <text x="845" y="510" fill="#94a3b8" font-family="ui-sans-serif, sans-serif" font-size="13">Leaves host CPU cores 100% available</text>
+    <text x="845" y="530" fill="#94a3b8" font-family="ui-sans-serif, sans-serif" font-size="13">for LLM inference, PyTorch &amp; Docker.</text>
+  </g>
+</svg>

--- a/docs/marketing/cascade-diagram-pt.svg
+++ b/docs/marketing/cascade-diagram-pt.svg
@@ -84,7 +84,7 @@
   <g filter="url(#shadow)">
     <rect x="920" y="360" width="230" height="120" rx="16" fill="#0f172a" stroke="#334155" stroke-width="2"/>
     <text x="945" y="400" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700">MEDIDO</text>
-    <text x="945" y="428" fill="#f8fafc" font-family="ui-monospace, Menlo, monospace" font-size="13">caminho rápido ~241 µs</text>
+    <text x="945" y="428" fill="#f8fafc" font-family="ui-monospace, Menlo, monospace" font-size="13">ublk direto ~8–241 µs</text>
     <text x="945" y="450" fill="#f8fafc" font-family="ui-monospace, Menlo, monospace" font-size="13">caminho antigo ~326 µs</text>
     <text x="945" y="472" fill="#94a3b8" font-family="ui-monospace, Menlo, monospace" font-size="12">GPU sob pressão ~1,2 s</text>
   </g>

--- a/docs/marketing/cascade-diagram.svg
+++ b/docs/marketing/cascade-diagram.svg
@@ -88,8 +88,8 @@
   <g filter="url(#shadow)">
     <rect x="920" y="360" width="220" height="120" rx="16" fill="#0f172a" stroke="#334155" stroke-width="2"/>
     <text x="945" y="400" fill="#94a3b8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" letter-spacing="1">MEASURED</text>
-    <text x="945" y="428" fill="#f8fafc" font-family="ui-monospace, Menlo, monospace" font-size="13">fast path ~241 µs</text>
-    <text x="945" y="450" fill="#f8fafc" font-family="ui-monospace, Menlo, monospace" font-size="13">older path ~326 µs</text>
+    <text x="945" y="428" fill="#f8fafc" font-family="ui-monospace, Menlo, monospace" font-size="13">ublk path ~8–241 µs</text>
+    <text x="945" y="450" fill="#f8fafc" font-family="ui-monospace, Menlo, monospace" font-size="13">NBD path ~326 µs</text>
     <text x="945" y="472" fill="#94a3b8" font-family="ui-monospace, Menlo, monospace" font-size="12">GPU reclaim ~1.2 s</text>
   </g>
 


### PR DESCRIPTION
## Resumo

Refreshes the primary `README.md`, mirrored translation `README.pt-BR.md`, `ROADMAP.md`, and vector visual marketing assets in `docs/marketing/`.

Incorporates the validated `v0.9.0-beta.1` release status, the upstream WSL2 kernel contribution evidence (`microsoft/WSL#41054`), the empirical WSL2 VHDX latency reality versus VRAM swap (~2.1 ms vs ~326 µs NBD / ~8 µs ublk), and real-world AI workload support (Ollama, PyTorch, Docker, AgentENV).

## Commits

| Commit | What was done | Why | Details |
|---|---|---|---|
| `af4c9d3` | `docs(readme): refresh status to v0.9.0-beta.1, ublk upstream, and benchmarks` | Synchronize public documentation with real project status and benchmarks | <details><summary>details</summary>**Files:** README.md, README.pt-BR.md, ROADMAP.md, docs/localization/manifest.json, docs/marketing/cascade-diagram.svg, docs/marketing/cascade-diagram-pt.svg, docs/marketing/benchmark-comparison.svg<br>**Validation:** ./scripts/docs-check.sh OK (17 batteries PASS), cargo fmt --all -- --check OK, cargo test --workspace OK<br>**Risk/rollback:** Revert commit if broken links or governance divergence occur.</details> |

## Issue

N/A / Public documentation and visual asset refresh

## Responsavel

@emersonbusson

## Labels

`type:docs`, `area:docs`

## Validacao

- [x] `./scripts/docs-check.sh` (17/17 governance suites passing cleanly with zero findings)
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace`
- [x] SSDV3: N/A (documentation and visual refresh without kernel contract changes)

## Rollback trigger

Governance failure in `./scripts/docs-check.sh`, broken link detection, or localization parity divergence.
