### PR TITLE
test(winbroker): add unit test for client disconnect and reconnect loop

### DIFF
--- a/crates/ramshared-winbroker/src/lib.rs
+++ b/crates/ramshared-winbroker/src/lib.rs
@@ -386,6 +386,21 @@ mod tests {
     }
 
     #[test]
+    fn client_disconnect_clears_live_session_allowing_reconnect() {
+        let mut core = BrokerSessionCore::new(1024, "winsvc", "01");
+        core.on_authenticated_msg(1, register("winsvc"));
+        assert!(core.status().registered);
+
+        let effects = core.on_disconnect(1);
+        assert!(effects.contains(&BrokerEffect::Audit("session_disconnected".into())));
+        assert!(!core.status().registered);
+
+        let reconnect_effects = core.on_authenticated_msg(2, register("winsvc"));
+        assert!(reconnect_effects.contains(&BrokerEffect::Reply(Msg::Registered { tenant_id: 1 })));
+        assert!(core.status().registered);
+    }
+
+    #[test]
     fn status_has_instance_and_lease_state() {
         let mut core = BrokerSessionCore::new(1024, "winsvc", "0123456789abcdef0123456789abcdef");
         core.on_authenticated_msg(1, register("winsvc"));


### PR DESCRIPTION
## Resumo
Adiciona um teste unitário (`client_disconnect_clears_live_session_allowing_reconnect`) no módulo `ramshared-winbroker/src/lib.rs` para simular desconexões abruptas de clientes, garantindo que o estado da sessão local seja resetado corretamente, permitindo reconexões imediatas.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| test(winbroker): add unit test for client disconnect and reconnect loop | Adicionou teste que valida o comportamento de reconexão do pipe | Garantir a estabilidade da recuperação após queda abrupta do client. | Testa `on_disconnect` e subsequente registro. |

## Labels
type:test

## Validacao
`cargo test --locked -p ramshared-winbroker`
`cargo clippy --locked -p ramshared-winbroker -- -D warnings`

## Rollback trigger
Se houver falha nos testes no CI ou efeitos colaterais na lógica de broker resultando em lockups de state.

---
*PR created automatically by Jules for task [12490916205669267361](https://jules.google.com/task/12490916205669267361) started by @emersonbusson*