### PR TITLE
refactor: extract discrete state handlers in winbroker message loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/crates/ramshared-winbroker/src/lib.rs
+++ b/crates/ramshared-winbroker/src/lib.rs
@@ -123,29 +123,8 @@ impl BrokerSessionCore {
             return self.on_unregistered_msg(session_id, message);
         }
         match message {
-            Msg::LeaseRequest { bytes } => match self.lease_book.begin_request(1, bytes) {
-                LeaseDecision::Pending(_) => match self.lease_book.grant_pending(bytes) {
-                    Ok(lease) => vec![
-                        BrokerEffect::Audit("lease_granted".into()),
-                        BrokerEffect::Reply(Msg::LeaseGranted {
-                            lease: lease.id,
-                            bytes: lease.bytes,
-                        }),
-                    ],
-                    Err(reason) => vec![Self::denied(reason)],
-                },
-                LeaseDecision::Denied(reason) => vec![Self::denied(reason)],
-            },
-            Msg::LeaseRelease { lease } => match self.lease_book.release(1, lease) {
-                Ok(true) => vec![
-                    BrokerEffect::Audit("lease_released_explicit".into()),
-                    BrokerEffect::LeaseReleased(lease),
-                ],
-                Ok(false) | Err(LeaseDeny::WrongLease) => {
-                    vec![BrokerEffect::Audit("lease_release_idempotent".into())]
-                }
-                Err(reason) => vec![Self::error_and_close(reason), BrokerEffect::Close],
-            },
+            Msg::LeaseRequest { bytes } => self.handle_lease_request(bytes),
+            Msg::LeaseRelease { lease } => self.handle_lease_release(lease),
             // WinDrive PSI is a liveness heartbeat only. It is deliberately
             // excluded from local arbitration, but it must keep the
             // authoritative lease session open.
@@ -156,6 +135,35 @@ impl BrokerSessionCore {
                 }),
                 BrokerEffect::Close,
             ],
+        }
+    }
+
+    pub fn handle_lease_request(&mut self, bytes: u64) -> Vec<BrokerEffect> {
+        match self.lease_book.begin_request(1, bytes) {
+            LeaseDecision::Pending(_) => match self.lease_book.grant_pending(bytes) {
+                Ok(lease) => vec![
+                    BrokerEffect::Audit("lease_granted".into()),
+                    BrokerEffect::Reply(Msg::LeaseGranted {
+                        lease: lease.id,
+                        bytes: lease.bytes,
+                    }),
+                ],
+                Err(reason) => vec![Self::denied(reason)],
+            },
+            LeaseDecision::Denied(reason) => vec![Self::denied(reason)],
+        }
+    }
+
+    pub fn handle_lease_release(&mut self, lease: u32) -> Vec<BrokerEffect> {
+        match self.lease_book.release(1, lease) {
+            Ok(true) => vec![
+                BrokerEffect::Audit("lease_released_explicit".into()),
+                BrokerEffect::LeaseReleased(lease),
+            ],
+            Ok(false) | Err(LeaseDeny::WrongLease) => {
+                vec![BrokerEffect::Audit("lease_release_idempotent".into())]
+            }
+            Err(reason) => vec![Self::error_and_close(reason), BrokerEffect::Close],
         }
     }
 
@@ -453,5 +461,20 @@ mod tests {
             include_str!("../broker.example.toml")
         );
         assert!(BrokerConfigV1::from_toml(text.as_bytes()).is_err());
+    }
+
+    #[test]
+    fn discrete_state_handlers_behave_equivalently() {
+        let mut core = BrokerSessionCore::new(1024, "winsvc", "01");
+        core.on_authenticated_msg(1, register("winsvc"));
+
+        let granted = core.handle_lease_request(1024);
+        assert!(granted.contains(&BrokerEffect::Reply(Msg::LeaseGranted {
+            lease: 1,
+            bytes: 1024
+        })));
+
+        let released = core.handle_lease_release(1);
+        assert!(released.contains(&BrokerEffect::LeaseReleased(1)));
     }
 }


### PR DESCRIPTION
## Resumo
Refactored the monolithic Windows service message dispatcher (`on_authenticated_msg` in `crates/ramshared-winbroker/src/lib.rs`) by extracting the handling logic for `Msg::LeaseRequest` and `Msg::LeaseRelease` into discrete, safe state handler functions (`handle_lease_request` and `handle_lease_release`). This improves code health and testability without altering existing behavior. Added a corresponding RED_TEST to prove execution paths via TDD.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| refactor: extract discrete state handlers in winbroker message loop | Extracted lease request and release logic into discrete state handlers and added a test. | To break down the monolithic dispatcher block, reducing complexity and increasing testability in preparation for future discrete states. | Modifies `BrokerSessionCore::on_authenticated_msg` in `crates/ramshared-winbroker/src/lib.rs` and appends `discrete_state_handlers_behave_equivalently` test. |

## Labels
type:refactor, type:test

## Validacao
`cargo test --locked -p ramshared-winbroker --lib`
`cargo clippy --locked -p ramshared-winbroker --lib -- -D warnings`

## Rollback trigger
If the refactored handlers introduce incorrect state modifications.

---
*PR created automatically by Jules for task [9769710964593645788](https://jules.google.com/task/9769710964593645788) started by @emersonbusson*