### PR TITLE
⚡ [reserve VecDeque capacity in ParentSeams::install loop]

### DIFF
--- a/crates/ramshared-cli/src/cascade/cascade_io.rs
+++ b/crates/ramshared-cli/src/cascade/cascade_io.rs
@@ -3370,6 +3370,7 @@ mod tests {
             SH_SCRIPT.with(|queue| {
                 let mut queue = queue.borrow_mut();
                 queue.clear();
+                queue.reserve(shell_responses);
                 for _ in 0..shell_responses {
                     queue.push_back(("*".into(), Ok(String::new())));
                 }


### PR DESCRIPTION
## Resumo
Pre-allocated `VecDeque` capacity using `queue.reserve(shell_responses)` before populating mock responses in `ParentSeams::install`.

💡 **What:** Pre-allocated `VecDeque` capacity in `ParentSeams::install`.
🎯 **Why:** Prevents repeated memory reallocations during loop execution when setting up mock shell script responses in tests.
📊 **Measured Improvement:** Eliminates redundant memory reallocations and copies during test queue population.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `perf` | Reserve VecDeque capacity in ParentSeams::install | Eliminate loop allocation overhead | <details>Added queue.reserve(shell_responses) before queue.push_back loop</details> |

## Issue
N/A

## Responsavel
Jules

## Labels
performance

## Validacao
Ran targeted test suite: `cargo test -p ramshared-cli --bin ramshared cascade::cascade_io::tests` (56 passed).

## Rollback trigger
Revert commit if any test seam issues occur.

---
*PR created automatically by Jules for task [13698400994123521605](https://jules.google.com/task/13698400994123521605) started by @emersonbusson*