### PR TITLE
🧪 [generate FINDING_ONLY report for non-existent capability logic]

### DIFF
--- a/docs/jules/findings/027-capability-validation.md
+++ b/docs/jules/findings/027-capability-validation.md
@@ -1,0 +1,16 @@
+# FINDING_ONLY: Capability Validation Logic
+
+## Context
+The task requested to "refactor complex adapter capability validation logic into predicates" in `crates/ramshared-dxg/src/lib.rs`.
+
+## Finding
+No such "capability validation logic" exists in the target file `crates/ramshared-dxg/src/lib.rs`.
+The crate acts as a minimal `/dev/dxg` WDDM video-memory budget provider responsible for GPU budget queries and adapter enumeration.
+It is an isolated architectural component that does not implement or contain any command stream, buffer allocation logic, or adapter capability validation logic.
+
+## Evidence
+- Grepping for "capability" yields no results.
+- `lib.rs` exports types like `AdapterInfo`, `EnumAdapters2`, and `QueryVideoMemoryInfo`, but doesn't have capability checks beyond basic IOCTL validation.
+
+## Resolution
+As per instructions, when an adversarial audit task requests code changes that are architecturally impossible or unsafe within the strictly confined scope (e.g. hallucinating code), a `FINDING_ONLY` markdown report with evidence in `docs/jules/findings/` is generated instead.


### PR DESCRIPTION
## Resumo
Generated `FINDING_ONLY` report in `docs/jules/findings/027-capability-validation.md` because the requested adapter capability validation logic does not exist in `ramshared-dxg`. The crate is purely an isolated WDDM budget provider and enumerator.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `test(dxg): generate FINDING_ONLY report for non-existent capability logic` | Added finding report. | The target file `ramshared-dxg/src/lib.rs` contains no such capability validation logic; hallucinating code is strictly prohibited by RS100. | <details>Created `docs/jules/findings/027-capability-validation.md` outlining the architectural reality of the crate.</details> |

## Issue
N/A (Adversarial Audit RS100/L21/dxg/027)

## Responsavel
@jules

## Labels
type:test

## Validacao
`cargo test -p ramshared-dxg && cargo clippy -p ramshared-dxg -- -D warnings`

## Rollback trigger
Revert if the finding document fails CI validation.

---
*PR created automatically by Jules for task [18120783669316514205](https://jules.google.com/task/18120783669316514205) started by @emersonbusson*