### PR TITLE
⚡ [eliminate unnecessary clone in wsl2d conn test loop]

### DIFF
--- a/crates/ramshared-wsl2d/src/conn.rs
+++ b/crates/ramshared-wsl2d/src/conn.rs
@@ -755,7 +755,7 @@ mod tests {
             served
         });
 
-        for _ in 0..10 {
+        for _ in 0..9 {
             jobs_tx
                 .send(WMsg::Job(Job {
                     export: 0,
@@ -765,6 +765,14 @@ mod tests {
                 }))
                 .unwrap();
         }
+        jobs_tx
+            .send(WMsg::Job(Job {
+                export: 0,
+                req: dummy_req(),
+                payload: Vec::new(),
+                reply: reply_tx,
+            }))
+            .unwrap();
         assert_eq!(
             worker.join().unwrap(),
             10,


### PR DESCRIPTION
## Resumo

Remove `reply_tx.clone()` desnecessario dentro do loop no teste `slow_writer_does_not_deadlock` em `crates/ramshared-wsl2d/src/conn.rs`, utilizando moving do `reply_tx` na ultima iteracao.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `head` | Removeu clone desnecessario de `reply_tx` no loop | Evita clonagem redundante de sender mpsc no teste | <details><summary>detalhes</summary>**Arquivos:** crates/ramshared-wsl2d/src/conn.rs<br>**Validacao:** cargo test -p ramshared-wsl2d<br>**Risco/rollback:** N/A (mudanca em teste)</details> |

## Issue

Closes #000

## Responsavel

@jules

## Labels

type:perf, area:wsl2d

## Validacao

- [x] Gates de build/test do escopo tocado (`cargo fmt`, `cargo clippy`, `cargo test -p ramshared-wsl2d`)
- [ ] `./scripts/docs-check.sh` (N/A)
- [ ] SSDV3: N/A

## Rollback trigger

Falha de compilacao ou regressao de teste no crate `ramshared-wsl2d`.

---

💡 **What:** Optimized `crates/ramshared-wsl2d/src/conn.rs` by sending the first 9 jobs with `reply_tx.clone()` and moving `reply_tx` directly for the 10th job, avoiding an unnecessary `clone()`.

🎯 **Why:** Calling `clone()` inside a loop when the original value is no longer needed afterwards does unnecessary reference-counting / heap allocation work. Moving `reply_tx` on the final iteration eliminates the redundant clone.

📊 **Measured Improvement:** Eliminates 1 unnecessary Arc/channel clone operation per loop execution. While the micro-performance impact in a 10-iteration test loop is small, avoiding unnecessary allocations in channel job dispatches improves resource usage and efficiency.

---
*PR created automatically by Jules for task [8044508460783117570](https://jules.google.com/task/8044508460783117570) started by @emersonbusson*