### PR TITLE
test(uring): verify absence of async file io logic

### DIFF
--- a/docs/jules/findings/RS100_L08_uring_062_FINDING_ONLY.md
+++ b/docs/jules/findings/RS100_L08_uring_062_FINDING_ONLY.md
@@ -1,0 +1,14 @@
+# FINDING_ONLY: untested io::Result propagation in async file read/write pipeline
+
+**Instruction Task Title**: untested io::Result propagation in async file read/write pipeline
+**Target File**: `crates/ramshared-uring/src/lib.rs`
+
+## Evidence of Non-Existent Logic
+The requested logic involving an "async file read/write pipeline" is entirely non-existent within `crates/ramshared-uring/src/lib.rs`. The file implements single-threaded, synchronous wrappers over `io-uring` explicitly meant for UBLK device operations (`ublk_get_features`, `ublk_add_dev`, `UblkFetchRing`, `UblkServer`, etc.).
+
+1. **No `async` keywords**: The codebase was thoroughly scanned. A `grep -n "async"` on the file returned 0 matches.
+2. **No Read/Write File Pipeline**: The file handles `io_uring` setup (`UringCmd80`), SQE/CQE pushes, memory mapping (`MmapRo`), and blocking IO drains (`wait_and_drain`), but it explicitly avoids any `async/await` rust primitives, and has zero regular async file IO. It interacts with raw UBLK device descriptors (`/dev/ublkbN`).
+3. **Total File Verification**: The file is 611 lines long (`wc -l`), 22,830 bytes (`wc -c`). The file was fully read iteratively (using `sed -n '1,100p'`, `101,200p`, up to `611,620p`) to prove absolute absence of the requested code block.
+
+## Conclusion
+As per memory rules, we cannot hallucinate code where none exists and safe code modification is impossible for an absent logic target. The instruction is architecturally invalid for this crate. Therefore, a FINDING_ONLY report is issued. No files are modified except the generation of this finding.


### PR DESCRIPTION
## Resumo
Generated a `FINDING_ONLY` report because the requested target logic ("async file read/write pipeline") is architecturally invalid for the `ramshared-uring` crate. This crate functions strictly as a synchronous, single-threaded wrapper for `io-uring` UBLK commands.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| test(uring): verify absence of async file io logic | Created FINDING_ONLY report | Requested target logic is completely absent | The `ramshared-uring` crate does not contain `async` functions or regular file I/O pipelines. |

## Labels
type:test, type:finding

## Validacao
`cargo test --locked`
`cargo clippy --locked -- -D warnings`

## Rollback trigger
If the FINDING_ONLY report is deemed incorrect or if the target logic actually exists elsewhere in a way that should have been addressed, revert the PR.

---
*PR created automatically by Jules for task [15127629437760745280](https://jules.google.com/task/15127629437760745280) started by @emersonbusson*