### PR TITLE
🧹 [code health improvement] add dxgkrnl collision incident comment to run_nbd_with_startup

### DIFF
--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -2632,7 +2632,7 @@ fn run_nbd_with_startup<P: VramProvider, S: NbdRuntimeStarter>(
     });
     let budget_gate = dxg_gate.as_ref().map(|gate| gate as &dyn CommitBudgetGate);
     let autotier_config = AutotierConfig::default();
-    // Discipline 3: mlock host pages; for sparse, CUDA commit is on-demand (SPEC).
+    // Discipline 3: mlock host pages (incident 2026-07-03: kernel BUG due to collision with dxgkrnl); for sparse, CUDA commit is on-demand (SPEC).
     starter.lock_memory(force, false)?;
 
     // The origin-cache starts with zero VRAM. The non-product sparse test seam


### PR DESCRIPTION
## Resumo

Adiciona o comentário de contexto da incidência de colisão com dxgkrnl em `run_nbd_with_startup` no crate `ramshared-wsl2d`.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `HEAD` | Adicionou referência ao incidente 2026-07-03 em `run_nbd_with_startup` | Esclarecer e documentar o motivo do bloqueio `MCL_CURRENT` no caminho NBD | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-wsl2d/src/main.rs`<br>**Validacao:** `cargo fmt`, `cargo clippy`, `cargo test`<br>**Risco/rollback:** Nenhum risco funcional, apenas comentários</details> |

## Issue

Resolves #000

## Responsavel

@emersonbusson

## Labels

type:docs, area:wsl2d

## Validacao

- [x] Gates de build/test do escopo tocado (`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p ramshared-wsl2d`)
- [ ] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
- [x] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)

## Rollback trigger

Qualquer falha de compilação ou regressão nos testes unitários do workspace.

---
*PR created automatically by Jules for task [17190732724894092313](https://jules.google.com/task/17190732724894092313) started by @emersonbusson*