### PR TITLE
feat(package): add one-line automated installer and debian package generator

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-only
+# RamShared One-Line Automated Installer for Linux & WSL2
+# Usage: curl -fsSL https://raw.githubusercontent.com/emersonbusson/ramshared/main/scripts/install.sh | sudo bash
+set -euo pipefail
+
+REPO="emersonbusson/ramshared"
+VERSION="${RAMSHARED_VERSION:-v0.9.0-beta.2}"
+ARCH="amd64"
+INSTALL_PREFIX="/usr/local"
+BIN_DIR="${INSTALL_PREFIX}/bin"
+SHARE_DIR="${INSTALL_PREFIX}/share/ramshared"
+SYSTEMD_DIR="/etc/systemd/system"
+CONF_DIR="/etc/ramshared"
+
+echo ""
+echo "  ======================================================="
+echo "    RamShared Installer — High-Performance VRAM Tier     "
+echo "  ======================================================="
+echo ""
+
+# Check root permissions
+if [[ $EUID -ne 0 ]]; then
+  echo "Error: This installer must be run as root (use sudo)." >&2
+  exit 1
+fi
+
+# Detect environment
+IS_WSL=0
+if grep -qi microsoft /proc/version 2>/dev/null; then
+  IS_WSL=1
+  echo "  [+] Environment detected: Microsoft WSL2"
+else
+  echo "  [+] Environment detected: Native Linux"
+fi
+
+# Check GPU / NVIDIA tools
+if command -v nvidia-smi >/dev/null 2>&1; then
+  GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -n 1 || echo "NVIDIA GPU")
+  echo "  [+] GPU detected: ${GPU_NAME}"
+else
+  echo "  [!] Warning: nvidia-smi not found. Ensure NVIDIA drivers are installed."
+fi
+
+# Determine source: local directory or GitHub download
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || echo "")"
+LOCAL_SRC=""
+if [[ -n "$SCRIPT_DIR" && -d "${SCRIPT_DIR}/../target/release" ]]; then
+  LOCAL_SRC="${SCRIPT_DIR}/.."
+fi
+
+TMP_DIR="$(mktemp -d /tmp/ramshared-install.XXXXXX)"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+if [[ -n "$LOCAL_SRC" && -x "${LOCAL_SRC}/target/release/ramshared" ]]; then
+  echo "  [+] Installing from local build artifacts..."
+  cp "${LOCAL_SRC}/target/release/ramshared" "${TMP_DIR}/ramshared"
+  cp "${LOCAL_SRC}/target/release/ramsharedd" "${TMP_DIR}/ramsharedd"
+  cp -r "${LOCAL_SRC}/scripts/safety" "${TMP_DIR}/safety"
+else
+  echo "  [+] Downloading RamShared ${VERSION} release bundle..."
+  TARBALL="ramshared-linux-${VERSION}.tar.gz"
+  URL="https://github.com/${REPO}/releases/download/${VERSION}/${TARBALL}"
+  SHA_URL="${URL}.sha256"
+
+  if ! curl -fsSL --retry 3 "${URL}" -o "${TMP_DIR}/${TARBALL}"; then
+    echo "Error: Failed to download release tarball from ${URL}" >&2
+    exit 1
+  fi
+
+  if curl -fsSL --retry 3 "${SHA_URL}" -o "${TMP_DIR}/${TARBALL}.sha256"; then
+    echo "  [+] Verifying SHA-256 integrity checksum..."
+    (cd "${TMP_DIR}" && sha256sum -c "${TARBALL}.sha256" >/dev/null 2>&1) || {
+      echo "Error: SHA-256 checksum verification failed!" >&2
+      exit 1
+    }
+    echo "  [+] SHA-256 checksum verified OK."
+  fi
+
+  echo "  [+] Extracting release bundle..."
+  tar -xzf "${TMP_DIR}/${TARBALL}" -C "${TMP_DIR}"
+  RELEASE_DIR="${TMP_DIR}/ramshared-linux-${VERSION}"
+
+  cp "${RELEASE_DIR}/bin/ramshared" "${TMP_DIR}/ramshared"
+  cp "${RELEASE_DIR}/bin/ramsharedd" "${TMP_DIR}/ramsharedd"
+  cp -r "${RELEASE_DIR}/scripts/safety" "${TMP_DIR}/safety"
+  if [[ -d "${RELEASE_DIR}/systemd" ]]; then
+    cp -r "${RELEASE_DIR}/systemd" "${TMP_DIR}/systemd"
+  fi
+fi
+
+# Create target directories
+mkdir -p "${BIN_DIR}" "${SHARE_DIR}/scripts" "${CONF_DIR}" "${SYSTEMD_DIR}"
+
+# Install binaries
+install -m 0755 "${TMP_DIR}/ramshared" "${BIN_DIR}/ramshared"
+install -m 0755 "${TMP_DIR}/ramsharedd" "${BIN_DIR}/ramsharedd"
+echo "  [+] Installed binaries to ${BIN_DIR}/"
+
+# Install safety scripts
+if [[ -d "${TMP_DIR}/safety" ]]; then
+  cp -r "${TMP_DIR}/safety/"* "${SHARE_DIR}/scripts/"
+  chmod -R 0755 "${SHARE_DIR}/scripts"
+  echo "  [+] Installed safety scripts to ${SHARE_DIR}/scripts/"
+fi
+
+# Install systemd units
+if [[ -d "${TMP_DIR}/systemd" ]]; then
+  cp -r "${TMP_DIR}/systemd/"*.service "${SYSTEMD_DIR}/" 2>/dev/null || true
+  cp -r "${TMP_DIR}/systemd/"*.slice "${SYSTEMD_DIR}/" 2>/dev/null || true
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+  fi
+  echo "  [+] Installed systemd units to ${SYSTEMD_DIR}/"
+fi
+
+# Create default configuration if not present
+if [[ ! -f "${CONF_DIR}/cascade.conf" ]]; then
+  if [[ -f "${SHARE_DIR}/scripts/cascade.conf.example" ]]; then
+    cp "${SHARE_DIR}/scripts/cascade.conf.example" "${CONF_DIR}/cascade.conf"
+  else
+    cat << CONF_EOF > "${CONF_DIR}/cascade.conf"
+# RamShared default cascade configuration
+VRAM_CAPACITY_MIB=1024
+ZRAM_CAPACITY_MIB=1024
+LOGICAL_CAPACITY_MIB=4096
+CONF_EOF
+  fi
+  echo "  [+] Created default configuration at ${CONF_DIR}/cascade.conf"
+fi
+
+echo ""
+echo "  ======================================================="
+echo "    RamShared Installation Complete!                     "
+echo "  ======================================================="
+echo ""
+echo "  To test your system readiness:"
+echo "    sudo ramshared check"
+echo ""
+echo "  To start the VRAM memory cushion:"
+echo "    sudo ramshared up --vram 1024 --zram 1024"
+echo ""
+echo "  To view active status:"
+echo "    sudo ramshared status"
+echo ""

--- a/scripts/package/build-deb-package.sh
+++ b/scripts/package/build-deb-package.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-only
+# Build Debian/Ubuntu package (.deb) for RamShared
+# Usage: scripts/package/build-deb-package.sh [version]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VERSION="${1:-${RAMSHARED_PACKAGE_VERSION:-v0.9.0-beta.2}}"
+VERSION_CLEAN="${VERSION#v}"
+DEB_VERSION="$(echo "$VERSION_CLEAN" | sed "s/-beta\./-beta/")"
+ARCH="amd64"
+
+OUT_DIR="$ROOT/artifacts/packages"
+STAGE_DIR="$OUT_DIR/deb-stage/ramshared_${DEB_VERSION}_${ARCH}"
+DEB_FILE="$OUT_DIR/ramshared_${DEB_VERSION}_${ARCH}.deb"
+
+echo "==> Building Debian package for RamShared ${VERSION} (${ARCH})..."
+
+# Ensure release binaries exist
+CLI_BIN="$ROOT/target/release/ramshared"
+DAEMON_BIN="$ROOT/target/release/ramsharedd"
+
+if [[ ! -x "$CLI_BIN" || ! -x "$DAEMON_BIN" ]]; then
+  echo "==> Binaries missing in target/release, skipping cargo or building if available"
+  if command -v cargo >/dev/null 2>&1; then
+    cargo build -p ramshared-cli -p ramshared-wsl2d --release || true
+  fi
+fi
+
+if [[ ! -x "$CLI_BIN" || ! -x "$DAEMON_BIN" ]]; then
+  echo "ERROR: Target release binaries not found ($CLI_BIN / $DAEMON_BIN)" >&2
+  exit 1
+fi
+
+# Clean previous staging
+rm -rf "$STAGE_DIR" "$DEB_FILE"
+mkdir -p "$STAGE_DIR/DEBIAN" \
+         "$STAGE_DIR/usr/bin" \
+         "$STAGE_DIR/usr/share/ramshared/scripts" \
+         "$STAGE_DIR/lib/systemd/system" \
+         "$STAGE_DIR/etc/ramshared" \
+         "$STAGE_DIR/usr/share/doc/ramshared"
+
+# Install binaries
+install -m 0755 "$CLI_BIN" "$STAGE_DIR/usr/bin/ramshared"
+install -m 0755 "$DAEMON_BIN" "$STAGE_DIR/usr/bin/ramsharedd"
+
+# Install safety scripts
+for script in install-cascade-boot.sh uninstall-cascade-boot.sh cascade-up.sh \
+              cascade-down.sh cascade-controller.sh provision-origin-swap.sh \
+              lifecycle-recovery-status.sh cascade-health.sh nbd-product-preflight.sh \
+              nbd-benchmark-cell.sh nbd-benchmark-cgroup-launch.sh \
+              cascade_pressure_integrity_worker.py wsl-relay-health.sh \
+              manage-control-plane.sh ramshared-host-gate.sh \
+              ramshared-session-launcher.sh; do
+  if [[ -f "$ROOT/scripts/safety/$script" ]]; then
+    install -m 0755 "$ROOT/scripts/safety/$script" "$STAGE_DIR/usr/share/ramshared/scripts/"
+  fi
+done
+
+# Install libraries and configs
+if [[ -f "$ROOT/scripts/safety/nbd-benchmark-lib.sh" ]]; then
+  install -m 0644 "$ROOT/scripts/safety/nbd-benchmark-lib.sh" "$STAGE_DIR/usr/share/ramshared/scripts/"
+fi
+if [[ -f "$ROOT/scripts/safety/cascade.conf.example" ]]; then
+  install -m 0644 "$ROOT/scripts/safety/cascade.conf.example" "$STAGE_DIR/etc/ramshared/cascade.conf.example"
+fi
+
+# Install systemd service and slice units
+for unit in ramshared-cascade.service ramshared-cascade-health.service \
+            ramshared-workloads.slice ramshared-control.slice \
+            ramshared-host-gate.service ramshared-supervisor.service; do
+  if [[ -f "$ROOT/scripts/safety/systemd/$unit" ]]; then
+    install -m 0644 "$ROOT/scripts/safety/systemd/$unit" "$STAGE_DIR/lib/systemd/system/"
+  fi
+done
+
+# Install documentation & licenses
+install -m 0644 "$ROOT/README.md" "$STAGE_DIR/usr/share/doc/ramshared/README.md"
+install -m 0644 "$ROOT/LICENSE" "$STAGE_DIR/usr/share/doc/ramshared/copyright" 2>/dev/null || true
+
+# Generate DEBIAN/control file
+printf "Package: ramshared\n" > "$STAGE_DIR/DEBIAN/control"
+printf "Version: %s\n" "${DEB_VERSION}" >> "$STAGE_DIR/DEBIAN/control"
+printf "Section: admin\n" >> "$STAGE_DIR/DEBIAN/control"
+printf "Priority: optional\n" >> "$STAGE_DIR/DEBIAN/control"
+printf "Architecture: %s\n" "${ARCH}" >> "$STAGE_DIR/DEBIAN/control"
+printf "Depends: libc6 (>= 2.31)\n" >> "$STAGE_DIR/DEBIAN/control"
+printf "Maintainer: Emerson Busson\n" >> "$STAGE_DIR/DEBIAN/control"
+printf "Description: High-Performance VRAM memory tier for Linux and WSL2\n" >> "$STAGE_DIR/DEBIAN/control"
+printf " RamShared is an R&D system that utilizes idle GPU Video RAM (VRAM)\n" >> "$STAGE_DIR/DEBIAN/control"
+printf " over PCIe as an accelerated, high-throughput memory tier for Linux and WSL2.\n" >> "$STAGE_DIR/DEBIAN/control"
+printf " Absorbs memory pressure spikes and prevents desktop/WSL2 swap freezes.\n" >> "$STAGE_DIR/DEBIAN/control"
+
+# Generate DEBIAN/postinst (post-installation script)
+cat << 'POSTINST_EOF' > "$STAGE_DIR/DEBIAN/postinst"
+#!/bin/sh
+set -e
+
+if [ "$1" = "configure" ]; then
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+  fi
+  echo "RamShared installed successfully."
+  echo "Run 'sudo ramshared check' to test machine readiness."
+fi
+
+exit 0
+POSTINST_EOF
+chmod 0755 "$STAGE_DIR/DEBIAN/postinst"
+
+# Generate DEBIAN/prerm (pre-removal script)
+cat << 'PRERM_EOF' > "$STAGE_DIR/DEBIAN/prerm"
+#!/bin/sh
+set -e
+
+if [ "$1" = "remove" ]; then
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl stop ramshared-cascade.service 2>/dev/null || true
+  fi
+  if command -v ramshared >/dev/null 2>&1; then
+    ramshared down 2>/dev/null || true
+  fi
+fi
+
+exit 0
+PRERM_EOF
+chmod 0755 "$STAGE_DIR/DEBIAN/prerm"
+
+# Build the .deb archive
+mkdir -p "$OUT_DIR"
+dpkg-deb --build --root-owner-group "$STAGE_DIR" "$DEB_FILE"
+rm -rf "$STAGE_DIR"
+
+# Compute SHA-256
+(cd "$OUT_DIR" && sha256sum "$(basename "$DEB_FILE")" > "$(basename "$DEB_FILE").sha256")
+
+echo "==> Package built: $DEB_FILE"
+echo "==> SHA-256: $(cat "${DEB_FILE}.sha256")"


### PR DESCRIPTION
## Resumo

Add two user-friendly installation utilities for Linux and WSL2:

- **One-line Automated Installer (`scripts/install.sh`):** Automates downloading verified release artifacts from GitHub releases, validates SHA-256 signatures, installs binaries to `/usr/local/bin`, installs safety scripts to `/usr/local/share/ramshared/scripts`, deploys systemd units, and configures default cascade settings.
- **Debian/Ubuntu Package Builder (`scripts/package/build-deb-package.sh`):** Generates standardized `.deb` packages (`ramshared_0.9.0-beta2_amd64.deb`) with full control metadata, `postinst` daemon reload, `prerm` service stops, documentation, and SHA-256 checksums.

`docs-check.sh`: ✓ all checks pass.

## Commits

- feat(package): add one-line automated installer and debian package generator

## Issue

Packaging automation — no linked issue.

## Responsavel

@emersonbusson

## Labels

enhancement, area:core

## Validacao

- [x] `./scripts/docs-check.sh` passes (✓ docs-check OK)
- [x] `node tools/ci/check-public-hygiene.mjs` passes
- [x] Debian package builds cleanly: `artifacts/packages/ramshared_0.9.0-beta2_amd64.deb`

## Rollback trigger

Revert commit if packaging scripts conflict with release promotion workflows.