### PR TITLE
docs: add finding for non-existent lease dispatcher

### DIFF
--- a/docs/jules/findings/RS100_L20_broker_050.md
+++ b/docs/jules/findings/RS100_L20_broker_050.md
@@ -1,0 +1,15 @@
+# FINDING_ONLY: Non-existent Target Function
+
+## Context
+Task: "decompose handle_lease_request dispatcher into focused handlers"
+File: `crates/ramshared-broker/src/lease.rs`
+
+## Finding
+The function `handle_lease_request` does not exist in `crates/ramshared-broker/src/lease.rs`. The logic inside `lease.rs` handles lease state updates and uses methods such as `begin_request`, `grant_pending`, `cancel_pending`, `release`, and `disconnect` on the `LeaseBook` struct.
+
+## Evidence
+- Used `grep` to search for `handle_lease_request` in `crates/ramshared-broker` which returned 0 results.
+- Read the entire content of `crates/ramshared-broker/src/lease.rs` (250 lines), confirming no such function exists.
+
+## Conclusion
+Code changes cannot be safely applied. Hallucinating this function or rewriting `begin_request` to fit this prompt without a specific request to do so would violate the strict scope constraints and architectural integrity of the system.


### PR DESCRIPTION
## Resumo
Produced a FINDING_ONLY report to document that the requested target function `handle_lease_request` does not exist within the strictly confined scope of `crates/ramshared-broker/src/lease.rs`. Applying changes was architecturally impossible, so a finding was recorded.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| docs: add finding for non-existent lease dispatcher | Created `docs/jules/findings/RS100_L20_broker_050.md` | Target function did not exist; hallucinating code is unsafe | Followed fallback instruction for impossible safe code modifications |

## Labels
type:docs, type:finding

## Validacao
cargo test -p ramshared-broker
cargo clippy -p ramshared-broker -- -D warnings

## Rollback trigger
Code contains invalid function calls or regressions.

do not merge

---
*PR created automatically by Jules for task [15009289969575764305](https://jules.google.com/task/15009289969575764305) started by @emersonbusson*