### PR TITLE
audit(vram): reject impossible transient eviction scope in ramshared-vram

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/docs/jules/findings/L28-vram-030.md
+++ b/docs/jules/findings/L28-vram-030.md
@@ -1,0 +1,15 @@
+# FINDING_ONLY: L28-vram-030
+
+## 🎯 What
+The task requested cleaning up "transient eviction bug comments and document invariants" as well as "atomic pointer swap contracts" inside `crates/ramshared-vram/src/lib.rs`.
+
+## ⚠️ Risk & 🛡️ Solution
+Upon auditing `crates/ramshared-vram/src/lib.rs`, it is evident that this file strictly contains the definition of safe VRAM abstraction traits (`VramMemory` and `VramProvider`) and a `VramError` enum. The file does not contain any implementation logic for "transient eviction", nor does it use any unsafe "atomic pointer swaps" or synchronization locks.
+
+The file explicitly enforces `#![forbid(unsafe_code)]` and defines thread-local trait methods (`VramMemory` explicitly does not require `Send`).
+
+Searching the workspace reveals that the "transient eviction" comments actually exist in `crates/ramshared-wsl2d/src/broker_srv.rs`.
+
+In accordance with the RamShared adversarial auditor instructions, because the requested changes are architecturally impossible and/or safely modifying the code as instructed within the strictly confined scope is not viable, a `FINDING_ONLY` report is produced rather than hallucinating incorrect or unsafe code into the pure logic crate.
+
+No modifications were made to `crates/ramshared-vram/src/lib.rs`.


### PR DESCRIPTION
## Resumo
Created a `FINDING_ONLY` audit report because the requested code changes regarding transient eviction bugs and atomic pointer swap contracts are not architecturally possible within `crates/ramshared-vram/src/lib.rs`. That file strictly defines safe trait interfaces and `#![forbid(unsafe_code)]`, and the referenced logic exists in a completely different crate (`ramshared-wsl2d`).

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| audit(vram): reject impossible transient eviction scope in ramshared-vram | Created `docs/jules/findings/L28-vram-030.md` audit report. | Task instructed to modify `crates/ramshared-vram/src/lib.rs` with atomic pointer swaps for transient eviction, which is invalid for the safe trait abstraction file. | <details>Added FINDING_ONLY document explaining why no code was touched.</details> |

## Issue
L28-vram-030

## Responsavel
RS100

## Labels
type:audit

## Validacao
`cargo test && cargo clippy -- -D warnings` executed correctly across the workspace.

## Rollback trigger
Not applicable (FINDING_ONLY audit report).

---
*PR created automatically by Jules for task [2959429693351889454](https://jules.google.com/task/2959429693351889454) started by @emersonbusson*