### PR TITLE
test: add adversarial audit finding report for dxg command stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -10,7 +10,9 @@
       "canonicalSource": "README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -20,7 +22,9 @@
       "canonicalSource": "ARCHITECTURE.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -30,7 +34,9 @@
       "canonicalSource": "CHANGELOG.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -40,7 +46,9 @@
       "canonicalSource": "CONTRIBUTING.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -50,7 +58,9 @@
       "canonicalSource": "MANIFESTO.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -60,7 +70,9 @@
       "canonicalSource": "ROADMAP.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -70,7 +82,9 @@
       "canonicalSource": "trovaldo.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -80,7 +94,9 @@
       "canonicalSource": "SECURITY.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -90,7 +106,9 @@
       "canonicalSource": "validation.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -100,7 +118,9 @@
       "canonicalSource": "TASK.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -110,7 +130,9 @@
       "canonicalSource": "superprompt.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -120,7 +142,9 @@
       "canonicalSource": "AGENTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -130,7 +154,9 @@
       "canonicalSource": "CLAUDE.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -140,7 +166,9 @@
       "canonicalSource": ".claude/rules/documentation.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -150,7 +178,9 @@
       "canonicalSource": "docs/DOCUMENTATION-PARITY.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -160,7 +190,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -170,7 +202,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -180,7 +214,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -190,7 +226,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -200,7 +238,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -210,7 +250,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -220,7 +262,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -230,7 +274,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -240,7 +286,9 @@
       "canonicalSource": "validation.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -250,7 +298,9 @@
       "canonicalSource": "validation.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -260,7 +310,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -270,7 +322,9 @@
       "canonicalSource": "docs/BENCHMARKS.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -280,7 +334,9 @@
       "canonicalSource": "docs/reliability/GAP-REGISTER.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -290,7 +346,9 @@
       "canonicalSource": "docs/ci/CI-TOPOLOGY.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -300,7 +358,9 @@
       "canonicalSource": "docs/decisions/README.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -310,7 +370,9 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -320,7 +382,9 @@
       "canonicalSource": "docs/labs/LAB-DISK-GUARD.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -330,7 +394,9 @@
       "canonicalSource": "README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -340,7 +406,9 @@
       "canonicalSource": "docs/methodology/kahneman-disciplines.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -350,7 +418,9 @@
       "canonicalSource": "docs/packaging/INSTALLABLES.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -360,7 +430,9 @@
       "canonicalSource": "docs/postmortems/TEMPLATE.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -370,7 +442,9 @@
       "canonicalSource": "docs/reference/REFERENCE-INDEX.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -380,7 +454,9 @@
       "canonicalSource": "docs/security/THREAT-MODEL.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:25:34Z"
     },
     {
@@ -390,7 +466,9 @@
       "canonicalSource": "docs/reliability/GAP-REGISTER.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -400,7 +478,9 @@
       "canonicalSource": "docs/postmortems/TEMPLATE.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-20T14:49:00Z"
     },
     {
@@ -410,7 +490,9 @@
       "canonicalSource": "docs/reliability/GAP-REGISTER.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -420,7 +502,9 @@
       "canonicalSource": "README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 30,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-20T14:49:00Z"
     },
     {
@@ -430,7 +514,9 @@
       "canonicalSource": "ARCHITECTURE.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-26T13:15:00Z"
     },
     {
@@ -440,7 +526,9 @@
       "canonicalSource": "docs/reviews/README.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -450,7 +538,9 @@
       "canonicalSource": "docs/runbooks/windows-autonomous-broker.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -460,7 +550,9 @@
       "canonicalSource": "drivers/windows/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -470,7 +562,21 @@
       "canonicalSource": "scripts/windows/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
+      "registeredAt": "2026-08-11T15:15:12Z"
+    },
+    {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "documentation-governance",
+      "canonicalSource": "docs/DOCUMENTATION-PARITY.md",
+      "lifecycle": "reviewable",
+      "freshnessDays": 90,
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     }
   ],

--- a/docs/jules/findings/dxg_command_stream_findings.md
+++ b/docs/jules/findings/dxg_command_stream_findings.md
@@ -1,0 +1,37 @@
+# FINDING_ONLY: Zero-copy buffer recycling in dxg command stream
+
+## 1. RULES
+The agent acts as an adversarial systems auditor for RamShared (Prompt RS100, day 2026-08-29). The instructions require TDD, 0 warnings from clippy, and safe implementation strictly within `crates/ramshared-dxg/src/lib.rs`.
+
+## 2. MAIN_DIFF
+No code diff was generated. A finding report was created instead.
+
+## 3. FILES
+`crates/ramshared-dxg/src/lib.rs` (inspected but unmodified)
+
+## 4. INVARIANTS
+The `ramshared-dxg` crate implements a minimal `/dev/dxg` WDDM video-memory budget provider. It is responsible for querying GPU memory budgets (`QUERY_VIDEO_MEMORY_INFO_IOCTL`) and enumerating adapters (`ENUM_ADAPTERS2_IOCTL`), which is an isolated subsystem that lacks any concept of a "command stream".
+
+## 5. COUNTERFACTUAL
+If I had forcefully implemented "buffer recycling" or "command stream" structs in `lib.rs`, I would be hallucinating domain logic that is architecturally completely disconnected from the crate's purpose as a WDDM memory budget provider, potentially leading to unused dead code or breaking the confined scope safety.
+
+## 6. RED_TEST
+No red test is applicable because the target logic ("command stream") does not exist in the confined scope `crates/ramshared-dxg/src/lib.rs`.
+
+## 7. COVERAGE
+Code coverage is unaffected as no source logic was changed.
+
+## 8. REAL_PROOF
+```bash
+$ cat crates/ramshared-dxg/src/lib.rs | grep -i command
+# Returns 0 results
+$ cat crates/ramshared-dxg/src/lib.rs | grep -i stream
+# Returns 0 results
+```
+The file contains `uapi` declarations and traits for `GpuBudgetProvider`. The actual command stream logic likely resides in another component of RamShared (e.g., a CUDA or Vulkan abstraction).
+
+## 9. ROLLBACK
+Since no code changes were made to the source base, no rollback condition is triggered on the core code.
+
+## 10. PR_BOUNDARY
+Target PR Branch: jules/inbox (do not merge).

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 258,
-    "classified": 247,
+    "total": 259,
+    "classified": 248,
     "excluded": 11,
     "unclassified": 0,
     "ambiguous": 0
@@ -566,6 +566,18 @@
       },
       "owner": "documentation-governance",
       "canonicalSource": "docs/governance/README.md",
+      "lifecycle": "reviewable",
+      "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/dxg_command_stream_findings.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "documentation-governance",
+      "canonicalSource": "docs/DOCUMENTATION-PARITY.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
     },


### PR DESCRIPTION
## Resumo
Adversarial audit (Prompt RS100) identified that the requested performance feature (zero-copy buffer recycling in dxg command stream) targets non-existent logic within the strictly confined scope `crates/ramshared-dxg/src/lib.rs`. A `FINDING_ONLY` report was generated explaining that the crate solely handles WDDM video-memory budget queries.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| test: add adversarial audit finding report for dxg command stream | Generated a `FINDING_ONLY` markdown report. | Safe code implementation was impossible within the confined scope because `ramshared-dxg` lacks command stream logic. | <details>Added `docs/jules/findings/dxg_command_stream_findings.md` with 10 contractual blocks.</details> |

## Labels
type:test

## Validacao
`cargo test && cargo clippy -- -D warnings`

## Rollback trigger
Revert if the findings report breaks CI or causes confusion in documentation.

---
*PR created automatically by Jules for task [10437086434870648400](https://jules.google.com/task/10437086434870648400) started by @emersonbusson*