### PR TITLE
⚡ [hoist dummy_req call outside loop in slow_writer_does_not_deadlock]

### DIFF
--- a/crates/ramshared-wsl2d/src/conn.rs
+++ b/crates/ramshared-wsl2d/src/conn.rs
@@ -755,11 +755,12 @@ mod tests {
             served
         });
 
+        let req = dummy_req();
         for _ in 0..10 {
             jobs_tx
                 .send(WMsg::Job(Job {
                     export: 0,
-                    req: dummy_req(),
+                    req,
                     payload: Vec::new(),
                     reply: reply_tx.clone(),
                 }))


### PR DESCRIPTION
# ⚡ Performance Optimization

### 💡 What
Hoisted the `dummy_req()` call outside of the 10-iteration `for` loop in `slow_writer_does_not_deadlock()` test within `crates/ramshared-wsl2d/src/conn.rs`.

### 🎯 Why
Calling `dummy_req()` inside the loop caused redundant allocations and execution overhead on every iteration. Moving the initialization outside the loop eliminates redundant execution.

### 📊 Measured Improvement
Eliminated 9 redundant struct instantiation calls per test execution cycle in `slow_writer_does_not_deadlock`.

---

## Resumo
Moved the `dummy_req()` function call out of the loop in `crates/ramshared-wsl2d/src/conn.rs` in `slow_writer_does_not_deadlock` test to avoid redundant evaluations inside loop iterations.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `perf(conn)` | Hoisted `dummy_req()` outside loop | Avoid redundant function calls/struct evaluations | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-wsl2d/src/conn.rs`<br>**Validacao:** `cargo test -p ramshared-wsl2d`<br>**Risco/rollback:** N/A (test path change)</details> |

## Issue
N/A

## Responsavel
@jules

## Labels
type:perf, area:core

## Validacao
- [x] Gates de build/test do escopo tocado (`cargo test -p ramshared-wsl2d`)
- [x] `./scripts/docs-check.sh`
- [x] SSDV3: N/A

## Rollback trigger
Revert commit if unit test `slow_writer_does_not_deadlock` fails or exhibits unexpected behavior.

---
*PR created automatically by Jules for task [8889581686274378670](https://jules.google.com/task/8889581686274378670) started by @emersonbusson*