### PR TITLE
docs: update release references to v0.9.0-beta.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ adds VRAM to applications nor identifies workloads by name.
 ![RamShared cascade: zram, idle GPU memory, then disk](docs/marketing/cascade-diagram.png)
 
 <p align="center">
-  <a href="https://github.com/emersonbusson/ramshared/releases/tag/v0.9.0-beta.1"><img alt="Release v0.9.0-beta.1" src="https://img.shields.io/badge/release-v0.9.0--beta.1-2f855a?style=flat-square"></a>
+  <a href="https://github.com/emersonbusson/ramshared/releases/tag/v0.9.0-beta.2"><img alt="Release v0.9.0-beta.2" src="https://img.shields.io/badge/release-v0.9.0--beta.2-2f855a?style=flat-square"></a>
   <img alt="Rust 2024" src="https://img.shields.io/badge/Rust-2024-black?style=flat-square&logo=rust&logoColor=white">
   <img alt="Git Clones" src="https://img.shields.io/badge/git_clones-1.5k%2B-blue?style=flat-square&logo=git">
   <img alt="Integrity" src="https://img.shields.io/badge/integrity-SHA--256_verified-success?style=flat-square">
@@ -25,7 +25,7 @@ adds VRAM to applications nor identifies workloads by name.
 
 ## Current Status
 
-Release: **v0.9.0-beta.1**. The installed WSL2 cascade is temporarily gated
+Release: **v0.9.0-beta.2**. The installed WSL2 cascade is temporarily gated
 after the 2026-08-20 control-plane timeout incident; historical results remain
 evidence for their exact builds, not proof for the current candidate.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -19,7 +19,7 @@ VRAM aos aplicativos nem identifica cargas pelo nome.
 ![Cascata do RamShared: zram, memória ociosa da GPU e depois disco](docs/marketing/cascade-diagram-pt.png)
 
 <p align="center">
-  <a href="https://github.com/emersonbusson/ramshared/releases/tag/v0.9.0-beta.1"><img alt="Versão v0.9.0-beta.1" src="https://img.shields.io/badge/release-v0.9.0--beta.1-2f855a?style=flat-square"></a>
+  <a href="https://github.com/emersonbusson/ramshared/releases/tag/v0.9.0-beta.2"><img alt="Versão v0.9.0-beta.2" src="https://img.shields.io/badge/release-v0.9.0--beta.2-2f855a?style=flat-square"></a>
   <img alt="Rust 2024" src="https://img.shields.io/badge/Rust-2024-black?style=flat-square&logo=rust&logoColor=white">
   <img alt="Clones Git" src="https://img.shields.io/badge/git_clones-1.5k%2B-blue?style=flat-square&logo=git">
   <img alt="Integridade" src="https://img.shields.io/badge/integridade-SHA--256_verificado-success?style=flat-square">
@@ -29,7 +29,7 @@ VRAM aos aplicativos nem identifica cargas pelo nome.
 
 ## Status atual
 
-Versão: **v0.9.0-beta.1**. A cascata instalada no WSL2 está temporariamente
+Versão: **v0.9.0-beta.2**. A cascata instalada no WSL2 está temporariamente
 bloqueada após o incidente de timeout do plano de controle de 20/08/2026.
 
 | Superfície | Status | O que isso significa |

--- a/docs/localization/manifest.json
+++ b/docs/localization/manifest.json
@@ -15,8 +15,8 @@
     {
       "canonical_source": "README.md",
       "localized_path": "README.pt-BR.md",
-      "source_sha256": "c8eec7a87ec4664d2a8f227d4f2abf96a180762746b4ff62ed39d479a4b47903",
-      "translation_sha256": "7fc2ec7d807c8e429019ce3102c9ebf37c2a70a2559a77a4f69039749f7527d1",
+      "source_sha256": "9a43edd26c174f5a1856344f93725b7e48b9e86215100d0be135aa02681a3816",
+      "translation_sha256": "c8707b48d2f6edec3090eedb7cf8822988a661f4a1220e0ebb67911bce5afb7d",
       "state": "stale",
       "state_reason": "The canonical README changed after the last recorded review; no current human review receipt exists.",
       "policy": "informational-non-normative",
@@ -27,7 +27,7 @@
     {
       "canonical_source": "README.md",
       "localized_path": "docs/pt-BR/README.md",
-      "source_sha256": "c8eec7a87ec4664d2a8f227d4f2abf96a180762746b4ff62ed39d479a4b47903",
+      "source_sha256": "9a43edd26c174f5a1856344f93725b7e48b9e86215100d0be135aa02681a3816",
       "translation_sha256": "f5e2a396ff0b04bad61610e58bc006210ee56d17cb006b0a0f3a39d934500718",
       "state": "partial",
       "state_reason": "Structural coverage is checked, but no human translation review receipt exists for the current canonical source.",


### PR DESCRIPTION
## Resumo

Update `README.md` and `README.pt-BR.md` release badge and current status text to reference the newly published `v0.9.0-beta.2` release.

- Badge updated to `v0.9.0-beta.2`
- Status header updated to `v0.9.0-beta.2`
- Synchronized with `README.pt-BR.md` and `docs/localization/manifest.json`

`docs-check.sh`: ✓ all checks pass.

## Commits

- docs: update release references to v0.9.0-beta.2

## Issue

Release documentation update — follows publication of v0.9.0-beta.2.

## Responsavel

@emersonbusson

## Labels

documentation

## Validacao

- [x] `./scripts/docs-check.sh` passes (✓ docs-check OK)
- [x] Release exists and is published: https://github.com/emersonbusson/ramshared/releases/tag/v0.9.0-beta.2

## Rollback trigger

Revert commit if release tag is renamed or updated.