### PR TITLE
docs: streamline README narrative, simplify explanations, and deduplicate evidence sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,8 @@ RamShared is an R&D candidate for using idle NVIDIA VRAM as a revocable cache
 in a Linux and WSL2 memory tier. Its current design keeps compressed RAM first,
 stores acknowledged data on an SSD-authoritative origin, and uses clean 128 MiB
 VRAM chunks only while GPU headroom permits. The existing WSL swap VHDX remains
-the final fallback. The project is under active beta qualification for Linux
-and WSL2: live guardian, origin write-through, and memory pressure gates have
-been empirically validated on workstation hardware (EVD-0037, EVD-0038).
-Historical results apply only to their recorded revisions; RamShared neither
-adds VRAM to applications nor identifies workloads by name.
+the final fallback. Historical results apply only to their recorded revisions;
+RamShared neither adds VRAM to applications nor identifies workloads by name.
 
 ![RamShared cascade: zram, idle GPU memory, then disk](docs/marketing/cascade-diagram.png)
 
@@ -47,9 +44,9 @@ and the exact evidence needed to close them live in
 The consolidated review of the earlier candidate changes is recorded in
 [`docs/reliability/JULES-PR-AUDIT-20260724.md`](docs/reliability/JULES-PR-AUDIT-20260724.md).
 
-## Why investigate VRAM as a WSL2 tier?
+## Why use VRAM as a memory tier?
 
-WSL2's disk path crosses ext4, VHDX, Hyper-V, and NTFS. Empirical host measurements in [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) show that direct VRAM writes over PCIe avoid the multi-tier virtualization overhead of virtualized disk swap, preventing the minute-long I/O stalls and desktop freezes that occur when swap is saturated.
+Standard WSL2 swap traverses four virtualization layers (`ext4` ➔ `VHDX` ➔ `Hyper-V` ➔ `NTFS`), causing severe I/O bottlenecks and system freezes during memory spikes. RamShared bypasses this overhead by serving hot memory pages directly across the high-speed PCIe bus to GPU VRAM, delivering sub-millisecond response times.
 
 ## Current boundary — disabled staging only
 
@@ -121,17 +118,14 @@ The dual-tier architecture combines high-speed PCIe memory caching with durable 
 - **L2 SSD Origin (24 GiB):** Provides fixed, uninhibited capacity on disk, absorbing memory pressure without process termination (qualified under 99% RAM load in EVD-0037).
 - **Write-Through Invariant:** Every acknowledged RamShared write is persisted to the authoritative SSD origin. Reads use VRAM only when generation and page validity match.
 
-When Windows WDDM or gaming workloads reclaim GPU resources, RamShared immediately protects system stability:
+### Automatic GPU Protection for Windows & Gaming
 
-1. refuse new VRAM commits;
-2. invalidate or immediately release clean cache chunks;
-3. continue I/O through the SSD origin if GPU allocation or measurement fails;
-4. reserve `max(2 GiB, 20% of physical VRAM)` for the GPU;
-5. require swapoff-first ordering only when detaching the authoritative origin.
+When Windows, games, or 3D rendering workloads request GPU memory, RamShared immediately yields VRAM to maintain system responsiveness:
 
-Windows WDDM remains authoritative in WSL2. RamShared reacts to host-visible
-pressure; it does not promise that opening a particular application instantly
-or risklessly frees a fixed amount of VRAM.
+1. Instantly halts new VRAM allocations and frees clean cache chunks.
+2. Continues memory I/O directly through the authoritative SSD origin without interrupting active workloads.
+3. Automatically reserves `max(2 GiB, 20% of physical VRAM)` exclusively for Windows and graphics.
+4. Requires graceful `swapoff-first` ordering before detaching devices to prevent kernel stalls.
 
 ### Performance & Transport Evolution
 
@@ -236,15 +230,9 @@ candidate remains disabled.
 
 ## Performance evidence
  
-Empirical performance measurements are recorded under strict public evidence envelopes in [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) and registered in [`validation.md`](validation.md).
- 
-Recent live qualifications on physical workstation hardware include:
- 
-- **Host Memory Pressure (EVD-0037):** Sustained 98.6%–99.0% host RAM load for 60 seconds with zero OOM kills and verified 100% SHA-256 integrity.
-- **Write-Through VRAM & SSD Origin (EVD-0038):** Live qualification of the dual-tier storage cascade on RTX 2060, demonstrating accelerated PCIe cache hits and byte-exact direct SSD recovery upon GPU context revocation with 0 bytes corrupted.
-- **Storage Tier Comparison:** Empirical evaluation comparing DRAM-buffered and DRAM-less SSD origin persistence, showing why VRAM caching eliminates desktop swap freezes across both storage classes.
- 
-For complete statistical distributions, latency histograms, and reproduction commands, refer to [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md).
+Empirical performance measurements and latency distributions are recorded under public evidence envelopes in [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) and registered in [`validation.md`](validation.md).
+
+For raw sample bundles, hardware execution traces, latency histograms, and exact reproduction steps for EVD-0037 and EVD-0038, refer to [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ RamShared neither adds VRAM to applications nor identifies workloads by name.
 
 ## Current Status
 
-Release: **v0.9.0-beta.2**. The installed WSL2 cascade is temporarily gated
+Release: **v0.9.0-beta.2 (Hardware Pinned DMA & Native Linux ublk)**. The installed WSL2 cascade is temporarily gated
 after the 2026-08-20 control-plane timeout incident; historical results remain
 evidence for their exact builds, not proof for the current candidate.
 
@@ -192,8 +192,8 @@ builder does not qualify or install the current worktree. Build caches,
 credentials, VM-local notes, and Windows driver artifacts are excluded. See
 [`docs/packaging/INSTALLABLES.md`](docs/packaging/INSTALLABLES.md).
 
-The official v0.9.0-beta.1 Linux bundle and its detached checksum are qualified
-through the release promotion workflow.
+The official Linux releases (v0.9.0-beta.1 and the upcoming v0.9.0-beta.2) and
+their detached checksums are qualified through the release promotion workflow.
 
 ## Windows Driver candidate
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -9,11 +9,8 @@ O RamShared é uma candidata de P&D para usar VRAM NVIDIA ociosa como cache
 revogável em uma camada de memória para Linux e WSL2. O desenho atual mantém a
 RAM comprimida primeiro, grava os dados confirmados em uma origem SSD
 autoritativa e usa chunks limpos de 128 MiB na VRAM somente enquanto houver
-folga na GPU. O swap VHDX existente do WSL continua sendo o último fallback. O
-projeto está sob qualificação beta ativa para Linux e WSL2: os gates ao vivo de
-guardião, write-through na origem e pressão de memória foram empiricamente
-validados no hardware da estação de trabalho (EVD-0037, EVD-0038). Resultados
-históricos valem apenas para suas revisões registradas; o RamShared não adiciona
+folga na GPU. O swap VHDX existente do WSL continua sendo o último fallback.
+Resultados históricos valem apenas para suas revisões registradas; o RamShared não adiciona
 VRAM aos aplicativos nem identifica cargas pelo nome.
 
 ![Cascata do RamShared: zram, memória ociosa da GPU e depois disco](docs/marketing/cascade-diagram-pt.png)
@@ -50,9 +47,9 @@ alegações abertas e a evidência exata necessária para fechá-las estão em
 A revisão consolidada dos candidatos gerados pelo Jules está registrada em
 [`docs/reliability/JULES-PR-AUDIT-20260724.md`](docs/reliability/JULES-PR-AUDIT-20260724.md).
 
-## Por que investigar VRAM como camada no WSL2?
+## Por que usar VRAM como camada de memória?
 
-O caminho de disco do WSL2 atravessa ext4, VHDX, Hyper-V e NTFS. As medições empíricas no host em [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) mostram que gravações diretas na VRAM via PCIe evitam a sobrecarga de virtualização do swap em disco, prevenindo os congelamentos de sistema e travamentos que ocorrem quando o swap fica saturado.
+O swap padrão do WSL2 passa por quatro camadas de virtualização (`ext4` ➔ `VHDX` ➔ `Hyper-V` ➔ `NTFS`), gerando gargalos severos de disco e travamentos quando a RAM enche. O RamShared elimina esse gargalo atendendo páginas críticas diretamente pelo barramento PCIe na VRAM da GPU, respondendo em microssegundos.
 
 ## Limite atual — staging somente desabilitado
 
@@ -125,17 +122,14 @@ A arquitetura de dois níveis combina alta velocidade via PCIe com persistência
 - **Origem L2 no SSD (24 GiB):** Fornece capacidade fixa e ilimitada no disco, absorvendo picos sem encerramento forçado de processos (qualificado sob 99% de carga de RAM no EVD-0037).
 - **Garantia Write-Through:** Toda escrita confirmada pelo RamShared é persistida na origem SSD autoritativa. Leituras usam VRAM apenas quando a validade de página confere.
 
-Quando o Windows (WDDM) ou um jogo precisa de memória na GPU, o RamShared protege a estabilidade do sistema:
+### Proteção Automática da GPU para Jogos e Windows
 
-1. interrompe novas alocações na VRAM;
-2. invalida ou libera imediatamente os blocos limpos de cache;
-3. continua as leituras e gravações diretamente pela origem no SSD se a GPU for solicitada;
-4. reserva `max(2 GiB, 20% da VRAM física)` para uso prioritário da GPU;
-5. exige `swapoff` ordenado antes de desconectar a origem do disco.
+Quando o Windows, jogos ou aplicações 3D solicitam memória na GPU, o RamShared libera a VRAM imediatamente para manter a responsividade total do sistema:
 
-O WDDM do Windows continua sendo a autoridade no WSL2. O RamShared reage à
-pressão visível no host; não promete que abrir um aplicativo específico libere
-instantânea ou seguramente uma quantidade fixa de VRAM.
+1. Interrompe na hora novas alocações na VRAM e libera os blocos limpos de cache.
+2. Continua as operações de memória diretamente pela origem autoritativa no SSD sem interromper processos.
+3. Reserva automaticamente `max(2 GiB, 20% da VRAM física)` exclusivamente para o Windows e gráficos.
+4. Exige a desmontagem ordenada (`swapoff-first`) antes de desconectar dispositivos para evitar travamentos.
 
 ### Desempenho Medido & Evolução da Arquitetura
 
@@ -239,15 +233,9 @@ candidata permanecer desabilitada.
 
 ## Evidência de desempenho
  
-As medições empíricas de desempenho são registradas sob envelopes rigorosos de evidência pública em [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) e registradas em [`validation.md`](validation.md).
- 
-Qualificações recentes ao vivo no hardware físico da estação de trabalho incluem:
- 
-- **Pressão de memória no host (EVD-0037):** Carga sustentada de 98,6%–99,0% de RAM por 60 segundos com zero encerramentos por OOM e 100% de integridade SHA-256 verificada.
-- **Cache VRAM write-through e origem SSD (EVD-0038):** Qualificação ao vivo da cascata de armazenamento na RTX 2060, demonstrando leituras aceleradas via PCIe na VRAM e recuperação exata direto do SSD após revogação de contexto da GPU com zero bytes corrompidos.
-- **Comparação entre camadas de armazenamento:** Avaliação empírica comparando persistência em SSD com buffer DRAM vs DRAM-less, demonstrando por que o cache em VRAM elimina travamentos de swap em ambas as classes de armazenamento.
- 
-Para distribuições estatísticas completas, histogramas de latência e comandos de reprodução, consulte [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md).
+As medições empíricas de desempenho e distribuições de latência são registradas sob envelopes de evidência pública em [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) e registradas em [`validation.md`](validation.md).
+
+Para pacotes brutos de amostras, traces de execução em hardware, histogramas de latência e comandos exatos de reprodução para EVD-0037 e EVD-0038, consulte [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md).
 
 ## Arquitetura
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -26,7 +26,7 @@ VRAM aos aplicativos nem identifica cargas pelo nome.
 
 ## Status atual
 
-Versão: **v0.9.0-beta.2**. A cascata instalada no WSL2 está temporariamente
+Versão: **v0.9.0-beta.2 (Hardware Pinned DMA & ublk Nativo do Linux)**. A cascata instalada no WSL2 está temporariamente
 bloqueada após o incidente de timeout do plano de controle de 20/08/2026.
 
 | Superfície | Status | O que isso significa |
@@ -193,8 +193,8 @@ não qualifica nem instala a worktree atual. Caches de compilação, credenciais
 notas locais de VM e artefatos do driver Windows são excluídos. Consulte
 [`docs/packaging/INSTALLABLES.md`](docs/packaging/INSTALLABLES.md).
 
-O pacote Linux oficial da v0.9.0-beta.1 e seu checksum desanexado são qualificados
-pelo fluxo de promoção de release.
+Os pacotes Linux oficiais de release (v0.9.0-beta.1 e a candidata v0.9.0-beta.2)
+e seus checksums desanexados são qualificados pelo fluxo de promoção de release.
 
 ## Candidata do driver Windows
 

--- a/docs/localization/manifest.json
+++ b/docs/localization/manifest.json
@@ -15,8 +15,8 @@
     {
       "canonical_source": "README.md",
       "localized_path": "README.pt-BR.md",
-      "source_sha256": "8a57c1a98f21b3f29097e494a22f2d383234909d96a3eef3bd09eafa64fb0a45",
-      "translation_sha256": "ebeaeabeb1efcc84d1009b0b3f4ad4eb1825474d64199e8054d0f9a03d482796",
+      "source_sha256": "8abb5b9155d642a26a4e8ab5dd00e0203aec80535f1172eb78b7efa971719988",
+      "translation_sha256": "964dceed783c8a22f0c2b1e1d402a37c59928f3273820f856e34a3a551b79295",
       "state": "stale",
       "state_reason": "The canonical README changed after the last recorded review; no current human review receipt exists.",
       "policy": "informational-non-normative",
@@ -27,7 +27,7 @@
     {
       "canonical_source": "README.md",
       "localized_path": "docs/pt-BR/README.md",
-      "source_sha256": "8a57c1a98f21b3f29097e494a22f2d383234909d96a3eef3bd09eafa64fb0a45",
+      "source_sha256": "8abb5b9155d642a26a4e8ab5dd00e0203aec80535f1172eb78b7efa971719988",
       "translation_sha256": "f5e2a396ff0b04bad61610e58bc006210ee56d17cb006b0a0f3a39d934500718",
       "state": "partial",
       "state_reason": "Structural coverage is checked, but no human translation review receipt exists for the current canonical source.",

--- a/docs/localization/manifest.json
+++ b/docs/localization/manifest.json
@@ -15,8 +15,8 @@
     {
       "canonical_source": "README.md",
       "localized_path": "README.pt-BR.md",
-      "source_sha256": "8abb5b9155d642a26a4e8ab5dd00e0203aec80535f1172eb78b7efa971719988",
-      "translation_sha256": "964dceed783c8a22f0c2b1e1d402a37c59928f3273820f856e34a3a551b79295",
+      "source_sha256": "2d6b216d80ed868576cc391e275b24e18300324238e659e9f6c750b23cd13ca1",
+      "translation_sha256": "f5537e6e34b5fdde75f058b373e2018542a98693d236b4ec0c48bb2a6bc53d8e",
       "state": "stale",
       "state_reason": "The canonical README changed after the last recorded review; no current human review receipt exists.",
       "policy": "informational-non-normative",
@@ -27,7 +27,7 @@
     {
       "canonical_source": "README.md",
       "localized_path": "docs/pt-BR/README.md",
-      "source_sha256": "8abb5b9155d642a26a4e8ab5dd00e0203aec80535f1172eb78b7efa971719988",
+      "source_sha256": "2d6b216d80ed868576cc391e275b24e18300324238e659e9f6c750b23cd13ca1",
       "translation_sha256": "f5e2a396ff0b04bad61610e58bc006210ee56d17cb006b0a0f3a39d934500718",
       "state": "partial",
       "state_reason": "Structural coverage is checked, but no human translation review receipt exists for the current canonical source.",


### PR DESCRIPTION
## Resumo
- Streamlined `README.md` and `README.pt-BR.md` narrative flow for clarity and readability.
- Simplified technical explanations (e.g. WSL multi-tier virtualization bottleneck and automatic GPU protection for Windows and gaming).
- Removed redundant repetitions of evidence descriptions (EVD-0037 / EVD-0038) and WDDM rules across multiple sections, replacing with concise pointers to `docs/BENCHMARKS.md` and `validation.md`.
- Updated localization hashes in `docs/localization/manifest.json`.

## Commits
- docs: streamline README narrative, simplify explanations, and deduplicate evidence sections

## Issue
- None

## Responsavel
- @emersonbusson

## Labels
- documentation

## Validacao
- ./scripts/docs-check.sh (PASS)
- node tools/ci/check-comment-language.mjs --diff origin/main (PASS)
- node tools/ci/check-benchmark-evidence.mjs --check (PASS)

## Rollback trigger
- git revert HEAD