### PR TITLE
🧪 [testing improvement] Add error propagation unit tests for ublk serve_request

### DIFF
--- a/crates/ramshared-wsl2d/src/ublk_server.rs
+++ b/crates/ramshared-wsl2d/src/ublk_server.rs
@@ -917,6 +917,51 @@ mod join_tests {
         residency.join().expect("residency success");
     }
 
+    struct ErrorBackend;
+
+    impl BlockBackend for ErrorBackend {
+        fn size_bytes(&self) -> u64 {
+            4096
+        }
+
+        fn block_size(&self) -> u32 {
+            4096
+        }
+
+        fn read_at(&mut self, _off: u64, _buf: &mut [u8]) -> Result<(), ramshared_block::IoError> {
+            Err(ramshared_block::IoError("simulated read error".into()))
+        }
+
+        fn write_at(&mut self, _off: u64, _data: &[u8]) -> Result<(), ramshared_block::IoError> {
+            Err(ramshared_block::IoError("simulated write error".into()))
+        }
+
+        fn flush(&mut self) -> Result<(), ramshared_block::IoError> {
+            Err(ramshared_block::IoError("simulated flush error".into()))
+        }
+    }
+
+    #[test]
+    fn serve_request_propagates_backend_errors() {
+        let mut backend = ErrorBackend;
+        let mut buffer = vec![0u8; 4096];
+
+        for cmd in [Command::Read, Command::Write, Command::Flush] {
+            let request = Request {
+                flags: 0,
+                cmd,
+                handle: 1,
+                offset: 0,
+                len: 4096,
+            };
+            assert_eq!(
+                serve_request(&request, &mut backend, &mut buffer),
+                EIO,
+                "expected EIO for cmd {cmd:?}"
+            );
+        }
+    }
+
     #[test]
     fn serve_request_refuses_unsupported_commands_and_covers_trim() {
         let mut backend = RamBackend::new(4096);


### PR DESCRIPTION
🎯 **What:**
Added unit test coverage for error propagation in `serve_request` in `crates/ramshared-wsl2d/src/ublk_server.rs` when storage backend operations (`Read`, `Write`, `Flush`) fail.

📊 **Coverage:**
Tested `serve_request` error handling using a mock `ErrorBackend` that returns `IoError` for `read_at`, `write_at`, and `flush`, confirming `EIO` (-5) is returned for each command type.

✨ **Result:**
Closes testing gap for backend I/O failures in the ublk request serving logic.

## Resumo

Adicionados testes unitários para a propagação de erros de I/O no backend (`BlockBackend`) dentro de `serve_request` (`crates/ramshared-wsl2d/src/ublk_server.rs`), cobrindo falhas em leituras, escritas e flushes.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `HEAD` | Adicionou o mock `ErrorBackend` e o teste `serve_request_propagates_backend_errors` | Testar o caminho de erro de I/O em `serve_request` para os comandos Read, Write e Flush | <details><summary>detalhes</summary>**Arquivos:** crates/ramshared-wsl2d/src/ublk_server.rs<br>**Validacao:** cargo test --package ramshared-wsl2d<br>**Risco/rollback:** Nenhum risco (apenas adicao de testes unitarios)</details> |

## Issue

Closes #0

## Responsavel

@jules

## Labels

type:test, area:wsl2d

## Validacao

- [x] Gates de build/test do escopo tocado (`cargo test --package ramshared-wsl2d`)
- [x] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
- [x] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)

## Rollback trigger

Falha de compilação ou regressão na suíte de testes de `ramshared-wsl2d`.

---
*PR created automatically by Jules for task [12611329730836145271](https://jules.google.com/task/12611329730836145271) started by @emersonbusson*