### PR TITLE
chore(probe): document FINDING_ONLY for invalid probe loop instruction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/docs/jules/findings/L01-cuda-074-FINDING_ONLY.md
+++ b/docs/jules/findings/L01-cuda-074-FINDING_ONLY.md
@@ -1,0 +1,20 @@
+# FINDING_ONLY: L01/cuda/074
+
+## Executive Summary
+
+The instruction requested the elimination of heap allocations in a "CUDA device probe loop" to query CUDA device properties within the strict scope of `crates/ramshared-cuda/src/probe.rs`.
+
+However, after a complete 115-line read of `crates/ramshared-cuda/src/probe.rs`, it was verified that the file contains **no CUDA hardware paths, device property queries, or execution loops**. It is a pure, offline math utility for calculating 4 KiB-aligned offset plans and generating deterministic memory patterns (`plan_probe_offsets` and `pattern_for_offset`).
+
+The file explicitly declares its architectural bounds on line 3: `//! Pure offset/pattern logic is unit-tested; hardware path is E2E-only.`, and on line 45: `/// Errors from pure probe planning (no CUDA).`
+
+## Evidence
+
+- `crates/ramshared-cuda/src/probe.rs` strictly operates on primitive integer arithmetic (e.g., `usize`).
+- It does not import or invoke `libcuda` Driver APIs, nor does it interact with FFI bindings.
+- There are no heap allocations (`Vec`, `Box`, `String`) used in the core functions (`plan_probe_offsets` and `pattern_for_offset`); they exclusively return stack-allocated arrays (`[usize; 3]` and `[u8; 4096]`). The only heap allocations in this module are in the test cases' standard library abstractions, not the core logic.
+- As such, the instruction describes a phantom operation that is architecturally impossible within the mandated file scope.
+
+## Resolution
+
+No code changes are applied to `probe.rs` to maintain its pure, side-effect-free offline logic design. No unsafe modifications were necessary.


### PR DESCRIPTION
## Resumo
A instruction determinou a eliminação de alocações na heap em um suposto "loop de probe do dispositivo CUDA" dentro do escopo estrito de `crates/ramshared-cuda/src/probe.rs`. Ao analisar o arquivo (115 linhas), verificou-se que não há chamadas para `libcuda`, requisições de propriedades do dispositivo ou `loops` de hardware. Trata-se de uma biblioteca de matemática pura offline para planejamento de offsets de 4 KiB. Como a mudança requisitada é arquitetonicamente impossível e violaria o design sem efeitos colaterais, a instrução foi classificada como FINDING_ONLY.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| chore(probe): document FINDING_ONLY for invalid probe loop instruction | Adicionou relatório `docs/jules/findings/L01-cuda-074-FINDING_ONLY.md` | O arquivo `probe.rs` contém lógica puramente matemática offline. Não existe contexto de FFI ou alocações de hardware para modificar. | Mantém o arquivo puro sem forçar injeções indevidas. |

## Labels
type:chore, type:docs, scope:probe

## Validacao
`cargo test --locked -p ramshared-cuda`
`cargo clippy --locked -p ramshared-cuda -- -D warnings`

## Rollback trigger
N/A (Nenhuma modificação estrutural foi feita nos fontes).

---
*PR created automatically by Jules for task [12043798565748326037](https://jules.google.com/task/12043798565748326037) started by @emersonbusson*