### PR TITLE
test: produce FINDING_ONLY report for serve_request in protocol.rs

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -476,6 +476,13 @@
   ],
   "exclusions": [
     {
+      "id": "findings-reports",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "security",
+      "reason": "Agent-generated finding reports for out-of-scope architectural issues.",
+      "registeredAt": "2026-08-29T00:00:00Z"
+    },
+    {
       "id": "localized-root-readme",
       "pattern": "README.pt-BR.md",
       "owner": "product-documentation",

--- a/docs/jules/findings/FINDING_ONLY.md
+++ b/docs/jules/findings/FINDING_ONLY.md
@@ -1,0 +1,17 @@
+# FINDING_ONLY: Task RS100/2026-08-29/L08/broker/045
+
+## Request
+The user requested adding comprehensive fault injection unit tests for `serve_request` covering `BrokenPipe`, `ConnectionReset`, and `Timeout` strictly confined to `crates/ramshared-broker/src/protocol.rs`.
+
+## Finding
+The function `serve_request` does not exist in `crates/ramshared-broker/src/protocol.rs`. A search across the repository reveals that `serve_request` is actually located in `crates/ramshared-wsl2d/src/ublk_server.rs`.
+
+Because the task instruction strictly mandates that the scope is "strictly confined to: crates/ramshared-broker/src/protocol.rs and its related test module", and since the target logic (`serve_request`) does not exist within this scope, it is impossible to safely modify code to accomplish the goal without violating the scope constraints.
+
+Therefore, no code changes were made to the source files.
+
+## Evidence
+- `grep serve_request crates/ramshared-broker/src/protocol.rs` yields no results.
+- `grep -R serve_request crates/ramshared-broker` yields no results.
+- `grep -R serve_request .` reveals it exists in `crates/ramshared-wsl2d/src/ublk_server.rs`.
+- The file `crates/ramshared-broker/src/protocol.rs` has been read to its final byte (10842 bytes, 342 lines) and no such function or logic is present.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,9 +2,9 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 258,
+    "total": 259,
     "classified": 247,
-    "excluded": 11,
+    "excluded": 12,
     "unclassified": 0,
     "ambiguous": 0
   },
@@ -568,6 +568,16 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/FINDING_ONLY.md",
+      "disposition": "excluded",
+      "ruleId": "findings-reports",
+      "verification": {
+        "state": "not-applicable"
+      },
+      "owner": "security",
+      "reason": "Agent-generated finding reports for out-of-scope architectural issues."
     },
     {
       "path": "docs/labs/DUALBOOT-KERNEL-TRUE.md",


### PR DESCRIPTION
## Resumo
A tarefa requisitou a adição de testes unitários para a função `serve_request` com foco estritamente no arquivo `crates/ramshared-broker/src/protocol.rs`. Após auditoria no escopo restrito, constatou-se que a função `serve_request` não existe neste arquivo, mas sim em `ramshared-wsl2d`. Diante da impossibilidade arquitetural e da restrição estrita, foi produzido um relatório de descobertas (`FINDING_ONLY.md`). Nenhuma modificação no código-fonte foi realizada.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| test: produce FINDING_ONLY... | Criou o relatório FINDING_ONLY.md | A função serve_request não existe no escopo restrito | Comprova ausência da função |

## Labels
type:test, type:finding

## Validacao
`cargo test && cargo clippy -- -D warnings` foram executados na workspace (passando com sucesso na crate `ramshared-broker`). 

## Rollback trigger
Rollback trigger: removal of the FINDING_ONLY markdown file.

---
*PR created automatically by Jules for task [4460855726283323196](https://jules.google.com/task/4460855726283323196) started by @emersonbusson*