### PR TITLE
docs(ramshared-block): add FINDING_ONLY report for inflight clones

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.md
+++ b/docs/jules/findings/FINDING_ONLY.md
@@ -1,0 +1,19 @@
+# Findings Report
+
+## Overview
+The instruction requested an optimization in `crates/ramshared-block/src/inflight.rs` to "avoid unnecessary clones in inflight request tracker" by using `RequestId` handles instead of cloning full request metadata structs.
+
+## Evidence
+After thoroughly reviewing `crates/ramshared-block/src/inflight.rs`, it was observed that the `Inflight` tracker only stores tuples of `(u64, u64)` representing offsets and lengths:
+
+```rust
+/// Set of ranges `[offset, offset+len)` currently inflight.
+#[derive(Default)]
+pub struct Inflight {
+    ranges: Vec<(u64, u64)>,
+}
+```
+
+The file is strictly 76 lines long and contains no request metadata structs, cloning operations, or `RequestId` usages. The logic simply checks for overlapping ranges and stores/removes `(u64, u64)` entries. Therefore, implementing the requested change in this file is architecturally impossible because the target logic does not exist. No safe minimal slice can be extracted.
+
+To satisfy the adversarial auditing and safety rules, this report documents the finding rather than hallucinating new logic or modifying the file in a way that violates its architectural constraints.


### PR DESCRIPTION
## Resumo
Adiciona um relatório `FINDING_ONLY` detalhando que a otimização solicitada em `crates/ramshared-block/src/inflight.rs` (evitar clones de requests usando RequestIds) não é possível porque o arquivo gerencia apenas tuplas `(u64, u64)` de ranges.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs(ramshared-block): add FINDING_ONLY report for inflight clones | Adicionou relatório em docs/jules/findings/ | A lógica descrita na instrução não existe no arquivo alvo, tornando a modificação segura impossível. | N/A |

## Labels
type:documentation, type:security, type:audit

## Validacao
`cargo test -p ramshared-block && cargo clippy -p ramshared-block -- -D warnings`

## Rollback trigger
Se o relatório for considerado incorreto e a lógica de fato existir ou for esperada em outro lugar.

do not merge

---
*PR created automatically by Jules for task [6462991999877251855](https://jules.google.com/task/6462991999877251855) started by @emersonbusson*