### PR TITLE
🧪 [testing improvement] add error propagation unit tests for ublk serve_request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -9758,4 +9758,54 @@ Filename Type Size Used Priority
         assert!(!path.exists(), "exact owned socket was not cleaned");
         std::fs::remove_dir_all(&dir).unwrap();
     }
+
+    struct ErrorBackend;
+
+    impl ramshared_block::BlockBackend for ErrorBackend {
+        fn size_bytes(&self) -> u64 { 4096 }
+        fn block_size(&self) -> u32 { 4096 }
+        fn read_at(&mut self, _off: u64, _buf: &mut [u8]) -> Result<(), ramshared_block::IoError> {
+            Err(ramshared_block::IoError("read failed".into()))
+        }
+        fn write_at(&mut self, _off: u64, _data: &[u8]) -> Result<(), ramshared_block::IoError> {
+            Err(ramshared_block::IoError("write failed".into()))
+        }
+        fn flush(&mut self) -> Result<(), ramshared_block::IoError> {
+            Err(ramshared_block::IoError("flush failed".into()))
+        }
+    }
+
+    #[test]
+    fn serve_request_propagates_backend_errors() {
+        let mut backend = ErrorBackend;
+        let mut buffer = vec![0u8; 4096];
+        let eio = -5; // defined in ublk::EIO originally but private maybe, EIO is -5 in ublk_server
+
+        let read_req = ramshared_block::protocol::Request {
+            flags: 0,
+            cmd: ramshared_block::protocol::Command::Read,
+            handle: 1,
+            offset: 0,
+            len: 4096,
+        };
+        assert_eq!(crate::ublk_server::serve_request(&read_req, &mut backend, &mut buffer), eio);
+
+        let write_req = ramshared_block::protocol::Request {
+            flags: 0,
+            cmd: ramshared_block::protocol::Command::Write,
+            handle: 2,
+            offset: 0,
+            len: 4096,
+        };
+        assert_eq!(crate::ublk_server::serve_request(&write_req, &mut backend, &mut buffer), eio);
+
+        let flush_req = ramshared_block::protocol::Request {
+            flags: 0,
+            cmd: ramshared_block::protocol::Command::Flush,
+            handle: 3,
+            offset: 0,
+            len: 4096,
+        };
+        assert_eq!(crate::ublk_server::serve_request(&flush_req, &mut backend, &mut buffer), eio);
+    }
 }

--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -9762,8 +9762,12 @@ Filename Type Size Used Priority
     struct ErrorBackend;
 
     impl ramshared_block::BlockBackend for ErrorBackend {
-        fn size_bytes(&self) -> u64 { 4096 }
-        fn block_size(&self) -> u32 { 4096 }
+        fn size_bytes(&self) -> u64 {
+            4096
+        }
+        fn block_size(&self) -> u32 {
+            4096
+        }
         fn read_at(&mut self, _off: u64, _buf: &mut [u8]) -> Result<(), ramshared_block::IoError> {
             Err(ramshared_block::IoError("read failed".into()))
         }
@@ -9788,7 +9792,10 @@ Filename Type Size Used Priority
             offset: 0,
             len: 4096,
         };
-        assert_eq!(crate::ublk_server::serve_request(&read_req, &mut backend, &mut buffer), eio);
+        assert_eq!(
+            crate::ublk_server::serve_request(&read_req, &mut backend, &mut buffer),
+            eio
+        );
 
         let write_req = ramshared_block::protocol::Request {
             flags: 0,
@@ -9797,7 +9804,10 @@ Filename Type Size Used Priority
             offset: 0,
             len: 4096,
         };
-        assert_eq!(crate::ublk_server::serve_request(&write_req, &mut backend, &mut buffer), eio);
+        assert_eq!(
+            crate::ublk_server::serve_request(&write_req, &mut backend, &mut buffer),
+            eio
+        );
 
         let flush_req = ramshared_block::protocol::Request {
             flags: 0,
@@ -9806,6 +9816,9 @@ Filename Type Size Used Priority
             offset: 0,
             len: 4096,
         };
-        assert_eq!(crate::ublk_server::serve_request(&flush_req, &mut backend, &mut buffer), eio);
+        assert_eq!(
+            crate::ublk_server::serve_request(&flush_req, &mut backend, &mut buffer),
+            eio
+        );
     }
 }


### PR DESCRIPTION
## Resumo
Add unit tests for error propagation in `serve_request` when storage backend operations fail, utilizing a mock `ErrorBackend` that forcefully returns `IoError`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 🧪 [testing improvement] add error propagation unit tests for ublk serve_request | Adicionado test module | Aumentar cobertura e validar propagação de erros | <details>Adicionado struct ErrorBackend e test case serve_request_propagates_backend_errors</details> |

## Issue
N/A

## Responsavel
jules

## Labels
type:test

## Validacao
cargo test -p ramshared-wsl2d --bin ramsharedd
cargo clippy -- -D warnings

## Rollback trigger
Revert if tests fail on main branch.

---
*PR created automatically by Jules for task [283181129034258194](https://jules.google.com/task/283181129034258194) started by @emersonbusson*