### PR TITLE
🔒 Fix PowerShell Command Injection in RamShared WinSvc

### DIFF
--- a/crates/ramshared-winsvc/src/main.rs
+++ b/crates/ramshared-winsvc/src/main.rs
@@ -902,19 +902,18 @@ mod windows_svc {
             root.join(&manifest.artifact(ArtifactRole::WinsvcConfig)?.relative_path),
         )?)?;
         let letter = config.volume_letter.to_ascii_uppercase();
-        let script = format!(
-            concat!(
-                "$ErrorActionPreference='Stop';",
-                "$d=@(Get-CimInstance Win32_DiskDrive|?{{",
-                "$_.Model -match 'RAMSHARE|VRAMDISK' -or $_.Caption -match 'RAMSHARE|VRAMDISK'}});",
-                "$p=@(Get-CimInstance Win32_PageFileUsage|?{{",
-                "$_.Name -match '^{letter}:\\\\'}});",
-                "Write-Output ($d.Count.ToString()+'|'+$p.Count.ToString())"
-            ),
-            letter = letter
+        let script = concat!(
+            "$ErrorActionPreference='Stop';",
+            "$letter=$env:RAMSHARED_LETTER;",
+            "$d=@(Get-CimInstance Win32_DiskDrive|?{",
+            "$_.Model -match 'RAMSHARE|VRAMDISK' -or $_.Caption -match 'RAMSHARE|VRAMDISK'});",
+            "$p=@(Get-CimInstance Win32_PageFileUsage|?{",
+            "$_.Name -match ('^'+[regex]::Escape($letter)+':\\\\')});",
+            "Write-Output ($d.Count.ToString()+'|'+$p.Count.ToString())"
         );
         let mut child = std::process::Command::new("powershell.exe")
-            .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+            .args(["-NoProfile", "-NonInteractive", "-Command", script])
+            .env("RAMSHARED_LETTER", &letter.to_string())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .spawn()?;


### PR DESCRIPTION
🔒 [Fix PowerShell Command Injection in RamShared WinSvc]

## Resumo
Fixed a security vulnerability in `crates/ramshared-winsvc/src/main.rs` where the drive volume letter from config was formatted directly into a PowerShell command string. The volume letter is now safely passed out-of-band as an environment variable (`RAMSHARED_LETTER`) and accessed securely within PowerShell via `$env:RAMSHARED_LETTER` and `[regex]::Escape()`.

🎯 **What:** PowerShell command injection vulnerability fixed in `observe_host_residue`.
⚠️ **Risk:** Arbitrary command execution with elevated service privileges if configuration file contains malicious volume letter inputs.
🛡️ **Solution:** Pass parameter out-of-band via environment variable `RAMSHARED_LETTER` to `powershell.exe` command execution.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `head` | Passed volume letter as environment variable to PowerShell process | Prevent PowerShell command injection vulnerability | <details><summary>detalhes</summary>**Arquivos:** crates/ramshared-winsvc/src/main.rs<br>**Validacao:** cargo test -p ramshared-winsvc, cargo test --workspace<br>**Risco/rollback:** Baixo / reverter commit</details> |

## Issue
Closes #1

## Responsavel
@jules

## Labels
type:security, area:winsvc

## Validacao
- [x] Gates de build/test do escopo tocado
- [x] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
- [x] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)

## Rollback trigger
Revert commit if host residue monitoring query fails or returns invalid outputs for valid volume letters.

---
*PR created automatically by Jules for task [10744220139253885302](https://jules.google.com/task/10744220139253885302) started by @emersonbusson*