### PR TITLE
test(core): add win32 loader tests for missing symbols and bad formats

### DIFF
--- a/crates/ramshared-cuda/src/loader_win.rs
+++ b/crates/ramshared-cuda/src/loader_win.rs
@@ -88,8 +88,8 @@ mod tests {
 
     #[test]
     fn test_invalid_library_handling() {
-        use std::fs;
         use std::ffi::CString;
+        use std::fs;
 
         let dummy_path = "test_invalid_format_12345.dll";
         // Create a dummy file with invalid PE data to test loader failure handling.
@@ -99,7 +99,10 @@ mod tests {
 
         // SAFETY: c_path is a valid null-terminated string pointing to the dummy file.
         let handle = unsafe { open(c_path.as_ptr()) };
-        assert!(handle.is_null(), "Loading an invalid library format should return a null pointer");
+        assert!(
+            handle.is_null(),
+            "Loading an invalid library format should return a null pointer"
+        );
 
         let err_msg = error();
         assert!(!err_msg.is_empty(), "Error message should not be empty");
@@ -119,13 +122,19 @@ mod tests {
 
         // SAFETY: valid_lib is a valid null-terminated string pointing to a known system library.
         let handle = unsafe { open(valid_lib.as_ptr()) };
-        assert!(!handle.is_null(), "kernel32.dll should load successfully on Windows/Wine");
+        assert!(
+            !handle.is_null(),
+            "kernel32.dll should load successfully on Windows/Wine"
+        );
 
         let missing_symbol = CString::new("ThisSymbolDoesNotExistInKernel32").unwrap();
 
         // SAFETY: handle is valid and missing_symbol is a valid null-terminated string.
         let sym_ptr = unsafe { sym(handle, missing_symbol.as_ptr()) };
-        assert!(sym_ptr.is_null(), "Loading a nonexistent symbol should return a null pointer");
+        assert!(
+            sym_ptr.is_null(),
+            "Loading a nonexistent symbol should return a null pointer"
+        );
 
         // SAFETY: handle was opened successfully and has not been closed yet.
         let close_result = unsafe { close(handle) };

--- a/crates/ramshared-cuda/src/loader_win.rs
+++ b/crates/ramshared-cuda/src/loader_win.rs
@@ -85,4 +85,50 @@ mod tests {
         unsafe { SetLastError(0) };
         assert_eq!(error(), "Windows error code: 0x00000000");
     }
+
+    #[test]
+    fn test_invalid_library_handling() {
+        use std::fs;
+        use std::ffi::CString;
+
+        let dummy_path = "test_invalid_format_12345.dll";
+        // Create a dummy file with invalid PE data to test loader failure handling.
+        fs::write(dummy_path, b"invalid pe data").unwrap();
+
+        let c_path = CString::new(dummy_path).unwrap();
+
+        // SAFETY: c_path is a valid null-terminated string pointing to the dummy file.
+        let handle = unsafe { open(c_path.as_ptr()) };
+        assert!(handle.is_null(), "Loading an invalid library format should return a null pointer");
+
+        let err_msg = error();
+        assert!(!err_msg.is_empty(), "Error message should not be empty");
+
+        // Clean up safely
+        if fs::metadata(dummy_path).is_ok() {
+            let _ = fs::remove_file(dummy_path);
+        }
+    }
+
+    #[test]
+    fn test_missing_symbol_handling() {
+        use std::ffi::CString;
+
+        // Use a universally present system library on Windows to ensure consistent test execution.
+        let valid_lib = CString::new("kernel32.dll").unwrap();
+
+        // SAFETY: valid_lib is a valid null-terminated string pointing to a known system library.
+        let handle = unsafe { open(valid_lib.as_ptr()) };
+        assert!(!handle.is_null(), "kernel32.dll should load successfully on Windows/Wine");
+
+        let missing_symbol = CString::new("ThisSymbolDoesNotExistInKernel32").unwrap();
+
+        // SAFETY: handle is valid and missing_symbol is a valid null-terminated string.
+        let sym_ptr = unsafe { sym(handle, missing_symbol.as_ptr()) };
+        assert!(sym_ptr.is_null(), "Loading a nonexistent symbol should return a null pointer");
+
+        // SAFETY: handle was opened successfully and has not been closed yet.
+        let close_result = unsafe { close(handle) };
+        assert_eq!(close_result, 0, "Closing the valid library should succeed");
+    }
 }


### PR DESCRIPTION
## Resumo
Added unit tests in `loader_win.rs` to cover failure paths for loading invalid dynamic libraries and attempting to resolve missing symbols.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| test(core): add win32 loader tests for missing symbols and bad formats | Added `test_invalid_library_handling` and `test_missing_symbol_handling` | To ensure the loader correctly handles invalid PE formats and absent symbols without panicking. | Uses a dummy file for bad format test and `kernel32.dll` for symbol resolution failure. |

## Labels
type:test

## Validacao
`cargo test -p ramshared-cuda --target x86_64-pc-windows-gnu --locked`
`cargo clippy -p ramshared-cuda --target x86_64-pc-windows-gnu --locked -- -D warnings`

## Rollback trigger
Rollback trigger: Revert if the tests fail sporadically on native Windows hosts due to aggressive antivirus blocking the dummy file, or if `kernel32.dll` is inaccessible.

---
*PR created automatically by Jules for task [8452022317465899900](https://jules.google.com/task/8452022317465899900) started by @emersonbusson*