### PR TITLE
🧹 [documentation improvement] report missing implementation for page table sync loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/docs/jules/findings/RS100-2026-08-29.md
+++ b/docs/jules/findings/RS100-2026-08-29.md
@@ -1,0 +1,37 @@
+# FINDING ONLY
+
+## Context
+
+**Task**: RS100-2026-08-29, eliminate hot-loop allocation in page table sync
+**Target File**: `crates/ramshared-vram/src/lib.rs`
+
+## Evidence
+
+The `crates/ramshared-vram/src/lib.rs` file does not contain any "page table sync" loop or any recurring `Vec/String` allocations. It strictly acts as a pure Rust abstraction (trait definitions for `VramMemory` and `VramProvider`) without the concrete backend implementation or data-plane loop where such an issue could exist.
+
+Modifying the file to include such an optimization is architecturally impossible and would require hallucinating code. Per SSDV3 constraints and adversarial instruction rule 4, no code was written.
+
+### Extracted proof from `lib.rs`:
+
+```rust
+//! `ramshared-vram` — VRAM backend abstraction (RF-G1, preparation for P3).
+// ...
+pub trait VramMemory {
+    fn len(&self) -> usize;
+    fn zero(&mut self) -> Result<(), VramError>;
+    fn read_at(&self, off: u64, dst: &mut [u8]) -> Result<(), VramError>;
+    fn write_at(&mut self, off: u64, src: &[u8]) -> Result<(), VramError>;
+}
+
+pub trait VramProvider {
+    type Mem<'p>: VramMemory where Self: 'p;
+    fn alloc(&self, bytes: usize) -> Result<Self::Mem<'_>, VramError>;
+    fn mem_info(&self) -> Result<(u64, u64), VramError>;
+}
+```
+
+No implementation code modifies `Vec` or `String` buffers inside a loop within this source module.
+
+## Conclusion
+
+The requested optimization is impossible within the explicitly constrained scope (`crates/ramshared-vram/src/lib.rs`). Safe execution requires preserving the codebase unchanged. No tests added because no implementations were added. No code changed.


### PR DESCRIPTION
## Resumo
Created a FINDING_ONLY report because the requested performance optimization ("hot-loop allocation in page table sync") targets non-existent logic in `crates/ramshared-vram/src/lib.rs`. The file strictly acts as an abstract control plane containing trait definitions (`VramMemory` and `VramProvider`), and no allocations occur inside a loop.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Adicionou relatório de FINDING_ONLY | A lógica requisitada não existe no escopo delimitado | <details>Modificar a abstração pura para incluir a lógica não era possível, criando o relatório RS100-2026-08-29.md com as provas concretas.</details> |

## Issue
RS100-2026-08-29

## Responsavel
jules

## Labels
type:documentation

## Validacao
cargo clippy -- -D warnings
cargo test (ignoring known flakiness in ramshared-agent without pressure/memory)

## Rollback trigger
If the PR breaks CI or introduces unexpected code modifications.

---
*PR created automatically by Jules for task [17389230711663933793](https://jules.google.com/task/17389230711663933793) started by @emersonbusson*