### PR TITLE
🧹 handle missing procfs pressure files and refactor Portuguese strings

### DIFF
--- a/crates/ramshared-agent/src/psi.rs
+++ b/crates/ramshared-agent/src/psi.rs
@@ -13,8 +13,13 @@ use ramshared_broker::protocol::SwapEntry;
 
 /// Core logic for `read_psi` with dependency injection for the file path.
 fn read_psi_impl(path: &str) -> Result<PsiSample> {
-    let raw = std::fs::read_to_string(path)?;
-    parse_psi(&raw).ok_or_else(|| Error::new(ErrorKind::InvalidData, "PSI ilegível"))
+    match std::fs::read_to_string(path) {
+        Ok(raw) => {
+            parse_psi(&raw).ok_or_else(|| Error::new(ErrorKind::InvalidData, "unreadable PSI"))
+        }
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(PsiSample::default()),
+        Err(e) => Err(e),
+    }
 }
 
 /// Reads and parses `/proc/pressure/memory`.
@@ -47,7 +52,11 @@ pub fn parse_psi(content: &str) -> Option<PsiSample> {
 
 /// Core logic for `read_swaps` with dependency injection.
 fn read_swaps_impl(path: &str) -> Result<Vec<SwapEntry>> {
-    Ok(parse_swaps(&std::fs::read_to_string(path)?))
+    match std::fs::read_to_string(path) {
+        Ok(raw) => Ok(parse_swaps(&raw)),
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(Vec::new()),
+        Err(e) => Err(e),
+    }
 }
 
 /// Reads and parses `/proc/swaps`.
@@ -222,7 +231,7 @@ mod tests {
     #[test]
     fn parse_memcg_swap_max_or_garbage_is_none() {
         assert_eq!(parse_memcg_swap("max\n"), None);
-        assert_eq!(parse_memcg_swap("lixo"), None);
+        assert_eq!(parse_memcg_swap("garbage"), None);
     }
 
     #[test]
@@ -293,7 +302,10 @@ mod tests {
 
     #[test]
     fn read_psi_impl_not_found() {
-        assert!(read_psi_impl("/proc/nonexistent_psi_file_12345").is_err());
+        assert_eq!(
+            read_psi_impl("/proc/nonexistent_psi_file_12345").unwrap(),
+            PsiSample::default()
+        );
     }
 
     #[test]
@@ -317,7 +329,11 @@ mod tests {
 
     #[test]
     fn read_swaps_impl_not_found() {
-        assert!(read_swaps_impl("/proc/nonexistent_swaps_file_12345").is_err());
+        assert!(
+            read_swaps_impl("/proc/nonexistent_swaps_file_12345")
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/ramshared-cli/src/supervisor.rs
+++ b/crates/ramshared-cli/src/supervisor.rs
@@ -1151,13 +1151,12 @@ fn apply_decision_with(
 
 fn collect_sample(start: Instant, previous: Instant) -> Result<PressureSample, String> {
     let meminfo = fs::read_to_string("/proc/meminfo").map_err(|error| error.to_string())?;
-    let pressure =
-        fs::read_to_string("/proc/pressure/memory").map_err(|error| error.to_string())?;
+    let pressure = fs::read_to_string("/proc/pressure/memory").unwrap_or_default();
     let (total, available) = parse_meminfo(&meminfo).ok_or("invalid /proc/meminfo")?;
     Ok(PressureSample {
         memory_available_bytes: available,
         control_reserve_bytes: (total.div_ceil(4)).max(4 * 1024 * 1024 * 1024),
-        psi_full_avg10: parse_psi_full_avg10(&pressure).ok_or("invalid memory PSI")?,
+        psi_full_avg10: parse_psi_full_avg10(&pressure).unwrap_or(0.0),
         sample_delay_ms: previous.elapsed().as_millis().saturating_sub(1_000) as u64,
         elapsed_ms: start.elapsed().as_millis() as u64,
     })

--- a/crates/ramshared-wsl2d/src/residency.rs
+++ b/crates/ramshared-wsl2d/src/residency.rs
@@ -169,7 +169,7 @@ mod tests {
     fn load_spike_below_threshold_stays_ok() {
         // Regression DT-31: LOAD spike ~17× baseline (not eviction) must NOT demote.
         // With 8× this triggered and dropped the swap under load (e2e civm bug); with 64×, it remains Ok.
-        let mut c = canary(); // baseline 4 ms → limiar 256 ms
+        let mut c = canary(); // baseline 4 ms → threshold 256 ms
         for _ in 0..10 {
             assert_eq!(c.sample(4000 * 17, true, u64::MAX), Verdict::Ok); // 68 ms = 17× < 256 ms
         }

--- a/docs/governance/rust-slice-coverage.json
+++ b/docs/governance/rust-slice-coverage.json
@@ -299,7 +299,7 @@
         "-p",
         "ramshared-agent",
         "--files",
-        "crates/ramshared-agent/src/main.rs",
+        "crates/ramshared-agent/src/main.rs,crates/ramshared-agent/src/psi.rs",
         "--min",
         "80",
         "--report-json",
@@ -309,7 +309,8 @@
         "ramshared-agent"
       ],
       "files": [
-        "crates/ramshared-agent/src/main.rs"
+        "crates/ramshared-agent/src/main.rs",
+        "crates/ramshared-agent/src/psi.rs"
       ],
       "min": 80
     },
@@ -402,7 +403,7 @@
         "-p",
         "ramshared-wsl2d",
         "--files",
-        "crates/ramshared-wsl2d/src/main.rs,crates/ramshared-wsl2d/src/swap.rs",
+        "crates/ramshared-wsl2d/src/main.rs,crates/ramshared-wsl2d/src/residency.rs,crates/ramshared-wsl2d/src/swap.rs",
         "--min",
         "80",
         "--report-json",
@@ -413,6 +414,7 @@
       ],
       "files": [
         "crates/ramshared-wsl2d/src/main.rs",
+        "crates/ramshared-wsl2d/src/residency.rs",
         "crates/ramshared-wsl2d/src/swap.rs"
       ],
       "min": 80

--- a/docs/specs/no-milestone/memory-broker/SPEC.md
+++ b/docs/specs/no-milestone/memory-broker/SPEC.md
@@ -340,7 +340,7 @@ fixtures issue only `Msg::Status`/reply frames; they never invoke `SwapOn`,
 The canonical per-file coverage owner for this business path is:
 
 ```bash
-node tools/ci/check-rust-slice-coverage.mjs -p ramshared-agent --files crates/ramshared-agent/src/main.rs --min 80 --report-json tmp/memory-broker-agent-cli-cov.json
+node tools/ci/check-rust-slice-coverage.mjs -p ramshared-agent --files crates/ramshared-agent/src/main.rs,crates/ramshared-agent/src/psi.rs --min 80 --report-json tmp/memory-broker-agent-cli-cov.json
 ```
 
 The process tests provide the public-surface validity/refusal evidence (#13),
@@ -425,7 +425,7 @@ The canonical coverage owner for this entry point is:
 ```bash
 node tools/ci/check-rust-slice-coverage.mjs \
   -p ramshared-wsl2d \
-  --files crates/ramshared-wsl2d/src/main.rs,crates/ramshared-wsl2d/src/swap.rs \
+  --files crates/ramshared-wsl2d/src/main.rs,crates/ramshared-wsl2d/src/residency.rs,crates/ramshared-wsl2d/src/swap.rs \
   --min 80 \
   --report-json tmp/memory-broker-wsl2d-daemon-cov.json
 ```

--- a/tools/ci/plan-rust-slice-coverage.test.mjs
+++ b/tools/ci/plan-rust-slice-coverage.test.mjs
@@ -214,12 +214,15 @@ const MEMORY_BROKER_AGENT_CLI_COVERAGE_ENTRY = {
   command: [
     'node', 'tools/ci/check-rust-slice-coverage.mjs',
     '-p', 'ramshared-agent',
-    '--files', 'crates/ramshared-agent/src/main.rs',
+    '--files', 'crates/ramshared-agent/src/main.rs,crates/ramshared-agent/src/psi.rs',
     '--min', '80',
     '--report-json', 'tmp/memory-broker-agent-cli-cov.json',
   ],
   packages: ['ramshared-agent'],
-  files: ['crates/ramshared-agent/src/main.rs'],
+  files: [
+    'crates/ramshared-agent/src/main.rs',
+    'crates/ramshared-agent/src/psi.rs',
+  ],
   min: 80,
 }
 const MEMORY_BROKER_AGENT_CLI_PROCESS_TESTS = [
@@ -247,13 +250,14 @@ const MEMORY_BROKER_WSL2D_DAEMON_COVERAGE_ENTRY = {
   command: [
     'node', 'tools/ci/check-rust-slice-coverage.mjs',
     '-p', 'ramshared-wsl2d',
-    '--files', 'crates/ramshared-wsl2d/src/main.rs,crates/ramshared-wsl2d/src/swap.rs',
+    '--files', 'crates/ramshared-wsl2d/src/main.rs,crates/ramshared-wsl2d/src/residency.rs,crates/ramshared-wsl2d/src/swap.rs',
     '--min', '80',
     '--report-json', 'tmp/memory-broker-wsl2d-daemon-cov.json',
   ],
   packages: ['ramshared-wsl2d'],
   files: [
     'crates/ramshared-wsl2d/src/main.rs',
+    'crates/ramshared-wsl2d/src/residency.rs',
     'crates/ramshared-wsl2d/src/swap.rs',
   ],
   min: 80,


### PR DESCRIPTION
## Resumo

Fallback gracefully when `/proc/pressure/memory` or `/proc/swaps` is not available on host/container environments in `ramshared-agent` and `ramshared-cli`, returning default metrics instead of failing agent heartbeat cycles and CLI samples. Also refactored remaining Portuguese comments and test strings to English across `residency.rs` and `psi.rs`.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `HEAD` | Improved procfs pressure file missing handling and translated Portuguese comments/strings to English | To ensure agent heartbeats and CLI samples succeed in environments without PSI enabled and comply with language rules | <details><summary>detalhes</summary>**Arquivos:** crates/ramshared-agent/src/psi.rs, crates/ramshared-cli/src/supervisor.rs, crates/ramshared-wsl2d/src/residency.rs<br>**Validacao:** cargo test --workspace -- --test-threads=1<br>**Risco/rollback:** Unit test failure on missing procfs files</details> |

## Issue

Closes #255

## Responsavel

@emersonbusson

## Labels

type:fix, area:core

## Validacao

- [x] Gates de build/test do escopo tocado (`cargo test --workspace -- --test-threads=1`)
- [x] `./scripts/docs-check.sh` (N/A)
- [x] SSDV3: N/A (mudança não estrutural)

## Rollback trigger

If unit tests in ramshared-agent or ramshared-wsl2d fail on hosts with or without /proc/pressure/memory.

---
*PR created automatically by Jules for task [9734869144821302498](https://jules.google.com/task/9734869144821302498) started by @emersonbusson*