### PR TITLE
docs(audit): publish FINDING_ONLY report for dxgkrnl ABI alignment

### DIFF
--- a/docs/jules/findings/contract.md
+++ b/docs/jules/findings/contract.md
@@ -1,0 +1,20 @@
+1. RULES
+   - Verify all rules and memory constraints.
+2. MAIN_DIFF
+   - Modify `crates/ramshared-dxg/src/lib.rs` to fix struct definitions for `D3dkmtHandle`, `QueryVideoMemoryInfo`, and `CloseAdapter` to correctly align and match the size/ioctl values from Microsoft WSL2 linux-msft-wsl-6.1.y `d3dkmthk.h`.
+3. FILES
+   - `crates/ramshared-dxg/src/lib.rs`
+4. INVARIANTS
+   - Ioctl bindings MUST have the correct values based on `_IOWR` macro expansion matching struct alignment (padding) for the size.
+5. COUNTERFACTUAL
+   - If not aligned correctly, the ioctl kernel boundaries for WSL2 integration would panic or write corrupt data because of struct size mismatch with `QueryVideoMemoryInfo` and `CloseAdapter`.
+6. RED_TEST
+   - Run `cargo test -p ramshared-dxg`, and we will temporarily update the test to expect the 64-byte `QueryVideoMemoryInfo` size before implementing the change, which will fail.
+7. COVERAGE
+   - The ABI layout test `official_uapi_layouts_and_ioctl_numbers_match_wsl_618` asserts size and ioctl numbers.
+8. REAL_PROOF
+   - Confirm via C programs using standard Linux `<linux/ioctl.h>` that the `_IOWR` result and struct offsets exactly match the newly defined structs in Rust.
+9. ROLLBACK
+   - The commit body will include a rollback trigger for the change.
+10. PR_BOUNDARY
+    - Open a PR strictly against `jules/inbox`, and ensure the PR description does not merge (`do not merge`).

--- a/docs/jules/findings/dxgkrnl-abi.md
+++ b/docs/jules/findings/dxgkrnl-abi.md
@@ -1,0 +1,23 @@
+# Finding
+
+The instructed task was to audit the dxgkrnl ABI struct alignment and collision against WSL2 headers.
+The C struct definition of `d3dkmthandle` in the WSL2 headers is:
+
+```c
+struct d3dkmthandle {
+	union {
+		struct {
+			__u32 instance	:  6;
+			__u32 index	: 24;
+			__u32 unique	: 2;
+		};
+		__u32 v;
+	};
+};
+```
+
+This struct relies on 32-bit bitfields and a `__u32` inside a union, resulting in exactly a 4-byte (`u32`) struct size. The C tests and kernel headers verify that `d3dkmthandle` is 4 bytes. Thus, `adapter_handle` in `AdapterInfo`, `adapter` in `QueryVideoMemoryInfo`, and `adapter_handle` in `CloseAdapter` are exactly 4-byte integers in C. The current Rust representation in `crates/ramshared-dxg/src/lib.rs` simply using `u32` is completely accurate. `QueryVideoMemoryInfo` is 56 bytes in C and 56 bytes in Rust, and the ioctl values match (`0xc038470a`).
+
+No safe code change is possible or needed because the current Rust code is structurally correct. It correctly aligns to the Windows and WSL2 ABI (d3dkmthk.h) for `D3DKMT_HANDLE`. Modifying the sizes to pad `D3DKMT_HANDLE` to 8 bytes would incorrectly bloat the structs and invalidate the ioctl numbers (e.g., from `0xc038470a` to `0xc040470a`), which breaks the dxgkrnl API.
+
+Since the premise of an ABI mismatch is a false positive and safe code changes cannot be made, this task is documented as a `FINDING_ONLY`.


### PR DESCRIPTION
## Resumo
Audit of the `dxgkrnl` ABI struct alignment in `crates/ramshared-dxg/src/lib.rs` against WSL2 headers. The audit concludes that the existing 4-byte `u32` representation of `d3dkmthandle` is structurally correct because the WSL2 C struct is exactly 4 bytes. Padding it would break the `ioctl` boundaries. Since the premise of the mismatch was a false positive and safe code changes cannot be made, this task is documented as a `FINDING_ONLY` report. (do not merge).

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| docs(audit): publish FINDING_ONLY report for dxgkrnl ABI alignment | Added audit finding report and contract. | The codebase is already correct and modifying the struct sizes would break the ioctl interface. | <details>Added `docs/jules/findings/dxgkrnl-abi.md` and `docs/jules/findings/contract.md` to document the successful audit.</details> |

## Labels
type:audit, type:security, type:documentation

## Validacao
`cargo test -p ramshared-dxg` and `cargo clippy -p ramshared-dxg -- -D warnings` (0 warnings). The C struct sizes and ioctl bounds were validated manually using GCC test programs.

## Rollback trigger
Revert this documentation if the findings are proven inaccurate due to new kernel updates.

---
*PR created automatically by Jules for task [9412041232717269454](https://jules.google.com/task/9412041232717269454) started by @emersonbusson*