### PR TITLE
docs: create FINDING_ONLY report for arbiter lease states

### DIFF
--- a/docs/jules/findings/lease-arbiter-state-tests.md
+++ b/docs/jules/findings/lease-arbiter-state-tests.md
@@ -1,0 +1,23 @@
+# FINDING_ONLY: Lease Expiration & Renewal Logic Non-Existent
+
+## Scope Analyzed
+`crates/ramshared-broker/src/arbiter.rs`
+
+## Finding
+The task requested implementing a full test matrix for lease acquisition, renewal, expiration, and conflict resolution states in `arbiter.rs`. However, a full inspection of `arbiter.rs` (exactly 529 lines, read completely via `sed`) confirms that this file only implements the pure `tick` policy for slice rebalancing (using `Action::GrantLease`, `Action::RevokeForLease`, `Action::MoveSlice`, etc.) and does not contain any state transitions or logic for:
+- Lease expiration (leases are granted indefinitely from the perspective of the pure tick).
+- Lease renewal.
+- Conflict resolution (beyond basic hysteresis and differential rebalancing).
+
+Attempting to test these non-existent states within `arbiter.rs` would require hallucinating behavior that is not implemented in this domain logic component (or is perhaps handled upstream in `lease.rs` or `protocol.rs`, which are outside the strictly confined scope).
+
+Therefore, safe code modification to fulfill the test matrix request in `arbiter.rs` is architecturally impossible.
+
+## Evidence
+- `wc -l crates/ramshared-broker/src/arbiter.rs` outputs 529 lines.
+- `grep -i expiration crates/ramshared-broker/src/arbiter.rs` returns nothing.
+- Manual inspection of `arbiter.rs` lines 50-200 confirms the `Action` enum and `tick` logic do not include lease expiration or renewal constructs. The only lease-related actions are `RevokeForLease` and `GrantLease`.
+- The task scope is strictly confined to `crates/ramshared-broker/src/arbiter.rs`.
+
+## Conclusion
+Code changes cannot be safely made within the confined scope to fulfill this prompt without hallucinating non-existent logic.


### PR DESCRIPTION
## Resumo
Created a FINDING_ONLY report as safe code modification to implement the requested lease expiration and renewal tests within `arbiter.rs` is impossible without hallucinating non-existent logic in this domain layer.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: create FINDING_ONLY report for arbiter lease states | Added `docs/jules/findings/lease-arbiter-state-tests.md` | Required by fallback rule 4 since arbiter.rs contains no logic for expiration or renewal. | Verified exactly 529 lines. |

## Labels
type:test, type:docs

## Validacao
`cargo test -p ramshared-broker`
`cargo clippy -p ramshared-broker -- -D warnings`

## Rollback trigger
Revert this commit if the finding file accidentally blocks main branch CI.

do not merge

---
*PR created automatically by Jules for task [16588653578150492387](https://jules.google.com/task/16588653578150492387) started by @emersonbusson*