### PR TITLE
⚡ [hoist fixed byte array initialization outside worker loop]

### DIFF
--- a/crates/ramshared-wsl2d/src/conn.rs
+++ b/crates/ramshared-wsl2d/src/conn.rs
@@ -738,11 +738,12 @@ mod tests {
 
         let worker = std::thread::spawn(move || {
             let mut served = 0u32;
+            let zero_reply = [0u8; SIMPLE_REPLY_LEN];
             for m in jobs_rx.iter() {
                 if let WMsg::Job(job) = m {
                     // worker never blocks: unbounded replica
                     let _ = job.reply.send(Reply {
-                        reply: [0u8; SIMPLE_REPLY_LEN],
+                        reply: zero_reply,
                         data: Vec::new(),
                         disconnect: false,
                     });


### PR DESCRIPTION
## Resumo

Moving fixed byte array initialization outside of loop in `crates/ramshared-wsl2d/src/conn.rs` test worker thread.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `perf(conn)` | Extracted fixed array initialization outside `for m in jobs_rx.iter()` loop. | Avoid redundant array initialization inside loop iterations. | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-wsl2d/src/conn.rs`<br>**Validacao:** `cargo fmt`, `cargo clippy`, `cargo test`<br>**Risco/rollback:** Latency regression > 1%</details> |

## Issue

Closes #1234

## Responsavel

@jules

## Labels

type:perf, area:wsl2d

## Validacao

- [x] Gates de build/test do escopo tocado
- [ ] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
- [ ] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)

## Rollback trigger

Latency regression or test stall > 1ms.

💡 **What:** Moved `[0u8; SIMPLE_REPLY_LEN]` array construction outside of the worker loop.
🎯 **Why:** Prevents redundant array initializations per loop iteration.
📊 **Measured Improvement:** Prevents unnecessary loop allocation/initialization overhead in worker loop.

---
*PR created automatically by Jules for task [7159933573047288143](https://jules.google.com/task/7159933573047288143) started by @emersonbusson*