### PR TITLE
test: [finding only] remove redundant clone in frame mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/docs/jules/findings/RS100-vram-032.md
+++ b/docs/jules/findings/RS100-vram-032.md
@@ -1,0 +1,15 @@
+# FINDING_ONLY: RS100-vram-032
+
+## Issue
+The task requests removing a redundant `.clone()` call in a physical frame mapping loop within `crates/ramshared-vram/src/lib.rs`.
+
+## Finding
+After a thorough inspection of `crates/ramshared-vram/src/lib.rs` and the entire `crates/ramshared-vram/` crate, the requested `Frame` structure, physical frame mapping loop, and the `.clone()` call **do not exist**.
+
+- The `ramshared-vram` crate contains only abstract trait definitions (`VramMemory`, `VramProvider`) and an error enum (`VramError`).
+- There is no implementation of a "frame mapping loop" inside this crate.
+- Running `grep -r -ni 'clone' crates/ramshared-vram/` and `grep -r -ni 'frame' crates/ramshared-vram/` yields empty results.
+
+As per the adversarial auditor instructions and immutable rules, since the requested logic to modify is non-existent within the strictly confined scope, no code changes can be safely made. Hallucinating or inserting new architecture into `lib.rs` would violate the strict scope and architectural constraints.
+
+Therefore, this report is generated in lieu of code modifications.


### PR DESCRIPTION
## Resumo
Adversarial audit RS100-vram-032. The requested task to remove a redundant `.clone()` call in a physical frame mapping loop within `crates/ramshared-vram/src/lib.rs` cannot be completed because the `Frame` structure, mapping loop, and `.clone()` call do not exist in the confined scope. A `FINDING_ONLY` report has been generated in `docs/jules/findings/` as per the immutable rules to prevent hallucinating code or architectural drift.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| test: [finding only] remove redundant clone in frame mapping | Generated FINDING_ONLY report | Requested target code does not exist in confined scope. | <details>Added docs/jules/findings/RS100-vram-032.md</details> |

## Issue
None

## Responsavel
Jules

## Labels
type:test

## Validacao
cargo test
cargo clippy -- -D warnings

## Rollback trigger
Revert if the finding is deemed incorrect and a valid codebase location exists.

do not merge

---
*PR created automatically by Jules for task [15443012878997174732](https://jules.google.com/task/15443012878997174732) started by @emersonbusson*