### PR TITLE
🧹 [refactor WinDriveConfig validation logic into helper functions]

### DIFF
--- a/crates/ramshared-winsvc/src/config.rs
+++ b/crates/ramshared-winsvc/src/config.rs
@@ -110,6 +110,14 @@ impl WinDriveConfig {
 
     /// Validate invariants before provision (DT-2).
     pub fn validate(&self) -> Result<(), ConfigError> {
+        self.validate_block_size_and_size()?;
+        self.validate_queue_depth_and_io()?;
+        self.validate_paths_and_letter()?;
+        self.validate_service_parameters()?;
+        Ok(())
+    }
+
+    fn validate_block_size_and_size(&self) -> Result<(), ConfigError> {
         if self.block_size != 512 && self.block_size != 4096 {
             return Err(ConfigError::Invalid {
                 field: "block_size",
@@ -134,6 +142,10 @@ impl WinDriveConfig {
                 detail: "must be multiple of block_size".into(),
             });
         }
+        Ok(())
+    }
+
+    fn validate_queue_depth_and_io(&self) -> Result<(), ConfigError> {
         if self.queue_depth == 0
             || self.queue_depth > MAX_QUEUE_DEPTH
             || !self.queue_depth.is_power_of_two()
@@ -175,6 +187,10 @@ impl WinDriveConfig {
                 ),
             });
         }
+        Ok(())
+    }
+
+    fn validate_paths_and_letter(&self) -> Result<(), ConfigError> {
         if !is_absolute_path(&self.evidence_path) {
             return Err(ConfigError::Invalid {
                 field: "evidence_path",
@@ -204,6 +220,10 @@ impl WinDriveConfig {
                 });
             }
         }
+        Ok(())
+    }
+
+    fn validate_service_parameters(&self) -> Result<(), ConfigError> {
         if self.tenant.is_empty() {
             return Err(ConfigError::Invalid {
                 field: "tenant",


### PR DESCRIPTION
## Resumo
Refactored `WinDriveConfig::validate` in `crates/ramshared-winsvc/src/config.rs` into modular helper validation methods (`validate_block_size_and_size`, `validate_queue_depth_and_io`, `validate_paths_and_letter`, and `validate_service_parameters`).

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| refactor(winsvc): split WinDriveConfig validation into helper functions | Separou a lógica de validação de `WinDriveConfig` em funções auxiliares | Melhora a legibilidade e manutenibilidade do código | <details><summary>Detalhes</summary>Dividiu a função monolithic `validate()` em 4 métodos privados focados em regras específicas, mantendo todas as verificações e mensagens de erro originais sem alterar o comportamento público.</details> |

## Issue
N/A

## Responsavel
@Jules

## Labels
refactoring, code-health, rust

## Validacao
- Ran `cargo test --package ramshared-winsvc` (123 passed, 1 ignored)
- Ran `cargo fmt --check`
- Ran `cargo clippy --package ramshared-winsvc --all-targets -- -D warnings`

## Rollback trigger
Rollback if config validation causes any unexpected error when parsing or provisioning `WinDriveConfig`.

---
*PR created automatically by Jules for task [2390673596000692795](https://jules.google.com/task/2390673596000692795) started by @emersonbusson*