### PR TITLE
test: verify io::Result propagation during sparse vRAM write failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/crates/ramshared-block/src/sparse_vram.rs
+++ b/crates/ramshared-block/src/sparse_vram.rs
@@ -752,6 +752,33 @@ mod tests {
     }
 
     #[test]
+    fn write_fail_returns_io_error() {
+        struct FailWriteMem;
+        impl VramMemory for FailWriteMem {
+            fn len(&self) -> usize { 4096 }
+            fn zero(&mut self) -> Result<(), VramError> { Ok(()) }
+            fn read_at(&self, _off: u64, _dst: &mut [u8]) -> Result<(), VramError> { Ok(()) }
+            fn write_at(&mut self, _off: u64, _src: &[u8]) -> Result<(), VramError> {
+                Err(VramError::Provider("simulated write failure".into()))
+            }
+        }
+        struct FailProvider;
+        impl VramProvider for FailProvider {
+            type Mem<'a> = FailWriteMem;
+            fn alloc(&self, _bytes: usize) -> Result<Self::Mem<'_>, VramError> {
+                Ok(FailWriteMem)
+            }
+            fn mem_info(&self) -> Result<(u64, u64), VramError> {
+                Ok((8 << 30, 8 << 30))
+            }
+        }
+        let p = FailProvider;
+        let mut be = SparseVramBackend::new(&p, 1024 * 1024, 256 * 1024, 4096).unwrap();
+        let err = be.write_at(0, &[1u8; 4096]).unwrap_err();
+        assert!(err.0.contains("simulated write failure"));
+    }
+
+    #[test]
     fn env_helpers_have_sane_defaults() {
         // Do not clobber user env permanently — only assert defaults when unset
         if std::env::var("RAMSHARED_VRAM_CHUNK_MIB").is_err() {


### PR DESCRIPTION
## Resumo
Added a unit test `write_fail_returns_io_error` to `sparse_vram.rs` to verify that disk write failures are properly caught and propagated as a typed error (custom `IoError`) by the sparse vRAM backend. This prevents unhandled write errors from risking data corruption.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | Added test `write_fail_returns_io_error` in `sparse_vram.rs` | To ensure write failures from the provider map to `IoError` | Used mock structs to simulate backend error |

## Labels
type:test

## Validacao
`cargo test -p ramshared-block`
`cargo clippy -p ramshared-block -- -D warnings`

## Rollback trigger
Trigger rollback if the new test causes unexpected regressions or if the CI pipeline fails.

do not merge

---
*PR created automatically by Jules for task [8229114573724278833](https://jules.google.com/task/8229114573724278833) started by @emersonbusson*