### PR TITLE
🧹 [code health] Clean up historical bug C1 references in broker_srv comments

### DIFF
--- a/crates/ramshared-wsl2d/src/broker_srv.rs
+++ b/crates/ramshared-wsl2d/src/broker_srv.rs
@@ -800,7 +800,7 @@ impl BrokerCore {
         // Hysteresis (DT-12) for SUSTAINED flags (Unaccounted/StuckSlice/Partial): confirms after
         // `recon_streak` consecutive identical ticks. `Eviction` is a canary EVENT (DT-6;
         // `demotes_delta` is per-tick, lasts 1 tick) → immediate confirmation; otherwise hysteresis would swallow
-        // a transient eviction (1-2 DEMOTEs) and the eviction signal would never appear (bug C1).
+        // a transient eviction (1-2 DEMOTEs) and the eviction signal would never appear.
         if candidate == self.recon_flag {
             self.recon_count = self.recon_count.saturating_add(1);
         } else {
@@ -808,7 +808,7 @@ impl BrokerCore {
             self.recon_count = 1;
         }
         let confirmed = match candidate {
-            ReconcileFlag::Eviction => ReconcileFlag::Eviction, // evento: sem histerese
+            ReconcileFlag::Eviction => ReconcileFlag::Eviction, // event: no hysteresis
             ReconcileFlag::None => ReconcileFlag::None,
             sustained if self.recon_count >= self.recon_streak => sustained,
             _ => ReconcileFlag::None,
@@ -1481,8 +1481,8 @@ mod tests {
 
     #[test]
     fn eviction_confirmed_immediately_despite_streak() {
-        // C1: Eviction is an EVENT (canary) → confirms in 1 tick even with recon_streak=3 (production).
-        // Without the fix, the hysteresis would swallow transient eviction.
+        // Eviction is an EVENT (canary) → confirms in 1 tick even with recon_streak=3 (production).
+        // Without immediate confirmation, hysteresis would swallow transient eviction.
         let mut c = core_streak(1, 3);
         reg(&mut c, 10, "a");
         c.vram.total.store(1 << 30, Ordering::Relaxed); // has_vram (senão Partial)


### PR DESCRIPTION
## Resumo

Cleaned up historical bug C1 references in `crates/ramshared-wsl2d/src/broker_srv.rs` and translated inline comments to English to ensure consistency with project standards.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Removed historical bug C1 references and updated comments to English | The bug C1 condition has been resolved and the references were non-actionable; comments must also adhere to project English language standards. | <details><summary>Detalhes</summary>Updated comments in `crates/ramshared-wsl2d/src/broker_srv.rs` around hysteresis handling and eviction event confirmation.</details> |

## Issue

N/A

## Responsavel

@jules

## Labels

`code-health`, `documentation`

## Validacao

- `cargo test -p ramshared-wsl2d` ran and passed all 86 unit and integration tests.
- `cargo fmt --all --check` verified code formatting.

## Rollback trigger

Revert commit if comment cleanups cause merge conflicts with concurrent broker_srv PRs.

---
*PR created automatically by Jules for task [5730270571144853746](https://jules.google.com/task/5730270571144853746) started by @emersonbusson*