### PR TITLE
test: add concurrency test for Vulkan command buffer pool recycling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/crates/ramshared-vulkan/src/lib.rs
+++ b/crates/ramshared-vulkan/src/lib.rs
@@ -649,4 +649,29 @@ mod tests {
             free1 >> 20
         );
     }
+
+    #[test]
+    #[ignore = "requires Vulkan loader + ICD (lavapipe is enough; run with --ignored)"]
+    fn vulkan_concurrent_cmd_pool_recycling() {
+        let threads: Vec<_> = (0..4)
+            .map(|id| {
+                std::thread::spawn(move || {
+                    let p = VulkanProvider::open(0).expect("opens Vulkan");
+                    let mut m = p.alloc(64 * 1024).expect("alloc 64 KiB");
+                    for i in 0..10 {
+                        let n = 64 * 1024;
+                        let pattern: Vec<u8> = (0..n).map(|x: usize| (x.wrapping_add(i as usize).wrapping_add(id)) as u8).collect();
+                        m.write_at(0, &pattern).expect("write");
+                        let mut back = vec![0u8; n];
+                        m.read_at(0, &mut back).expect("read");
+                        assert_eq!(back, pattern, "thread {} iteration {} round-trip", id, i);
+                        m.zero().expect("zero");
+                    }
+                })
+            })
+            .collect();
+        for t in threads {
+            t.join().expect("thread joined");
+        }
+    }
 }

--- a/crates/ramshared-vulkan/src/lib.rs
+++ b/crates/ramshared-vulkan/src/lib.rs
@@ -660,7 +660,9 @@ mod tests {
                     let mut m = p.alloc(64 * 1024).expect("alloc 64 KiB");
                     for i in 0..10 {
                         let n = 64 * 1024;
-                        let pattern: Vec<u8> = (0..n).map(|x: usize| (x.wrapping_add(i as usize).wrapping_add(id)) as u8).collect();
+                        let pattern: Vec<u8> = (0..n)
+                            .map(|x: usize| (x.wrapping_add(i as usize).wrapping_add(id)) as u8)
+                            .collect();
                         m.write_at(0, &pattern).expect("write");
                         let mut back = vec![0u8; n];
                         m.read_at(0, &mut back).expect("read");


### PR DESCRIPTION
## Resumo
Adds `vulkan_concurrent_cmd_pool_recycling` test to `crates/ramshared-vulkan/src/lib.rs` to verify that `VulkanProvider` safely isolates command pools when instantiated across multiple threads. This exercises concurrent allocation, writing, reading, and zeroing to ensure no data races or leakages occur during multi-threaded `VramProvider` usage.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| test: add concurrency test for Vulkan command buffer pool recycling | Added `vulkan_concurrent_cmd_pool_recycling` test in `ramshared-vulkan` | To verify thread isolation and command pool recycling | Spawns 4 threads, each opening an independent provider and cycling I/O |

## Labels
type:test

## Validacao
```bash
VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.json cargo test -p ramshared-vulkan -- --ignored
cargo clippy -p ramshared-vulkan -- -D warnings
```

## Rollback trigger
Revert test if it causes CI flakes or lavapipe compatibility issues.

---
*PR created automatically by Jules for task [11715635167817745259](https://jules.google.com/task/11715635167817745259) started by @emersonbusson*