### PR TITLE
test(vram): document finding on architecturally impossible swap dropping test

### DIFF
--- a/docs/jules/findings/vram_stress_test_finding.md
+++ b/docs/jules/findings/vram_stress_test_finding.md
@@ -1,0 +1,24 @@
+# FINDING_ONLY: VRAM Stress Test for Swap Dropping
+
+## Request Context
+
+- **Task**: Stress test swap dropping under vRAM pressure and memory saturation.
+- **Scope**: Strictly confined to `crates/ramshared-vram/src/lib.rs` and its related test module.
+
+## Findings
+
+It is architecturally impossible and unsafe to implement concrete swap dropping logic or a stress test for swap dropping within `crates/ramshared-vram/src/lib.rs`.
+
+### Evidence
+
+1. **Pure Trait Abstraction Layer**: As indicated in the file comments (`//! `ramshared-vram` — VRAM backend abstraction (RF-G1, preparation for P3).`), this crate is designed strictly as an abstraction layer for VRAM backend control planes. It separates the control plane from concrete backend implementations like CUDA or Vulkan.
+
+2. **No Concrete Backend Data Plane**: The documentation explicitly states that "The **data plane** (block I/O) is already abstracted by `ramshared_block::BlockBackend`; this crate handles VRAM-specific operations." It only contains the `VramError` enum and the traits `VramMemory` and `VramProvider`.
+
+3. **No Swap Logic or Storage Components**: There is no code related to swap, memory saturation metrics, or I/O dropping within this crate. It strictly enforces `#![forbid(unsafe_code)]` and relies entirely on external concrete implementers to provide actual VRAM allocation logic.
+
+4. **Testing Architecturally Invalid**: Because this crate only defines interfaces, there is no implementation to "stress test" against swap dropping under memory saturation. Writing a test here for swap dropping would require hallucinating concrete components and data planes that violate the architectural boundaries of `ramshared-vram`.
+
+### Conclusion
+
+The task requests an implementation that violates the architectural invariants of the `ramshared-vram` crate. The scoped file `crates/ramshared-vram/src/lib.rs` must remain a pure abstraction. Therefore, no code modifications have been made to avoid breaking the control plane separation architecture and introducing unsafe code.


### PR DESCRIPTION
## Resumo
Documented that implementing a stress test for swap dropping under memory saturation in `ramshared-vram` is architecturally impossible and unsafe, as it is a pure trait abstraction layer containing no swap logic or data plane.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| test(vram): document finding on architecturally impossible swap dropping test | Created a FINDING_ONLY report in docs/jules/findings/vram_stress_test_finding.md | The requested test scope (`crates/ramshared-vram/src/lib.rs`) is strictly confined to a pure trait abstraction layer, making it impossible to test swap dropping logic without violating the architecture. | <details><summary>Detalhes</summary>Added `vram_stress_test_finding.md` which lists the evidence.</details> |

## Issue
N/A

## Responsavel
RS100

## Labels
type:test, type:docs

## Validacao
Executed `cargo test` and `cargo clippy -- -D warnings` across the workspace successfully.

## Rollback trigger
Revert if the findings report format is disputed or causes docs/ tooling issues.

---
*PR created automatically by Jules for task [1418833333706901468](https://jules.google.com/task/1418833333706901468) started by @emersonbusson*