### PR TITLE
🧹 [code health improvement description] FINDING_ONLY: WinDriveConfig validation logic out of scope

### DIFF
--- a/docs/jules/findings/refactor_winsvc.md
+++ b/docs/jules/findings/refactor_winsvc.md
@@ -1,0 +1,42 @@
+# FINDING_ONLY: WinDriveConfig validation logic not in scope
+
+## Issue
+
+The instruction mandates the following goal: "Decompose complex validation logic for Windows service config settings into early-return validators."
+
+The instruction strictly confines the scope to: "crates/ramshared-winsvc/src/main.rs and its related test module."
+
+## Finding
+
+An architectural check of the codebase reveals that the validation logic for `WinDriveConfig` does not reside in `crates/ramshared-winsvc/src/main.rs`. Instead, it resides entirely within `crates/ramshared-winsvc/src/config.rs` under the `pub fn validate(&self) -> Result<(), ConfigError>` method.
+
+Because the instructions explicitly state:
+- "Scope is strictly confined to: crates/ramshared-winsvc/src/main.rs and its related test module."
+- "If safe code is not possible, produce FINDING_ONLY with evidence in docs/jules/findings/."
+
+We cannot safely perform this refactoring. Modifying `config.rs` directly violates the strict scope confinement. Adding hallucinated validation code to `main.rs` that duplicates or bypasses `config.rs` is architecturally unsound and unsafe.
+
+## Evidence
+
+Running `grep -n "pub fn validate" -A 10 crates/ramshared-winsvc/src/config.rs` shows the validation logic:
+
+```rust
+112:    pub fn validate(&self) -> Result<(), ConfigError> {
+113-        if self.block_size != 512 && self.block_size != 4096 {
+114-            return Err(ConfigError::Invalid {
+115-                field: "block_size",
+116-                detail: format!("must be 512 or 4096, got {}", self.block_size),
+117-            });
+118-        }
+119-        if self.size_bytes < MIN_SIZE_BYTES {
+120-            return Err(ConfigError::Invalid {
+121-                field: "size_bytes",
+122-                detail: format!("must be >= {MIN_SIZE_BYTES} (64 MiB)"),
+...
+```
+
+No implementation of `WinDriveConfig` or its validation exists in `crates/ramshared-winsvc/src/main.rs`.
+
+## Conclusion
+
+Safe code modification within the strictly confined scope is impossible.


### PR DESCRIPTION
## Resumo
Generated FINDING_ONLY report because the requested refactoring requires changing a file out of the allowed scope. The validation logic for `WinDriveConfig` is located in `crates/ramshared-winsvc/src/config.rs`, not `src/main.rs` as mandated by the instructions.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `🧹 [code health] FINDING_ONLY: WinDriveConfig validation logic out of scope` | Created a `FINDING_ONLY` report at `docs/jules/findings/refactor_winsvc.md`. | The required logic to refactor is not in the strictly confined scope (`main.rs`), but rather in `config.rs`. | <details>Modifying `config.rs` is out of scope. Modifying `main.rs` to implement this is not possible as the logic is not there. As per instructions, generated a FINDING_ONLY report with evidence.</details> |

## Issue
RS100/2026-08-29/L21/winsvc/012

## Responsavel
jules

## Labels
type:cleanup

## Validacao
`cargo test -p ramshared-winsvc`
`cargo clippy -- -D warnings`

## Rollback trigger
If the finding report is factually incorrect or if a safe way to fulfill the request within the strictly confined scope is discovered.

---
*PR created automatically by Jules for task [4872570292389082869](https://jules.google.com/task/4872570292389082869) started by @emersonbusson*