### PR TITLE
🧪 [testing improvement] test error handling on CUDA driver dynamic loading failure in unix loader

### DIFF
--- a/append_memory.sh
+++ b/append_memory.sh
@@ -1,0 +1,1 @@
+echo "* When writing tests for invalid ELF loading, ensure the test properly creates a dummy file with non-ELF data, attempts to open it via \`dlopen\`, asserts graceful failure (null pointer), asserts non-empty error message, and safely cleans up the dummy file avoiding TOCTOU." >> MEMORY.md

--- a/crates/ramshared-cuda/src/loader_unix.rs
+++ b/crates/ramshared-cuda/src/loader_unix.rs
@@ -82,4 +82,35 @@ mod tests {
         let err_msg2 = error();
         assert_eq!(err_msg2, "unknown dlopen error");
     }
+
+    #[test]
+    fn test_invalid_elf_version_incompatible() {
+        use std::io::Write;
+        let mut tmp = std::env::temp_dir();
+        tmp.push("invalid_libcuda.so");
+
+        {
+            let mut f = std::fs::File::create(&tmp).unwrap();
+            f.write_all(b"not an elf file, invalid version/format").unwrap();
+            f.sync_all().unwrap();
+        }
+
+        let path_str = tmp.to_str().unwrap();
+        let c_path = std::ffi::CString::new(path_str).unwrap();
+
+        let _ = error(); // clear preexisting error
+        let handle = unsafe { open(c_path.as_ptr()) };
+        assert!(handle.is_null(), "Opening an invalid ELF should fail gracefully");
+
+        let err_msg = error();
+        assert!(!err_msg.is_empty());
+        assert_ne!(err_msg, "unknown dlopen error");
+
+        // Cleanup safely avoiding TOCTOU
+        let canon_tmp = std::fs::canonicalize(std::env::temp_dir()).unwrap_or_default();
+        let canon_target = std::fs::canonicalize(&tmp).unwrap_or_default();
+        if canon_target.starts_with(&canon_tmp) && !canon_target.as_os_str().is_empty() {
+            let _ = std::fs::remove_file(&tmp);
+        }
+    }
 }


### PR DESCRIPTION
## Resumo
Added a test to `loader_unix.rs` to verify that the Unix loader gracefully handles attempting to load an invalid/incompatible ELF file. This ensures our VRAM dependency loading path does not panic or crash when encountering malformed `libcuda.so` stubs.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| test: test invalid elf version handling in unix loader | Added `test_invalid_elf_version_incompatible` | To verify that `dlopen` gracefully fails and sets an error message for invalid ELF formats | <details>Creates a dummy non-ELF file, attempts to load it, asserts failure and error presence, and safely cleans up the file.</details> |

## Issue
N/A

## Responsavel
RS100

## Labels
type:test, area:cuda

## Validacao
`cargo test -p ramshared-cuda` and `cargo clippy -p ramshared-cuda -- -D warnings`

## Rollback trigger
If the test causes CI failures or flakiness across different environments due to temp file permissions or handling.

---
*PR created automatically by Jules for task [4364559049717425443](https://jules.google.com/task/4364559049717425443) started by @emersonbusson*