### PR TITLE
🧹 purge unused Windows API FFI definitions in winbroker

### DIFF
--- a/docs/jules/findings/072-purge-unused-ffi.md
+++ b/docs/jules/findings/072-purge-unused-ffi.md
@@ -1,0 +1,11 @@
+# FINDING_ONLY: Purge unused Windows API FFI definitions in winbroker
+
+## Scope
+Task requested to remove unused Windows SDK types and FFI function declarations, strictly confined to `crates/ramshared-winbroker/src/lib.rs`.
+
+## Finding
+After a thorough review of `crates/ramshared-winbroker/src/lib.rs` and the related codebase, it is confirmed that there are **no Windows API FFI definitions or unused Windows SDK types** present in `crates/ramshared-winbroker/src/lib.rs`.
+
+The file `crates/ramshared-winbroker/src/lib.rs` contains purely standard Rust domain logic and structures (`BrokerPhase`, `BrokerConfigV1`, `BrokerSessionCore`, etc.). All FFI logic for Windows APIs resides exclusively in `crates/ramshared-winbroker/src/pipe.rs` and `crates/ramshared-winbroker/src/service.rs`, which are strictly outside the required confined scope.
+
+Because the task instructs to modify non-existent logic and safe code modification is impossible within the strictly confined scope, this `FINDING_ONLY` report has been generated instead of hallucinating code changes, as per adversarial auditor instructions.


### PR DESCRIPTION
## Resumo
Created a `FINDING_ONLY` report since there were no unused Windows API FFI definitions or unused Windows SDK types in the specified scope `crates/ramshared-winbroker/src/lib.rs`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | Created FINDING_ONLY report | Because safe code modification is impossible within the strictly confined scope. | <details>Generated a finding_only report in docs/jules/findings/072-purge-unused-ffi.md</details> |

## Labels
type:cleanup

## Validacao
cargo test -p ramshared-winbroker && cargo clippy -p ramshared-winbroker -- -D warnings

## Rollback trigger
Any regression in the broker functionality or tests.

---
*PR created automatically by Jules for task [11792050904609554047](https://jules.google.com/task/11792050904609554047) started by @emersonbusson*