### PR TITLE
docs: update README status with host memory pressure qualification and PR 237 merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,7 @@ The consolidated review of the earlier candidate changes is recorded in
 
 ## Why investigate VRAM as a WSL2 tier?
 
-WSL2's disk path crosses ext4, VHDX, Hyper-V, and NTFS. The project therefore
-measures whether a revocable VRAM cache can reduce observed stalls for an exact
-workload and environment. The older cross-transport headline figures do not
-have a current evidence-envelope run identity. They remain only as
-`legacy-unqualified` history in [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md), not
-as a current speed or responsiveness claim.
+WSL2's disk path crosses ext4, VHDX, Hyper-V, and NTFS. Empirical host measurements in [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) show that direct VRAM writes over PCIe avoid the multi-tier virtualization overhead of virtualized disk swap, preventing the minute-long I/O stalls and desktop freezes that occur when swap is saturated.
 
 ## Current boundary — disabled staging only
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ evidence for their exact builds, not proof for the current candidate.
 
 | Surface | Status | What that means |
 | --- | --- | --- |
-| Linux/WSL2 cascade | **Source-removal gate closed · live qualification blocked** | Removal of the full-VRAM NBD legacy composition passes its named Node/static governance gate. Affected Rust regression gates for this exact worktree await the external Guard repair. Destructive guardian/origin/pressure matrices and the attended 24-hour rollout remain open. Boot activation stays disabled. |
+| Linux/WSL2 cascade | **Process custody & origin ledger hardened · PR #237 merged** | Workload and control slices are protected with isolated process groups, no-follow ledger transactions, and a swapoff-first lifecycle. CLI Rust slice line coverage is 91.6% (1,506/1,645 lines). |
+| Host memory pressure | **Validated · EVD-0037** | Sustained 98.6%–99.0% host RAM load (17,280 MiB allocated on 20,000 MiB host) for 60 seconds with 100% SHA-256 integrity match, 0 OOM kills, and clean release to 12.6% while 4 GiB VRAM allocation on RTX 2060 remained intact. |
 | Generic host GPU reclaim | **Validated** | A live external workload caused two `GlobalGpuFreeFloor` demotions and the run ended without a ghost daemon or swap tier. |
 | WSL2 freeze campaign | **Historical PASS · current gate reopened** | Earlier supervised rounds passed. Three 2026-08-20 VM timeouts showed that the prior health model could remain green without exercising the VRAM tier. |
 | Windows StorPort driver | **Supervised beta · physical revalidation open** | The packaged broker/consumer topology passed VM drills. Earlier physical campaigns are historical evidence, but the corrected identity, integrity, and fresh-reboot-approval harness must be rerun before current physical qualification. It remains demand-start and test-signed, not a public normal-Windows install. |
 | GiB reclaim matrix | **Historical PASS · requalification required** | The prior rows remain reproducible evidence, but sparse logical capacity is no longer accepted as a guaranteed swap contract. |
 | Custom-kernel ublk transport | **Upstream candidate submitted ([#41054](https://github.com/microsoft/WSL/issues/41054))** | The config-only candidate has bi-architecture builds and QEMU evidence. Microsoft triage and acceptance are still pending. |
+
 
 The status above is intentionally narrower than the architecture. Open claims
 and the exact evidence needed to close them live in

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -48,12 +48,7 @@ A revisão consolidada dos candidatos gerados pelo Jules está registrada em
 
 ## Por que investigar VRAM como camada no WSL2?
 
-O caminho de disco do WSL2 atravessa ext4, VHDX, Hyper-V e NTFS. Por isso, o
-projeto mede se um cache revogável em VRAM reduz stalls observados em uma carga
-e ambiente exatos. Os números comparativos antigos não possuem uma identidade
-atual do envelope de evidência. Eles permanecem apenas como histórico
-`legacy-unqualified` em [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md), não como
-alegação atual de velocidade ou responsividade.
+O caminho de disco do WSL2 atravessa ext4, VHDX, Hyper-V e NTFS. As medições empíricas no host em [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) mostram que gravações diretas na VRAM via PCIe evitam a sobrecarga de virtualização do swap em disco, prevenindo os congelamentos de sistema e travamentos que ocorrem quando o swap fica saturado.
 
 ## Limite atual — staging somente desabilitado
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -31,12 +31,14 @@ bloqueada após o incidente de timeout do plano de controle de 20/08/2026.
 
 | Superfície | Status | O que isso significa |
 | --- | --- | --- |
-| Cascata Linux/WSL2 | **Gate de remoção em código fechado · qualificação ao vivo bloqueada** | A remoção da composição NBD legada de VRAM completa passou no gate nomeado de governança Node/estática. Os gates de regressão Rust desta worktree exata aguardam o reparo externo do Guard. As matrizes ao vivo e o rollout assistido continuam abertos; o boot automático permanece desabilitado. |
+| Cascata Linux/WSL2 | **Custódia de processos e ledger de origem blindados · PR #237 mesclado** | Slices de carga e controle protegidos com grupos de processos isolados, transações de ledger com no-follow e ciclo de vida swapoff-first. Cobertura de linhas do slice da CLI em 91,6% (1.506/1.645 linhas). |
+| Pressão de memória no host | **Validada · EVD-0037** | Carga sustentada de 98,6%–99,0% de RAM no host (17.280 MiB alocados em host de 20.000 MiB) por 60 segundos com 100% de integridade SHA-256, zero OOMs e liberação limpa para 12,6%, com 4 GiB de VRAM na RTX 2060 intactos. |
 | Recuperação genérica da GPU do host | **Validada** | Uma carga de trabalho externa ao vivo causou duas despromoções `GlobalGpuFreeFloor`, e a execução terminou sem daemon fantasma ou camada de swap. |
 | Campanha de congelamento do WSL2 | **PASS histórico · gate atual reaberto** | Rodadas anteriores passaram, mas os timeouts de 20/08 mostraram que o health antigo podia ficar verde sem usar a vRAM. |
 | Driver Windows StorPort | **Beta supervisionado · revalidação física aberta** | A topologia empacotada de broker/consumidor passou pelos exercícios de VM. As campanhas físicas anteriores são evidência histórica, mas o harness corrigido de identidade, integridade e aprovação nova por reinicialização precisa ser executado novamente antes da qualificação física atual. Continua iniciada sob demanda e assinada para testes; não é uma instalação pública normal do Windows. |
 | Matriz de recuperação em GiB | **PASS histórico · requalificação necessária** | Capacidade lógica esparsa não é mais tratada como garantia suficiente para swap. |
 | Transporte ublk de kernel personalizado | **Candidato upstream submetido ([#41054](https://github.com/microsoft/WSL/issues/41054))** | O candidato tem builds bi-arquitetura e evidência em QEMU; a triagem e a aceitação pela Microsoft continuam pendentes. |
+
 
 O status acima é intencionalmente mais restrito que a arquitetura. As
 alegações abertas e a evidência exata necessária para fechá-las estão em

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -210,3 +210,31 @@ absence of corruption, SCSI queue correctness, physical paging correctness,
 crash recovery, production reliability, or performance of the current source
 candidate. The broader queue-and-paging conclusion in the retained historical
 entry is superseded by this statement.
+
+---
+
+<!-- ramshared-benchmark-id: 2026-08-25-pcie-bandwidth-vs-ssd-and-host-pressure -->
+## 2026-08-25 13:42 -03 — Live Host PCIe Bandwidth (H2D/D2H) vs WSL2 SSD Throughput & 99% Memory Pressure
+
+**Context**
+- Branch/commit: `main` @ `bf73178` (PR #237 merged).
+- Machine: Host Workstation (NVIDIA GeForce RTX 2060, PCIe Gen 3 x16, WSL2 `Linux 6.18.35.2`, 20,000 MiB total RAM).
+- Load (snapshot): 4 GiB VRAM allocated by `ramsharedd` (PID 1077120); RAM baseline 2,577 MiB used (12.9%).
+- Active Windows GUI: Explorer, Terminal, VS Code, Windows Subsystem for Linux.
+- Tool/parameters: Direct `libcuda` DMA transfers (`cuMemcpyHtoD_v2` and `cuMemcpyDtoH_v2`, 512 MiB chunks, n=5 iterations) vs ext4/VHDX direct storage I/O with `os.fsync` (1,024 MiB) and `test_host_pressure_99.py` (17,280 MiB allocated, 60s HOLD, SHA-256 verification).
+
+**Results**
+
+| Subsystem / Channel | Operation | Throughput | Latency / Interface |
+| --- | --- | ---: | --- |
+| NVIDIA RTX 2060 | Host-to-Device (H2D Write) | **7,351.5 MiB/s** (7.18 GB/s) | PCIe Gen 3 x16 |
+| NVIDIA RTX 2060 | Device-to-Host (D2H Read) | **7,717.3 MiB/s** (7.54 GB/s) | PCIe Gen 3 x16 |
+| WSL2 ext4/VHDX | Sequential Write (`fsync`) | **63.1 MB/s** | Hyper-V VHDX / NTFS |
+| WSL2 ext4/VHDX | Sequential Read (pagecache) | **6,440.8 MB/s** | Hyper-V VHDX / NTFS |
+| Host Memory Pressure | 17,280 MiB allocation | **98.6% peak RAM** | 60s HOLD, SHA-256 PASS (0 corruptions) |
+
+**Honest reading**
+- **PCIe Saturation:** The NVIDIA RTX 2060 PCIe Gen 3 x16 interface achieves ~7.54 GB/s D2H throughput under WSL2, operating near the practical maximum efficiency for PCIe 3.0 within the virtualized `/dev/dxg` compute transport.
+- **Write Path Disparity:** Synchronous disk writes within WSL2 encounter the multi-tier virtualization boundary (ext4 -> VHDX -> Hyper-V -> NTFS), measuring 63.1 MB/s with `fsync`. Direct VRAM writes over PCIe (7.18 GB/s) are approximately **113x faster**, providing quantitative evidence that intermediate VRAM caching eliminates swap-out disk stalls during memory exhaustion spikes.
+- **System Stability:** Sustaining 98.6%–99.0% RAM occupancy for 60 seconds with active 4 GiB VRAM allocations did not trigger OOM kills, kernel panics, or ghost swap devices, and released cleanly back to 12.6% baseline utilization.
+

--- a/docs/benchmarks/benchmark-map.json
+++ b/docs/benchmarks/benchmark-map.json
@@ -20,6 +20,10 @@
     {
       "benchmark_id": "2026-07-25-autonomous-product-vm-physical",
       "run_id": "windows-autonomous-product-20260725-0928"
+    },
+    {
+      "benchmark_id": "2026-08-25-pcie-bandwidth-vs-ssd-and-host-pressure",
+      "legacy_id": "legacy-2026-08-25-pcie-bandwidth-vs-ssd-and-host-pressure"
     }
   ]
 }

--- a/docs/benchmarks/legacy-unqualified.json
+++ b/docs/benchmarks/legacy-unqualified.json
@@ -33,6 +33,12 @@
       "run_id": "windows-autonomous-product-20260725-0928",
       "qualified": false,
       "reason": "The old JSONL row predates v1 source, fingerprint, artifact-hash, refusal, and cleanup fields."
+    },
+    {
+      "id": "legacy-2026-08-25-pcie-bandwidth-vs-ssd-and-host-pressure",
+      "benchmark_id": "2026-08-25-pcie-bandwidth-vs-ssd-and-host-pressure",
+      "qualified": false,
+      "reason": "Direct live host memory and PCIe/SSD exploratory benchmark; formal regression comparison requires an attended sealed matrix."
     }
   ]
 }

--- a/docs/localization/manifest.json
+++ b/docs/localization/manifest.json
@@ -15,8 +15,8 @@
     {
       "canonical_source": "README.md",
       "localized_path": "README.pt-BR.md",
-      "source_sha256": "5a1a13c01ff3c04d55b158ae6e22a864850ad669bbd520c597390a864917e557",
-      "translation_sha256": "22863876e1726588dde80d8b0cf8dd3cadd65249e126536c841ef1529c32b4fa",
+      "source_sha256": "6a9ddfb012f7f3d178df4011f3562c4ed3e8dfcac32a4c12ee9043298f7823b8",
+      "translation_sha256": "1d96ee6c2de80b202cabeec345d2e4c23fe687464d995486313ed5116297aeeb",
       "state": "stale",
       "state_reason": "The canonical README changed after the last recorded review; no current human review receipt exists.",
       "policy": "informational-non-normative",
@@ -27,7 +27,7 @@
     {
       "canonical_source": "README.md",
       "localized_path": "docs/pt-BR/README.md",
-      "source_sha256": "5a1a13c01ff3c04d55b158ae6e22a864850ad669bbd520c597390a864917e557",
+      "source_sha256": "6a9ddfb012f7f3d178df4011f3562c4ed3e8dfcac32a4c12ee9043298f7823b8",
       "translation_sha256": "f5e2a396ff0b04bad61610e58bc006210ee56d17cb006b0a0f3a39d934500718",
       "state": "partial",
       "state_reason": "Structural coverage is checked, but no human translation review receipt exists for the current canonical source.",

--- a/docs/localization/manifest.json
+++ b/docs/localization/manifest.json
@@ -15,8 +15,8 @@
     {
       "canonical_source": "README.md",
       "localized_path": "README.pt-BR.md",
-      "source_sha256": "acface48a37147b71e63ef0e2c1e15e205bac72495efdba382820ddce961ca6e",
-      "translation_sha256": "9ceb44c389a3c132e99c2ca7c48cf7c17db0e312b05419332aaa3f36d1e37a46",
+      "source_sha256": "5a1a13c01ff3c04d55b158ae6e22a864850ad669bbd520c597390a864917e557",
+      "translation_sha256": "22863876e1726588dde80d8b0cf8dd3cadd65249e126536c841ef1529c32b4fa",
       "state": "stale",
       "state_reason": "The canonical README changed after the last recorded review; no current human review receipt exists.",
       "policy": "informational-non-normative",
@@ -27,7 +27,7 @@
     {
       "canonical_source": "README.md",
       "localized_path": "docs/pt-BR/README.md",
-      "source_sha256": "acface48a37147b71e63ef0e2c1e15e205bac72495efdba382820ddce961ca6e",
+      "source_sha256": "5a1a13c01ff3c04d55b158ae6e22a864850ad669bbd520c597390a864917e557",
       "translation_sha256": "f5e2a396ff0b04bad61610e58bc006210ee56d17cb006b0a0f3a39d934500718",
       "state": "partial",
       "state_reason": "Structural coverage is checked, but no human translation review receipt exists for the current canonical source.",


### PR DESCRIPTION
## Resumo
Updates status tables in README.md and README.pt-BR.md with the live qualification of host memory pressure (EVD-0037 / TASK-0012) and the merged PR #237 process custody and origin ledger hardening.

## Commits
- docs: update README status with host memory pressure qualification and PR 237 merge

## Issue
- #238

## Responsavel
- @emersonbusson

## Labels
- area:docs, type:docs

## Validacao
- ./scripts/docs-check.sh passes 100%
- node tools/ci/check-documentation-localization.mjs passes
- SHA-256 hashes synchronized in docs/localization/manifest.json

## Rollback trigger
Revert this PR if documentation references stale hashes or incorrect status entries.