### PR TITLE
🧹 [code health improvement] generate FINDING_ONLY report for compute capability refactor

### DIFF
--- a/docs/jules/findings/compute_capability_finding.md
+++ b/docs/jules/findings/compute_capability_finding.md
@@ -1,0 +1,30 @@
+# FINDING_ONLY: Compute Capability Validation Logic Does Not Exist
+
+**Objective:** Refactor CUDA compute capability check validation logic in `crates/ramshared-cuda/src/driver.rs`.
+
+## Finding
+
+During the exploration phase, it was determined that the `crates/ramshared-cuda/src/driver.rs` file does not contain any logic related to "compute capability".
+
+The explicit instruction requires me to simplify compute capability matching rules into clean pattern-matching functions within the strictly confined scope of `crates/ramshared-cuda/src/driver.rs`.
+
+However, the file exclusively deals with basic CUDA driver API wrappers (initialization, device enumeration, context creation, memory allocation, zeroing, and host-device copies). The `ramshared-cuda` workspace does not expose or validate CUDA compute capabilities.
+
+Per the adversarial systems auditor rules:
+"When an adversarial audit task requests code changes that are architecturally impossible or unsafe within the strictly confined scope (e.g., adding locks to a pure logic file), produce a FINDING_ONLY markdown report with evidence in the docs/jules/findings/ directory instead of modifying code."
+
+Attempting to implement this refactoring would require hallucinating non-existent functionalities, which violates the auditor instructions.
+
+## Evidence
+
+Running `grep` across the target directory yields no results for "compute" or "capability":
+
+```
+$ grep -rin "compute" crates/ramshared-cuda/
+Not found
+
+$ grep -rin "capability" crates/ramshared-cuda/
+Not found
+```
+
+As there is no such logic, no code modification has been made to strictly adhere to the project constraints.


### PR DESCRIPTION
## Resumo
Adicionado um relatório FINDING_ONLY em `docs/jules/findings/compute_capability_finding.md` documentando que a lógica de validação de 'compute capability' solicitada não existe em `crates/ramshared-cuda/src/driver.rs`. Modificações de código não puderam ser aplicadas por falta de código base correspondente (como explicitamente verificado com o comando `grep`), sendo a geração do relatório a única ação permitida e segura dentro das estritas regras de auditoria adversarial.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | Adicionou FINDING_ONLY report | A instrução requeria a refatoração de uma lógica inexistente no escopo confinado. | <details>Foi criado o documento `docs/jules/findings/compute_capability_finding.md` conforme as regras `FINDING_ONLY`.</details> |

## Labels
type:cleanup

## Validacao
`cargo test && cargo clippy -- -D warnings` foi executado para garantir que nenhuma regressão ou unvetted unsafe code foi introduzido em `crates/ramshared-cuda`. 

## Rollback trigger
Reverter se a pipeline de CI falhar na validação do relatório FINDING_ONLY ou se os revisores determinarem que outra abordagem é possível apesar das severas restrições de escopo.

---
*PR created automatically by Jules for task [3874551768136593303](https://jules.google.com/task/3874551768136593303) started by @emersonbusson*