### PR TITLE
perf(uring): optimize SQE submission ring loop with zero-copy buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -289,11 +289,12 @@ impl UblkFetchRing {
 
         for tag in 0..queue_depth {
             let addr = buffers[usize::from(tag)].as_mut_ptr() as u64;
-            let cmd = fetch_cmd80(QUEUE_ID_ZERO, tag, addr);
-            let entry = opcode::UringCmd80::new(types::Fd(fd), UBLK_U_IO_FETCH_REQ)
+            let cmd = fetch_cmd16(QUEUE_ID_ZERO, tag, addr);
+            let entry: squeue::Entry128 = opcode::UringCmd16::new(types::Fd(fd), UBLK_U_IO_FETCH_REQ)
                 .cmd(cmd)
                 .build()
-                .user_data(u64::from(tag));
+                .user_data(u64::from(tag))
+                .into();
 
             // SAFETY: `cmd` (including `addr`) is copied into the SQE during `push`.
             // The `addr` points to `buffers[tag]`, which remains valid inside this struct
@@ -327,10 +328,10 @@ impl UblkFetchRing {
     }
 }
 
-/// Packs a `struct ublksrv_io_cmd` (16 B: q_id, tag, result, addr) into the
-/// first bytes of the SQE's 80 B `UringCmd80` buffer; the remaining bytes are zeroed.
-fn io_cmd80(q_id: u16, tag: u16, result: i32, addr: u64) -> [u8; 80] {
-    let mut cmd = [0u8; 80];
+/// Packs a `struct ublksrv_io_cmd` (16 B: q_id, tag, result, addr) into a 16 B array.
+/// When built with `UringCmd16` and cast to `Entry128`, the kernel receives it zero-extended.
+fn io_cmd16(q_id: u16, tag: u16, result: i32, addr: u64) -> [u8; 16] {
+    let mut cmd = [0u8; 16];
     cmd[0..2].copy_from_slice(&q_id.to_ne_bytes());
     cmd[2..4].copy_from_slice(&tag.to_ne_bytes());
     cmd[4..8].copy_from_slice(&result.to_ne_bytes());
@@ -339,8 +340,8 @@ fn io_cmd80(q_id: u16, tag: u16, result: i32, addr: u64) -> [u8; 80] {
 }
 
 /// `ublksrv_io_cmd` structure for a `FETCH_REQ` (result initialized to zero).
-fn fetch_cmd80(q_id: u16, tag: u16, addr: u64) -> [u8; 80] {
-    io_cmd80(q_id, tag, 0, addr)
+fn fetch_cmd16(q_id: u16, tag: u16, addr: u64) -> [u8; 16] {
+    io_cmd16(q_id, tag, 0, addr)
 }
 
 /// Persistent ublk queue server: manages a persistent `Entry128` ring, performs a
@@ -451,11 +452,12 @@ impl UblkServer {
     }
 
     fn push(&mut self, cmd_op: u32, tag: u16, result: i32, addr: u64) -> io::Result<()> {
-        let cmd = io_cmd80(0, tag, result, addr);
-        let entry = opcode::UringCmd80::new(types::Fd(self.fd), cmd_op)
+        let cmd = io_cmd16(0, tag, result, addr);
+        let entry: squeue::Entry128 = opcode::UringCmd16::new(types::Fd(self.fd), cmd_op)
             .cmd(cmd)
             .build()
-            .user_data(u64::from(tag));
+            .user_data(u64::from(tag))
+            .into();
 
         // SAFETY: `cmd` (carrying `addr`) is copied into the SQE in `push`. `addr` points
         // to `self.buffers[tag]`, which remains valid for the server's lifetime; `self.fd`
@@ -497,8 +499,8 @@ mod tests {
     }
 
     #[test]
-    fn fetch_cmd80_packs_ublksrv_io_cmd_in_first_16_bytes() {
-        let cmd = fetch_cmd80(0, 7, 0xdead_beef);
+    fn fetch_cmd16_packs_ublksrv_io_cmd_in_first_16_bytes() {
+        let cmd = fetch_cmd16(0, 7, 0xdead_beef);
 
         assert_eq!(u16::from_ne_bytes([cmd[0], cmd[1]]), 0);
         assert_eq!(u16::from_ne_bytes([cmd[2], cmd[3]]), 7);
@@ -509,7 +511,6 @@ mod tests {
             ]),
             0xdead_beef
         );
-        assert!(cmd[16..].iter().all(|&b| b == 0));
     }
 
     #[test]


### PR DESCRIPTION
## Resumo
Optimized the io_uring submission hot path inside `ramshared-uring` to avoid unnecessary 80-byte copies and zeroing for 16-byte ublk fetches and commits. Changed the structure usage to build an `Entry` with `UringCmd16` and gracefully zero-extend it to `Entry128` without explicit stack allocations mapping the entire 80-byte `ublksrv_io_cmd` footprint.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `<hash>` | Switched `io_cmd80` and `fetch_cmd80` to 16-byte variants | Eliminate buffer copies on the SQE hot path | Creates `[u8; 16]` locally and constructs using `UringCmd16` before zero-extending into an `Entry128` rather than copying via `UringCmd80`. |

## Labels
type:perf, area:uring

## Validacao
`cargo test -p ramshared-uring`
`cargo clippy -p ramshared-uring -- -D warnings`

## Rollback trigger
If `UringCmd16` incorrectly zeroes out expected non-zero fields or invalidates ublk driver expectations resulting in -EINVAL.

do not merge

---
*PR created automatically by Jules for task [10891890044172667268](https://jules.google.com/task/10891890044172667268) started by @emersonbusson*