### PR TITLE
docs: add FINDING_ONLY report for VRAM audit

### DIFF
--- a/docs/jules/findings/RS100_vram_audit.md
+++ b/docs/jules/findings/RS100_vram_audit.md
@@ -1,0 +1,34 @@
+# FINDING ONLY: VRAM Pointer Boundary Audit
+
+**IDENTIDADE:** RS100/2026-08-29/L15/vram/035
+**CRATE:** crates/ramshared-vram
+**TARGET_FILE:** crates/ramshared-vram/src/lib.rs
+**AREA:** Security
+**LENS:** L15
+
+## Finding
+
+The instruction requests adding strict bounds checking, pointer alignment verification, and rigorous `// SAFETY:` comments on raw pointer dereferences within `crates/ramshared-vram/src/lib.rs`.
+
+However, `crates/ramshared-vram/src/lib.rs` is a pure Rust abstraction layer containing trait definitions (like `VramMemory` and `VramProvider`) for VRAM backends. Crucially, it enforces `#![forbid(unsafe_code)]` at the top of the file, and does not contain any raw pointers, unsafe blocks, or implementation of memory allocation logic. The concrete backend logic (where such pointer operations would exist) resides in backend-specific crates like `ramshared-cuda` or `ramshared-vulkan`.
+
+Therefore, it is architecturally impossible and unsafe to introduce raw pointer logic or unsafe blocks into this strictly safe abstraction crate.
+
+## Evidence
+
+The `crates/ramshared-vram/src/lib.rs` file begins with:
+```rust
+//! `ramshared-vram` — VRAM backend abstraction (RF-G1, preparation for P3).
+//!
+//! Separates the VRAM **control plane** (lifecycle + allocation + wipe + free-floor) from
+//! the concrete backend (currently CUDA; Vulkan in the future). The **data plane** (block I/O) is
+//! already abstracted by `ramshared_block::BlockBackend`; this crate handles VRAM-specific operations.
+//!
+//! Safe Rust only, completely driver-agnostic. The concrete CUDA implementation lives in
+//! `ramshared-cuda` (which re-exports the types + impl); a future `ramshared-vulkan` would do the same.
+//!
+//! SPEC: docs/vram-provider/SPEC.md.
+#![forbid(unsafe_code)]
+```
+
+Adding `unsafe` blocks here would directly violate `#![forbid(unsafe_code)]` and the crate's architectural purpose as a safe abstraction layer.


### PR DESCRIPTION
## Resumo
Adiciona um relatório FINDING_ONLY documentando por que não é possível adicionar checagem de limites e verificação de alinhamento de ponteiro no crate `ramshared-vram`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: add FINDING_ONLY report for VRAM audit | Adicionou FINDING_ONLY | Para documentar a impossibilidade arquitetural | <details>O crate `ramshared-vram` é uma camada de abstração segura (`#![forbid(unsafe_code)]`) sem ponteiros ou lógica de alocação de memória</details> |

## Issue
N/A

## Responsavel
@jules

## Labels
type:docs

## Validacao
`cargo test` e `cargo clippy -- -D warnings` executados e passaram com 0 warnings.

## Rollback trigger
Se o relatório for impreciso ou desnecessário.

---
*PR created automatically by Jules for task [17608815832561891977](https://jules.google.com/task/17608815832561891977) started by @emersonbusson*