### PR TITLE
docs: generate finding report for non-existent fixed buffer registration

### DIFF
--- a/docs/jules/findings/audit_fixed_buffer_registration.md
+++ b/docs/jules/findings/audit_fixed_buffer_registration.md
@@ -1,0 +1,15 @@
+# FINDING_ONLY: audit fixed buffer registration unsafe memory lifetime
+
+## Objective
+Audit the fixed buffer registration memory lifetime in `crates/ramshared-uring/src/lib.rs` to ensure registered fixed buffers maintain valid memory lifetime throughout `io_uring` kernel submission.
+
+## Conclusion
+The requested logic involving `io_uring` fixed buffer registration (e.g., `register_buffers`, `IORING_REGISTER_BUFFERS`, `iovec` arrays) does not exist in `crates/ramshared-uring/src/lib.rs`.
+
+## Evidence
+- `crates/ramshared-uring/src/lib.rs` was fully read up to its last line (611 lines total).
+- The file only utilizes standard `io_uring` features and a read-only memory mapping via `mmap` (`MmapRo`).
+- It submits `UBLK_U_IO_FETCH_REQ` requests directly using pointers to heap-allocated `Vec<u8>` arrays (`_buffers: Vec<Vec<u8>>`), passing them inside `UringCmd80` (`addr`) via normal submission queue entries.
+- Searches for `register`, `fixed`, and `iovec` yielded no matches in `crates/ramshared-uring/src/lib.rs`.
+
+Following the Groundedness and Exploration Rules, no code modifications were made. Safe code cannot be hallucinated if the target feature doesn't exist.


### PR DESCRIPTION
## Resumo
Generate a FINDING_ONLY report to document that the requested fixed buffer registration logic does not exist in `crates/ramshared-uring/src/lib.rs`.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| docs: generate finding report for non-existent fixed buffer registration | Created `docs/jules/findings/audit_fixed_buffer_registration.md` | `crates/ramshared-uring/src/lib.rs` does not contain `register_buffers` logic | Non-existent logic cannot be safely fixed, so a report is issued per the fallback rules. |

## Labels
type:security, type:docs

## Validacao
`cargo test -p ramshared-uring`
`cargo clippy -p ramshared-uring -- -D warnings`

## Rollback trigger
Revert if finding documentation breaks any validation or markdown checks.

---
*PR created automatically by Jules for task [9166496753088518040](https://jules.google.com/task/9166496753088518040) started by @emersonbusson*