### PR TITLE
🧹 [report absence of obsolete WSL2 kernel module loading shims]

### DIFF
--- a/docs/jules/findings/022-wsl2-shims-obsolete.md
+++ b/docs/jules/findings/022-wsl2-shims-obsolete.md
@@ -1,0 +1,17 @@
+# FINDING_ONLY: Purge dead code and obsolete WSL2 kernel module loading shims
+
+## Scope
+Task: purge dead code and obsolete WSL2 kernel module loading shims
+Target file: `crates/ramshared-wsl2d/src/main.rs` and its related test module.
+
+## Finding
+As an adversarial auditor, I investigated the codebase to implement the requested cleanup of legacy kernel module loading workarounds for older WSL2 kernel releases.
+
+1. Within the strictly confined scope (`crates/ramshared-wsl2d/src/main.rs`), there are **no** kernel module loading shims (e.g., executing `modprobe`, `insmod`, or shelling out to manage modules).
+2. The `ramshared-wsl2d` daemon does not load kernel modules itself. The responsibility of loading required kernel modules (such as `nbd` or `zram`) is managed by `ramshared-cli` (e.g. `crates/ramshared-cli/src/cascade/cascade_io.rs` calls `modprobe`).
+3. The only code in `crates/ramshared-wsl2d/src/main.rs` specifically checking WSL2 release strings is the `guard_not_wsl2()` function, which acts as a safety mechanism to prevent host freezes by refusing to start the standalone ublk server on WSL2. It does not perform module loading workarounds.
+4. A thorough grep for `legacy`, `obsolete`, `workaround`, `shim`, and `modprobe` in the target file returned no matches related to WSL2 kernel module loading.
+
+Because the instructed task requests changes to non-existent logic where safe code modification is impossible, I must produce this `FINDING_ONLY` report to avoid hallucinating code modifications, violating invariants, and introducing instability into the codebase.
+
+No safe orthogonal slice of code can be removed to satisfy this prompt. The system is already secure regarding this specific concern within the specified scope.


### PR DESCRIPTION
## Resumo
Adversarial audit of `crates/ramshared-wsl2d/src/main.rs` for obsolete WSL2 kernel module loading shims. Confirmed via codebase search that the daemon contains no module loading logic (e.g. `modprobe`), as this is handled externally by `ramshared-cli`. Generated a FINDING_ONLY report to document the absence of these shims and explicitly avoided hallucinating code changes in the target file, maintaining its safety and stability.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: report absence of obsolete WSL2 kernel module loading shims | Documented the absence of requested shims in the target scope. | To satisfy the prompt's instruction safely without hallucinating code or introducing regressions, per the adversarial audit rules. | <details>Created `docs/jules/findings/022-wsl2-shims-obsolete.md`.</details> |

## Issue
do not merge

## Responsavel
Jules

## Labels
type:cleanup

## Validacao
`cargo test -p ramshared-wsl2d`
`cargo clippy --workspace -- -D warnings`

## Rollback trigger
The finding report is inaccurate or modifies code outside the required scope.

---
*PR created automatically by Jules for task [4240211913549395011](https://jules.google.com/task/4240211913549395011) started by @emersonbusson*