### PR TITLE
🔒 [security fix description] Document absence of WSL host bridge in ramshared-wsl2d

### DIFF
--- a/docs/jules/findings/019_finding.md
+++ b/docs/jules/findings/019_finding.md
@@ -1,0 +1,39 @@
+# FINDING ONLY
+
+## Area
+Security
+
+## Task
+prevent command injection in wsl host bridge invocation
+
+## Finding
+The logic requested to be modified (wsl host bridge invocation, invoking `wsl.exe` or `powershell.exe`) does not exist within the strictly confined scope: `crates/ramshared-wsl2d/src/main.rs`.
+
+Extensive searches for `powershell`, `wsl.exe`, `powershell.exe`, `wsl_host_bridge`, `wsl host bridge` and `Command` invocations did not reveal any logic that crossed the WSL2/Windows host boundary executing commands in the specified file. The daemon `ramsharedd` operates within the WSL2 Linux environment and its external command invocations (like `blkid`, `nvidia-smi`, `swapoff`, `head`, `sleep`, `/bin/sh`) are standard Linux processes, without any cross-boundary `wsl.exe` calls in `crates/ramshared-wsl2d/src/main.rs`.
+
+Since the target logic is architecturally impossible or non-existent within the strictly confined scope, no code modifications are possible.
+
+## Evidence
+
+Running `grep` inside the `crates/ramshared-wsl2d/src/main.rs` file for command invocations across the host boundary showed no results:
+
+```bash
+$ grep -i "wsl.exe" crates/ramshared-wsl2d/src/main.rs
+# (No results)
+
+$ grep -i "powershell.exe" crates/ramshared-wsl2d/src/main.rs
+# (No results)
+
+$ grep -i "host bridge" crates/ramshared-wsl2d/src/main.rs
+# (No results)
+```
+
+The command executions using `std::process::Command` inside `crates/ramshared-wsl2d/src/main.rs` are all Linux commands:
+- `nvidia-smi`
+- `blkid`
+- `swapoff`
+- `head`
+- `sleep`
+- `/bin/sh` (in tests only)
+
+Therefore, the requested command injection prevention is not applicable to the targeted scope.


### PR DESCRIPTION
## Resumo
Created a FINDING_ONLY report to document the absence of `wsl.exe` / `powershell.exe` host bridge invocations in the `ramshared-wsl2d` crate `main.rs`, as no such logic exists within the scoped file to sanitize.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs(security): document absence of wsl host bridge logic | Created `docs/jules/findings/019_finding.md` | The requested logic to modify (WSL host bridge invocation) does not exist in the confined scope | <details>The file `crates/ramshared-wsl2d/src/main.rs` contains only Linux native `Command::new` invocations and no cross-boundary bridge execution.</details> |

## Issue
N/A (Security Audit Task)

## Responsavel
@jules

## Labels
type:security

## Validacao
`cargo test` and `cargo clippy -- -D warnings`

## Rollback trigger
If the documentation is placed incorrectly or violates repository structure.

---
*PR created automatically by Jules for task [2690963976277706286](https://jules.google.com/task/2690963976277706286) started by @emersonbusson*