### PR TITLE
📝 [audit report] Document absent loop allocation in diagnostic probe

### DIFF
--- a/docs/jules/findings/L01_cli_039_finding.md
+++ b/docs/jules/findings/L01_cli_039_finding.md
@@ -1,0 +1,8 @@
+# FINDING_ONLY: L01_cli_039
+
+## Evidence
+The requested task "hoist fixed byte array allocation out of loop in diagnostic probe" is not applicable to the target file `crates/ramshared-cli/src/diagnose.rs`.
+
+The file `crates/ramshared-cli/src/diagnose.rs` strictly contains JSONL parsing and evaluation logic (e.g., `diagnose_jsonl`, `diagnose_events`) for evaluating resource demotions and anomalies based on telemetry events. There is no loop performing byte array allocation in this file.
+
+Attempting to implement this task would require hallucinating code that is neither present nor relevant to the current architectural purpose of `diagnose.rs`, strictly violating the constraints. Therefore, no safe code modifications can be made within the explicitly confined scope.


### PR DESCRIPTION
## Resumo
Created a FINDING_ONLY report because the requested performance optimization ("hoist fixed byte array allocation out of loop in diagnostic probe") cannot be implemented. The target file `crates/ramshared-cli/src/diagnose.rs` strictly contains pure JSONL parsing and evaluation logic, and does not contain any loops performing byte array allocation. Hallucinating this logic would violate the strict scope constraints of the adversarial audit.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|--------|-----------|-------------|----------|
| docs: add FINDING_ONLY report for L01_cli_039 | Added a markdown report in `docs/jules/findings/` | To document that the requested logic does not exist in the target file | <details>Created `L01_cli_039_finding.md` explaining the absence of the target loop in `diagnose.rs`.</details> |

## Issue
RS100: L01/cli/039

## Responsavel
Jules

## Labels
type:documentation

## Validacao
`cargo test && cargo clippy -- -D warnings`

## Rollback trigger
If the diagnostic loop allocation is later proven to exist in this file, this finding must be reverted.

---
*PR created automatically by Jules for task [3911142536015456364](https://jules.google.com/task/3911142536015456364) started by @emersonbusson*