### PR TITLE
docs(uring): report missing monolithic worker dispatcher

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.md
+++ b/docs/jules/findings/FINDING_ONLY.md
@@ -1,0 +1,14 @@
+# FINDING_ONLY: Break down monolithic uring worker dispatcher into modular handlers
+
+**Goal**: Decompose worker dispatch loop into focused event handlers.
+**Scope**: Strictly confined to `crates/ramshared-uring/src/lib.rs` and its related test module.
+
+## Findings
+An architectural analysis of `crates/ramshared-uring/src/lib.rs` indicates that the target logic—a "monolithic uring worker dispatcher"—does not exist within this file.
+
+- The file only implements lower-level safe wrappers for the `io-uring` crate and standard I/O structs (`UblkServer`, `UblkFetchRing`).
+- The `wait_and_drain` method blocks for CQEs and explicitly avoids running a dispatcher loop that processes application-level tasks.
+- The actual plumbing and core broker loops handling those responsibilities are located in `ramshared-wsl2d`, outside the mandated narrow scope of this task.
+- Modifying `lib.rs` to hallucinate a dispatcher abstraction that serves no actual internal consumer would violate the Groundedness and Exploration Rules as there are no tests or consuming endpoints that use it inside the current scope constraint.
+
+Since the instruction strictly confines the scope to `crates/ramshared-uring/src/lib.rs` and requests breaking down logic that is absent, a safe orthogonal slice cannot be achieved here without hallucinating code. Therefore, no source code changes are provided, strictly adhering to the "If safe code is not possible, produce FINDING_ONLY with evidence in docs/jules/findings/" directive.


### PR DESCRIPTION
## Resumo
Created a FINDING_ONLY report because the requested logic to break down a "monolithic uring worker dispatcher" does not exist in `crates/ramshared-uring/src/lib.rs`. The file only contains lower-level uring wrappers and the `UblkServer::wait_and_drain` method. The actual broker loop is located in `ramshared-wsl2d`. A safe orthogonal slice could not be achieved without hallucinating code outside the strictly confined scope.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| docs(uring): report missing monolithic worker dispatcher | Added FINDING_ONLY.md report | To report that the instructed modification targets logic that does not exist in the requested file scope | Confined scope to `docs/jules/findings/` as safe safe code modification was not possible |

## Labels
type:docs

## Validacao
cargo test -p ramshared-uring --locked
cargo clippy -p ramshared-uring --locked -- -D warnings

## Rollback trigger
If the findings report breaks documentation constraints or causes CI failure.

---
*PR created automatically by Jules for task [9476415504924716036](https://jules.google.com/task/9476415504924716036) started by @emersonbusson*