### PR TITLE
docs(block): add FINDING_ONLY report for non-existent parse_from function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/docs/jules/findings/L20_block_051_finding.md
+++ b/docs/jules/findings/L20_block_051_finding.md
@@ -1,0 +1,17 @@
+# FINDING_ONLY: L20/block/051
+
+## Request
+Task Title: refactor long parse_from function in block protocol into sub-parsers
+Area: Code Health
+Target File: crates/ramshared-block/src/protocol.rs
+
+## Finding
+The requested function `parse_from` does not exist in `crates/ramshared-block/src/protocol.rs`.
+The file was read to its final line (182 lines total) and there is no function by that name.
+The closest function is `parse_request`, which is a small function (under 20 lines) that already cleanly handles parsing an NBD request header without requiring decomposition into sub-parsers.
+As safe code modification is impossible within the strictly confined scope (since the target function does not exist), this `FINDING_ONLY` report is produced as per the rules.
+
+## Evidence
+- `wc -l crates/ramshared-block/src/protocol.rs` outputs 182 lines.
+- `cat crates/ramshared-block/src/protocol.rs | grep -n "parse"` lists `parse_request` on line 95, its usages in tests, and no other parsing functions.
+- `grep -r "parse_from" crates/ramshared-block/src/` returns no matches.


### PR DESCRIPTION
## Resumo
Produced a FINDING_ONLY report because the requested `parse_from` function does not exist in `crates/ramshared-block/src/protocol.rs`. Safe code modification is impossible as the target logic is not present. The existing `parse_request` function is already minimal.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs(block): add FINDING_ONLY report... | Generated L20_block_051_finding.md | The requested function `parse_from` does not exist | Includes `wc -l` and `grep` evidence |

## Labels
type:docs, type:audit

## Validacao
`cargo test -p ramshared-block && cargo clippy -p ramshared-block -- -D warnings`

## Rollback trigger
Revert if the report format violates audit rules.

do not merge

---
*PR created automatically by Jules for task [15681612834702023485](https://jules.google.com/task/15681612834702023485) started by @emersonbusson*