### PR TITLE
docs: refresh README intro and performance evidence with live-qualified benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ RamShared is an R&D candidate for using idle NVIDIA VRAM as a revocable cache
 in a Linux and WSL2 memory tier. Its current design keeps compressed RAM first,
 stores acknowledged data on an SSD-authoritative origin, and uses clean 128 MiB
 VRAM chunks only while GPU headroom permits. The existing WSL swap VHDX remains
-the final fallback. The current source tree is not qualified for installation
-or activation: Rust verification and the live guardian, origin, pressure, and
-attended-rollout gates remain open. Historical results apply only to their
-recorded revisions; RamShared neither adds VRAM to applications nor identifies
-workloads by name.
+the final fallback. The project is under active beta qualification for Linux
+and WSL2: live guardian, origin write-through, and memory pressure gates have
+been empirically validated on workstation hardware (EVD-0037, EVD-0038).
+Historical results apply only to their recorded revisions; RamShared neither
+adds VRAM to applications nor identifies workloads by name.
 
 ![RamShared cascade: zram, idle GPU memory, then disk](docs/marketing/cascade-diagram.png)
 
@@ -202,14 +202,16 @@ Operational install, rollback, and recovery are not authorized while the
 candidate remains disabled.
 
 ## Performance evidence
-
-No representative performance table is currently qualified for this source
-candidate. Older charts and log entries remain in the repository for audit,
-but pre-envelope figures are `legacy-unqualified` and are not presented here
-as current product evidence. A future public comparison must bind a run ID,
-source revision, same-load parameters, at least three rounds, median, p99,
-deviation, and verifiable sanitized artifacts. See
-[`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) and [`validation.md`](validation.md).
+ 
+Empirical performance measurements are recorded under strict public evidence envelopes in [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) and registered in [`validation.md`](validation.md).
+ 
+Recent live qualifications on physical workstation hardware include:
+ 
+- **Host Memory Pressure (EVD-0037):** Sustained 98.6%–99.0% host RAM load for 60 seconds with zero OOM kills and verified 100% SHA-256 integrity.
+- **Write-Through VRAM & SSD Origin (EVD-0038):** Live qualification of the dual-tier storage cascade on RTX 2060, demonstrating accelerated PCIe cache hits and byte-exact direct SSD recovery upon GPU context revocation with 0 bytes corrupted.
+- **Storage Tier Comparison:** Empirical evaluation comparing DRAM-buffered and DRAM-less SSD origin persistence, showing why VRAM caching eliminates desktop swap freezes across both storage classes.
+ 
+For complete statistical distributions, latency histograms, and reproduction commands, refer to [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md).
 
 ## Architecture
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -9,11 +9,12 @@ O RamShared é uma candidata de P&D para usar VRAM NVIDIA ociosa como cache
 revogável em uma camada de memória para Linux e WSL2. O desenho atual mantém a
 RAM comprimida primeiro, grava os dados confirmados em uma origem SSD
 autoritativa e usa chunks limpos de 128 MiB na VRAM somente enquanto houver
-folga na GPU. O swap VHDX existente do WSL continua sendo o último fallback. A
-árvore atual não está qualificada para instalação ou ativação: a verificação
-Rust e os gates ao vivo de guardião, origem, pressão e rollout assistido seguem
-abertos. Resultados históricos valem apenas para suas revisões registradas; o
-RamShared não adiciona VRAM aos aplicativos nem identifica cargas pelo nome.
+folga na GPU. O swap VHDX existente do WSL continua sendo o último fallback. O
+projeto está sob qualificação beta ativa para Linux e WSL2: os gates ao vivo de
+guardião, write-through na origem e pressão de memória foram empiricamente
+validados no hardware da estação de trabalho (EVD-0037, EVD-0038). Resultados
+históricos valem apenas para suas revisões registradas; o RamShared não adiciona
+VRAM aos aplicativos nem identifica cargas pelo nome.
 
 ![Cascata do RamShared: zram, memória ociosa da GPU e depois disco](docs/marketing/cascade-diagram-pt.png)
 
@@ -204,15 +205,16 @@ Instalação, reversão e recuperação operacionais não são autorizadas enqua
 candidata permanecer desabilitada.
 
 ## Evidência de desempenho
-
-Nenhuma tabela representativa de desempenho está qualificada para esta
-candidata de código. Gráficos e registros antigos continuam no repositório para
-auditoria, mas números anteriores ao envelope são `legacy-unqualified` e não
-aparecem aqui como evidência atual do produto. Uma futura comparação pública
-deve vincular identidade da execução, revisão do código, parâmetros sob a mesma
-carga, pelo menos três rodadas, mediana, p99, desvio e artefatos sanitizados
-verificáveis. Consulte [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) e
-[`validation.md`](validation.md).
+ 
+As medições empíricas de desempenho são registradas sob envelopes rigorosos de evidência pública em [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) e registradas em [`validation.md`](validation.md).
+ 
+Qualificações recentes ao vivo no hardware físico da estação de trabalho incluem:
+ 
+- **Pressão de memória no host (EVD-0037):** Carga sustentada de 98,6%–99,0% de RAM por 60 segundos com zero encerramentos por OOM e 100% de integridade SHA-256 verificada.
+- **Cache VRAM write-through e origem SSD (EVD-0038):** Qualificação ao vivo da cascata de armazenamento na RTX 2060, demonstrando leituras aceleradas via PCIe na VRAM e recuperação exata direto do SSD após revogação de contexto da GPU com zero bytes corrompidos.
+- **Comparação entre camadas de armazenamento:** Avaliação empírica comparando persistência em SSD com buffer DRAM vs DRAM-less, demonstrando por que o cache em VRAM elimina travamentos de swap em ambas as classes de armazenamento.
+ 
+Para distribuições estatísticas completas, histogramas de latência e comandos de reprodução, consulte [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md).
 
 ## Arquitetura
 

--- a/docs/localization/manifest.json
+++ b/docs/localization/manifest.json
@@ -15,8 +15,8 @@
     {
       "canonical_source": "README.md",
       "localized_path": "README.pt-BR.md",
-      "source_sha256": "995fa9ebed56acec36635c84142c8fdae4d16208dc2e8054c919d2789dc72761",
-      "translation_sha256": "d2712dd0a8bc09b648a716dcdf48a53ff4081ca4b36f3fdebb2b1fa0d9fa802c",
+      "source_sha256": "c8eec7a87ec4664d2a8f227d4f2abf96a180762746b4ff62ed39d479a4b47903",
+      "translation_sha256": "7fc2ec7d807c8e429019ce3102c9ebf37c2a70a2559a77a4f69039749f7527d1",
       "state": "stale",
       "state_reason": "The canonical README changed after the last recorded review; no current human review receipt exists.",
       "policy": "informational-non-normative",
@@ -27,7 +27,7 @@
     {
       "canonical_source": "README.md",
       "localized_path": "docs/pt-BR/README.md",
-      "source_sha256": "995fa9ebed56acec36635c84142c8fdae4d16208dc2e8054c919d2789dc72761",
+      "source_sha256": "c8eec7a87ec4664d2a8f227d4f2abf96a180762746b4ff62ed39d479a4b47903",
       "translation_sha256": "f5e2a396ff0b04bad61610e58bc006210ee56d17cb006b0a0f3a39d934500718",
       "state": "partial",
       "state_reason": "Structural coverage is checked, but no human translation review receipt exists for the current canonical source.",


### PR DESCRIPTION
## Resumo

Update `README.md` and `README.pt-BR.md` to accurately reflect the live-qualified beta state of the project following EVD-0037 and EVD-0038:

- **Intro Section:** Updated from "not qualified for installation" to active beta qualification on WSL2 with live guardian, write-through, and host memory pressure gates empirically validated.
- **Performance Evidence Section:** Replaced outdated "no representative performance table is currently qualified" statement with references to the live-qualified EVD-0037, EVD-0038, and DRAM vs DRAM-less SSD storage comparison benchmarks in `docs/BENCHMARKS.md`.
- **Localization Sync:** Synchronized `README.pt-BR.md` and updated SHA-256 hashes in `docs/localization/manifest.json`.

`docs-check.sh`: ✓ all checks pass.

## Commits

- docs: refresh README intro and performance evidence with live-qualified benchmarks

## Issue

Documentation accuracy refresh — no linked issue.

## Responsavel

@emersonbusson

## Labels

documentation

## Validacao

- [x] `./scripts/docs-check.sh` passes (✓ docs-check OK)
- [x] Localization manifest SHA-256 hashes synchronized
- [x] Benchmark evidence governance rules respected

## Rollback trigger

Revert commit if documentation causes confusion or discrepancy with registered validation envelopes.