### PR TITLE
refactor: add finding report for fine-grained locking on slices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/docs/jules/findings/047-findings.md
+++ b/docs/jules/findings/047-findings.md
@@ -1,0 +1,16 @@
+# FINDING_ONLY: fine-grained locking in slice manager to reduce thread contention
+
+## Issue
+The task requested to "Replace global broker mutex with partitioned concurrent slice map to avoid thread contention under heavy load" in `crates/ramshared-broker/src/slices.rs`.
+
+## Finding
+`ramshared-broker` is a pure domain logic library. The file `crates/ramshared-broker/src/slices.rs` states: `/// Map of VRAM slices (sole owner of truth about the state; no locks — ITEM-8 is single-threaded).` The `SliceMap` does not implement locks nor contains threading primitives like `Mutex` or `RwLock`.
+
+According to the Memory instructions:
+* "The `crates/ramshared-broker/src/lib.rs` file acts only as a pure library module root. It does not contain the core broker loop logic; the actual plumbing and broker loop reside in the `ramsharedd` daemon (crate `ramshared-wsl2d`)."
+* "When an adversarial audit task requests code changes that are architecturally impossible or unsafe within the strictly confined scope (e.g., adding locks to a pure logic file), produce a FINDING_ONLY markdown report with evidence in the docs/jules/findings/ directory instead of modifying code."
+
+I confirmed the entire file up to line 212 does not have any `Mutex` and explicitly documents the lack of locks and threads in this logic.
+
+## Conclusion
+It is architecturally invalid to add locks or thread partitions to `crates/ramshared-broker/src/slices.rs`, since it is purely a domain logic model. I am producing this FINDING_ONLY report to document the impossibility of implementing this task.


### PR DESCRIPTION
## Resumo
The task requested to replace a global mutex with a partitioned concurrent slice map to avoid thread contention. I discovered that `ramshared-broker` is a pure domain logic crate that strictly forbids thread primitives, locks, or IO, and the file `slices.rs` clearly states it is single-threaded with no locks. I generated a FINDING_ONLY report at `docs/jules/findings/047-findings.md` to document the architectural impossibility.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor: add finding report for fine-grained locking on slices | Produced a FINDING_ONLY report in `docs/jules/findings/047-findings.md`. | It is architecturally impossible to implement locks in a pure logic file. | Adhered to the adversarial audit escape hatch. |

## Labels
type:refactor

## Validacao
`cargo test` and `cargo clippy -- -D warnings` executed successfully.

## Rollback trigger
If the finding report is deemed unnecessary.

do not merge

---
*PR created automatically by Jules for task [11551953802518386231](https://jules.google.com/task/11551953802518386231) started by @emersonbusson*