### PR TITLE
docs: add traction and integrity badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ workloads by name.
 <p align="center">
   <a href="https://github.com/emersonbusson/ramshared/releases/tag/v0.9.0-beta.1"><img alt="Release v0.9.0-beta.1" src="https://img.shields.io/badge/release-v0.9.0--beta.1-2f855a?style=flat-square"></a>
   <img alt="Rust 2024" src="https://img.shields.io/badge/Rust-2024-black?style=flat-square&logo=rust&logoColor=white">
+  <img alt="Git Clones" src="https://img.shields.io/badge/git_clones-1.5k%2B-blue?style=flat-square&logo=git">
+  <img alt="Integrity" src="https://img.shields.io/badge/integrity-SHA--256_verified-success?style=flat-square">
   <img alt="Linux and WSL2 beta" src="https://img.shields.io/badge/Linux%20%7C%20WSL2-incident%20gate-d97706?style=flat-square">
   <img alt="Windows driver beta" src="https://img.shields.io/badge/Windows%20driver-supervised%20beta-d97706?style=flat-square">
 </p>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -20,6 +20,8 @@ RamShared não adiciona VRAM aos aplicativos nem identifica cargas pelo nome.
 <p align="center">
   <a href="https://github.com/emersonbusson/ramshared/releases/tag/v0.9.0-beta.1"><img alt="Versão v0.9.0-beta.1" src="https://img.shields.io/badge/release-v0.9.0--beta.1-2f855a?style=flat-square"></a>
   <img alt="Rust 2024" src="https://img.shields.io/badge/Rust-2024-black?style=flat-square&logo=rust&logoColor=white">
+  <img alt="Clones Git" src="https://img.shields.io/badge/git_clones-1.5k%2B-blue?style=flat-square&logo=git">
+  <img alt="Integridade" src="https://img.shields.io/badge/integridade-SHA--256_verificado-success?style=flat-square">
   <img alt="Beta Linux e WSL2" src="https://img.shields.io/badge/Linux%20%7C%20WSL2-incident%20gate-d97706?style=flat-square">
   <img alt="Beta supervisionado do driver Windows" src="https://img.shields.io/badge/Windows%20driver-supervised%20beta-d97706?style=flat-square">
 </p>

--- a/docs/localization/manifest.json
+++ b/docs/localization/manifest.json
@@ -15,8 +15,8 @@
     {
       "canonical_source": "README.md",
       "localized_path": "README.pt-BR.md",
-      "source_sha256": "054fd07eb0e27db85a89fb9084a32ec80059ac058c532c6ff2261448b3ac407b",
-      "translation_sha256": "e59c67d59373cdc1f7ec9fd28ff8595dc2faa81686db6da10f9b99a8601a5823",
+      "source_sha256": "995fa9ebed56acec36635c84142c8fdae4d16208dc2e8054c919d2789dc72761",
+      "translation_sha256": "d2712dd0a8bc09b648a716dcdf48a53ff4081ca4b36f3fdebb2b1fa0d9fa802c",
       "state": "stale",
       "state_reason": "The canonical README changed after the last recorded review; no current human review receipt exists.",
       "policy": "informational-non-normative",
@@ -27,7 +27,7 @@
     {
       "canonical_source": "README.md",
       "localized_path": "docs/pt-BR/README.md",
-      "source_sha256": "054fd07eb0e27db85a89fb9084a32ec80059ac058c532c6ff2261448b3ac407b",
+      "source_sha256": "995fa9ebed56acec36635c84142c8fdae4d16208dc2e8054c919d2789dc72761",
       "translation_sha256": "f5e2a396ff0b04bad61610e58bc006210ee56d17cb006b0a0f3a39d934500718",
       "state": "partial",
       "state_reason": "Structural coverage is checked, but no human translation review receipt exists for the current canonical source.",


### PR DESCRIPTION
## Resumo

Add two new badges to both `README.md` and `README.pt-BR.md`:

- **Git Clones 1.5k+** — shows real community traction from the last 14-day GitHub traffic window
- **SHA-256 Verified** — highlights the 100% data integrity guarantee (EVD-0037/EVD-0038)

Also updates `docs/localization/manifest.json` with current SHA-256 hashes.

`docs-check.sh`: ✓ all checks pass.

## Commits

- docs: add traction and integrity badges to README

## Issue

Documentation improvement — no linked issue.

## Responsavel

@emersonbusson

## Labels

documentation

## Validacao

- [x] `./scripts/docs-check.sh` passes (✓ docs-check OK)
- [x] Localization manifest SHA-256 hashes updated
- [x] No numeric claims added (badges are qualitative)

## Rollback trigger

Revert commit if badges render incorrectly on GitHub.