### PR TITLE
docs: create FINDING_ONLY report for L14-winbroker-066

### DIFF
--- a/docs/jules/findings/L14-winbroker-066.md
+++ b/docs/jules/findings/L14-winbroker-066.md
@@ -1,0 +1,14 @@
+FINDING_ONLY
+
+1. RULES: Read all rules, use English only.
+2. MAIN_DIFF: FINDING_ONLY; no PowerShell injection exists in the targeted file (crates/ramshared-winbroker/src/lib.rs).
+3. FILES: crates/ramshared-winbroker/src/lib.rs.
+4. INVARIANTS: Scope is strictly limited to lib.rs which only handles broker domain logic.
+5. COUNTERFACTUAL: If I added PowerShell commands, I would violate the file's architectural purpose (it has no system interaction).
+6. RED_TEST: N/A - FINDING_ONLY.
+7. COVERAGE: 100% of the targeted file was read.
+8. REAL_PROOF: The file has 457 lines, none contain powershell or std::process::Command.
+9. ROLLBACK: N/A.
+10. PR_BOUNDARY: do not merge.
+
+The file crates/ramshared-winbroker/src/lib.rs does not contain any PowerShell script execution or Command::new calls. It is a pure data structures and logic library.


### PR DESCRIPTION
## Resumo
The issue requested the remediation of a PowerShell command injection vulnerability in `crates/ramshared-winbroker/src/lib.rs`. Upon auditing the file and 100% of its lines, it was determined that this file is a pure domain logic library that does not use `std::process::Command`, `Command::new("powershell.exe")`, or any system/shell execution. Modifying it to include such commands would violate its architectural invariants. Therefore, a FINDING_ONLY report was created as per the instructions for when safe code modifications are not possible.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `<hash>` | Added FINDING_ONLY report for L14-winbroker-066 | The target file `crates/ramshared-winbroker/src/lib.rs` does not contain any PowerShell script execution or Command::new calls. | The report proves the file has no system interaction and documents the invariants and counterfactual. |

## Labels
type:security, area:winbroker

## Validacao
`cargo test -p ramshared-winbroker && cargo clippy -p ramshared-winbroker -- -D warnings`

## Rollback trigger
N/A - This is a FINDING_ONLY documentation report.

---
*PR created automatically by Jules for task [13658141611888021519](https://jules.google.com/task/13658141611888021519) started by @emersonbusson*