### PR TITLE
🧪 [testing improvement] Add inline unit tests for n3_state.rs state transitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/crates/ramshared-tier/src/n3_state.rs
+++ b/crates/ramshared-tier/src/n3_state.rs
@@ -1821,7 +1821,10 @@ mod tests {
         let mut model = PreflightModel::new();
         // Requesting demotion when not constrained should be an invalid transition
         let decision = model.request_demotion();
-        assert_eq!(decision.action, PreflightAction::Unavailable(FailureReason::InvalidTransition));
+        assert_eq!(
+            decision.action,
+            PreflightAction::Unavailable(FailureReason::InvalidTransition)
+        );
 
         // Let's create a constrained state by observing an empty budget
         let event_id = EventId::new(b"event-1").unwrap();
@@ -1838,7 +1841,7 @@ mod tests {
             100,
             MAX_OBSERVATION_AGE,
             event_id,
-            Vec::new()
+            Vec::new(),
         );
 
         let decision = model.observe(observation, 100);
@@ -1883,11 +1886,14 @@ mod tests {
         match decision {
             ProtocolDecision::FailAck(fail_ack) => {
                 assert_eq!(fail_ack.reason, FailureReason::InvalidTransition);
-            },
+            }
             _ => panic!("Expected FailAck"),
         }
 
         // The machine's state should now be Failed(InvalidTransition)
-        assert_eq!(machine.lease_state(), LeaseState::Failed(FailureReason::InvalidTransition));
+        assert_eq!(
+            machine.lease_state(),
+            LeaseState::Failed(FailureReason::InvalidTransition)
+        );
     }
 }

--- a/crates/ramshared-tier/src/n3_state.rs
+++ b/crates/ramshared-tier/src/n3_state.rs
@@ -1802,3 +1802,92 @@ enum EventRegistration {
     Conflict,
     Overflow,
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+
+    #[test]
+    fn test_initial_state() {
+        let machine = LeaseMachine::new();
+        assert_eq!(machine.lease_state(), LeaseState::Absent);
+        assert_eq!(machine.preflight_state(), PreflightState::HostUnavailable);
+    }
+
+    #[test]
+    fn test_request_demotion() {
+        let mut model = PreflightModel::new();
+        // Requesting demotion when not constrained should be an invalid transition
+        let decision = model.request_demotion();
+        assert_eq!(decision.action, PreflightAction::Unavailable(FailureReason::InvalidTransition));
+
+        // Let's create a constrained state by observing an empty budget
+        let event_id = EventId::new(b"event-1").unwrap();
+        let adapter_id = AdapterId::new(b"adapter-1").unwrap();
+
+        let observation = HostObservation::new(
+            N3_SCHEMA_VERSION,
+            1,
+            adapter_id,
+            Authority::Host,
+            0, // Budget 0 -> Constrained
+            0,
+            0,
+            100,
+            MAX_OBSERVATION_AGE,
+            event_id,
+            Vec::new()
+        );
+
+        let decision = model.observe(observation, 100);
+        assert_eq!(decision.state, PreflightState::Constrained);
+
+        // Now request demotion should succeed
+        let decision = model.request_demotion();
+        assert_eq!(decision.state, PreflightState::DemotionRequested);
+        assert_eq!(decision.action, PreflightAction::DemotionRequested);
+    }
+
+    #[test]
+    fn test_restart_record_serialization() {
+        let lease_id = LeaseId::new(b"lease-abc").unwrap();
+        let checkpoint = GenerationCheckpoint {
+            lease_id: lease_id.clone(),
+            generation: 42,
+        };
+
+        let record = RestartRecord::host(10, vec![checkpoint.clone()]).unwrap();
+        let bytes = record.to_bytes();
+
+        let decoded = RestartRecord::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded.host_epoch(), 10);
+
+        let checkpoints = decoded.checkpoints();
+        assert_eq!(checkpoints.len(), 1);
+        assert_eq!(checkpoints[0].lease_id, lease_id);
+        assert_eq!(checkpoints[0].generation, 42);
+    }
+
+    #[test]
+    fn test_invalid_revoke_transition() {
+        let mut machine = LeaseMachine::new();
+        let lease_id = LeaseId::new(b"lease-1").unwrap();
+        let event_id = EventId::new(b"event-1").unwrap();
+
+        let revoke = Revoke::host(lease_id, 1, event_id, 200);
+
+        // Applying Revoke to an Absent state should result in an invalid transition error
+        let decision = machine.receive_revoke(revoke);
+        match decision {
+            ProtocolDecision::FailAck(fail_ack) => {
+                assert_eq!(fail_ack.reason, FailureReason::InvalidTransition);
+            },
+            _ => panic!("Expected FailAck"),
+        }
+
+        // The machine's state should now be Failed(InvalidTransition)
+        assert_eq!(machine.lease_state(), LeaseState::Failed(FailureReason::InvalidTransition));
+    }
+}


### PR DESCRIPTION
## Resumo
Adicionados testes unitários inline abrangentes para `crates/ramshared-tier/src/n3_state.rs` para cobrir o estado inicial da máquina, transições válidas de solicitação de rebaixamento (`request_demotion`), serialização e desserialização (`RestartRecord::to_bytes` e `from_bytes`), além de garantir a rejeição de transições inválidas (ex: aplicar `Revoke` no estado `Absent`).

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| test: add comprehensive inline unit tests for n3_state.rs state transitions | Adicionado módulo `tests` com funções de teste no arquivo `n3_state.rs`. | Para garantir a corretude das transições de estado, requisições de rebaixamento, e conversão de bytes de registros N3, atendendo a tarefa solicitada e aumentando a cobertura. | <details>Modificado `crates/ramshared-tier/src/n3_state.rs` para incluir o bloco `mod tests` ao final do arquivo, utilizando a configuração `#[cfg(test)]` e `#![allow(clippy::unwrap_used, clippy::expect_used)]`.</details> |

## Issue
Adição de testes de unidade para máquina de estado N3.

## Responsavel
Jules

## Labels
type:test

## Validacao
Os seguintes comandos foram utilizados para verificação de corretude e linting:
```bash
cargo test -p ramshared-tier
cargo test --workspace
cargo clippy -- -D warnings
```

## Rollback trigger
Qualquer falha introduzida nos testes ou aumento no número de avisos do Clippy apontando regressões nesta implementação.

---
*PR created automatically by Jules for task [2268035931002971543](https://jules.google.com/task/2268035931002971543) started by @emersonbusson*