### PR TITLE
🧹 docs: report absent fallback paths in main.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/docs/jules/findings/FINDING_ONLY.md
+++ b/docs/jules/findings/FINDING_ONLY.md
@@ -1,0 +1,10 @@
+# Finding Report
+
+Task Title: clean up obsolete Windows registry migration fallback paths
+Scope: crates/ramshared-winsvc/src/main.rs and its related test module.
+
+## Evidence
+
+Searched for "fallback", "v0.1", "registry", and "migration" in `crates/ramshared-winsvc/src/main.rs`. There are no matching registry migration fallback paths or occurrences of "v0.1" in `main.rs` that can be removed safely.
+
+The task describes a scenario that is not present in the strictly confined scope file `crates/ramshared-winsvc/src/main.rs`. Therefore, it is architecturally impossible/unsafe to carry out the described action without hallucinating code.


### PR DESCRIPTION
## Resumo
Created a finding report as the requested obsolete v0.1 registry migration fallback paths do not exist in `crates/ramshared-winsvc/src/main.rs`. Modifying code to remove non-existent paths is impossible/unsafe.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: report absent fallback paths | Created FINDING_ONLY report | Instructions requested removing non-existent code | <details>Created `docs/jules/findings/FINDING_ONLY.md` detailing the absence of v0.1 fallback paths in main.rs.</details> |

## Labels
type:cleanup

## Validacao
cargo clippy -- -D warnings
cargo test

## Rollback trigger
Invalid or malformed FINDING_ONLY.md file.

---
*PR created automatically by Jules for task [6296768743795105028](https://jules.google.com/task/6296768743795105028) started by @emersonbusson*