### PR TITLE
🧹 [add dxgkrnl ANTI-BUG prefix to run_ublk memory locking comment]

### DIFF
--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -4586,7 +4586,7 @@ fn run_ublk_with_runtime(
             .into());
     }
     runtime.guard_not_wsl2()?;
-    // MCL_CURRENT only: MCL_FUTURE races dxgkrnl mapping and can hang the host.
+    // dxgkrnl ANTI-BUG: MCL_CURRENT only: MCL_FUTURE races dxgkrnl mapping and can hang the host.
     runtime.lock_memory(force, false)?;
     runtime.install_shutdown_handler()?;
 


### PR DESCRIPTION
## Resumo

Adiciona o prefixo `dxgkrnl ANTI-BUG:` ao comentário de bloqueio de memória em `run_ublk` no arquivo `crates/ramshared-wsl2d/src/main.rs`, alinhando-o com a referência cruzada existente na linha 4766.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `HEAD` | Adiciona o prefixo `dxgkrnl ANTI-BUG:` no comentário em `run_ublk` | Garantir o alinhamento de referência do comentário com a nota no arquivo | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-wsl2d/src/main.rs`<br>**Validacao:** `cargo check`, `cargo test -p ramshared-wsl2d`<br>**Risco/rollback:** N/A (apenas comentário)</details> |

## Issue

Closes #000

## Responsavel

@jules

## Labels

type:docs, area:wsl2d

## Validacao

- [x] Gates de build/test do escopo tocado
- [x] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
- [x] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)

## Rollback trigger

Reverter se causar regressão sintática ou quebra na compilação do workspace.

---
*PR created automatically by Jules for task [15118533784072380467](https://jules.google.com/task/15118533784072380467) started by @emersonbusson*