### PR TITLE
docs: point Portuguese README to localized cascade diagram

### DIFF
--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -15,7 +15,7 @@ Rust e os gates ao vivo de guardião, origem, pressão e rollout assistido segue
 abertos. Resultados históricos valem apenas para suas revisões registradas; o
 RamShared não adiciona VRAM aos aplicativos nem identifica cargas pelo nome.
 
-![Cascata do RamShared: zram, memória ociosa da GPU e depois disco](docs/marketing/cascade-diagram.png)
+![Cascata do RamShared: zram, memória ociosa da GPU e depois disco](docs/marketing/cascade-diagram-pt.png)
 
 <p align="center">
   <a href="https://github.com/emersonbusson/ramshared/releases/tag/v0.9.0-beta.1"><img alt="Versão v0.9.0-beta.1" src="https://img.shields.io/badge/release-v0.9.0--beta.1-2f855a?style=flat-square"></a>

--- a/docs/localization/manifest.json
+++ b/docs/localization/manifest.json
@@ -16,7 +16,7 @@
       "canonical_source": "README.md",
       "localized_path": "README.pt-BR.md",
       "source_sha256": "054fd07eb0e27db85a89fb9084a32ec80059ac058c532c6ff2261448b3ac407b",
-      "translation_sha256": "a2a59227ce5b2f9f5dd6b7c8d352db7c60dc3d1b780e145420c234c4af73cda1",
+      "translation_sha256": "e59c67d59373cdc1f7ec9fd28ff8595dc2faa81686db6da10f9b99a8601a5823",
       "state": "stale",
       "state_reason": "The canonical README changed after the last recorded review; no current human review receipt exists.",
       "policy": "informational-non-normative",


### PR DESCRIPTION
## Resumo

Points the localized Portuguese README (`README.pt-BR.md`) to `docs/marketing/cascade-diagram-pt.png` instead of the English diagram (`cascade-diagram.png`), and updates the corresponding SHA-256 hash in `docs/localization/manifest.json`.

## Commits

- `d114dce` — docs: point Portuguese README to localized cascade diagram

## Issue

N/A

## Responsavel

@emersonbusson

## Labels

`area:core`, `type:docs`

## Validacao

- `./scripts/docs-check.sh` — 100% PASS (✓ docs-check OK).

## Rollback trigger

Broken image links or localization checksum mismatch.