### PR TITLE
📝 docs: add finding for non-existent vmstat parsing logic in wsl2d

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/docs/jules/findings/FINDING_ONLY_RS100.md
+++ b/docs/jules/findings/FINDING_ONLY_RS100.md
@@ -1,0 +1,18 @@
+# FINDING ONLY: Non-existent logic in ramshared-wsl2d
+
+## Scope of Task
+- Scope is strictly confined to: `crates/ramshared-wsl2d/src/main.rs` and its related test module.
+- Goal: Parse `/proc/vmstat` and `/proc/meminfo` metrics using in-place byte buffer scanning without allocating Strings.
+
+## Finding Details
+The instructions request to parse `/proc/vmstat` and `/proc/meminfo` within `crates/ramshared-wsl2d/src/main.rs`. However, a comprehensive analysis of the file confirms that this logic does not exist.
+
+### Evidence
+- Executing `grep -i "vmstat" crates/ramshared-wsl2d/src/main.rs` yields no results.
+- Executing `grep -i "meminfo" crates/ramshared-wsl2d/src/main.rs` yields no results.
+- The `parse_vmstat` and `parse_meminfo` functions exist in `crates/ramshared-cli/src/monitor.rs` and `crates/ramshared-cli/src/supervisor.rs`, but are completely absent from `ramshared-wsl2d`.
+
+## Conclusion
+As per the adversarial auditor instructions (Memory constraint): "If an instructed task requests changes to non-existent logic or a fix where safe code modification is impossible, do not hallucinate code. Instead, generate a FINDING_ONLY report with evidence in the docs/jules/findings/ directory instead of modifying code."
+
+Therefore, no code modifications have been made to `crates/ramshared-wsl2d/src/main.rs` as the requested logic is structurally absent from the permitted scope.


### PR DESCRIPTION
## Resumo
Identified that the requested `/proc/vmstat` and `/proc/meminfo` parsing logic is structurally non-existent within `crates/ramshared-wsl2d/src/main.rs`. A `FINDING_ONLY` report was generated in `docs/jules/findings/FINDING_ONLY_RS100.md` instead of hallucinating code, abiding by adversarial auditor rules.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: add finding for non-existent vmstat parsing logic in wsl2d | Created a `FINDING_ONLY` report | The target logic does not exist in the confined scope, and the memory constraint strictly prohibits hallucinating code. | <details>Added `docs/jules/findings/FINDING_ONLY_RS100.md` detailing the absence of `parse_vmstat` and `parse_meminfo` in `ramshared-wsl2d` (they reside in `ramshared-cli`).</details> |

## Issue
None

## Responsavel
Jules

## Labels
type:docs

## Validacao
cargo test --workspace && cargo clippy -- -D warnings (both passed)

## Rollback trigger
Remove the generated finding report if this audit is deemed invalid.

do not merge

---
*PR created automatically by Jules for task [11394456379956754977](https://jules.google.com/task/11394456379956754977) started by @emersonbusson*