### PR TITLE
test: finding report for transient page eviction race condition

### DIFF
--- a/docs/jules/findings/transient_page_eviction.md
+++ b/docs/jules/findings/transient_page_eviction.md
@@ -1,0 +1,15 @@
+# Finding: Architecturally Impossible Test Request
+
+**Date:** 2026-08-29
+**Task:** race condition test for transient page eviction and atomic pointer swap
+**Scope Target:** `crates/ramshared-vram/src/lib.rs`
+
+## Evidence
+
+The requested task mandates the creation of a "concurrency test verifying atomic pointer swap during transient page eviction to prevent double-free", strictly confined to `crates/ramshared-vram/src/lib.rs`.
+
+However, code inspection reveals that `crates/ramshared-vram/src/lib.rs` is solely an abstraction layer defining traits (`VramMemory` and `VramProvider`) and an error enum (`VramError`). It does not contain any concrete implementations, atomic pointers, or page eviction logic. The entire file is exactly 73 lines long and enforces `#![forbid(unsafe_code)]`. Furthermore, the traits explicitly state that they represent thread-affinity contexts and do NOT require `Send`, making concurrency inherently architecturally invalid in this specific module.
+
+Attempting to fulfill this instruction would require hallucinating non-existent logic and violating the strict file scope and `#![forbid(unsafe_code)]` invariant.
+
+Therefore, safe code modification within the defined boundaries is impossible, and this `FINDING_ONLY` report is produced as per the adversarial systems auditor instructions.


### PR DESCRIPTION
## Resumo
Added a `FINDING_ONLY` report in `docs/jules/findings/transient_page_eviction.md` to document that the requested concurrency test for atomic pointer swaps during transient page eviction cannot be safely implemented in `crates/ramshared-vram/src/lib.rs`. The target module solely contains trait definitions without implementations and strictly forbids unsafe code, making the requested logic architecturally impossible.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| test: finding report for transient page eviction race condition | Created a `FINDING_ONLY` report | Because implementing the test in `crates/ramshared-vram/src/lib.rs` is impossible and would violate the `#![forbid(unsafe_code)]` invariant and architectural scope. | <details>The report documents that `ramshared-vram` provides purely thread-local `VramMemory` trait definitions without concurrency or eviction logic.</details> |

## Labels
type:test

## Validacao
Executed `cargo test` and `cargo clippy -- -D warnings` on the entire workspace to ensure no regressions were introduced.

## Rollback trigger
Code modification violates `#![forbid(unsafe_code)]` or attempts to implement non-existent logic in `ramshared-vram`.

---
*PR created automatically by Jules for task [4692186681326379287](https://jules.google.com/task/4692186681326379287) started by @emersonbusson*