### PR TITLE
fix(ramshared-vulkan): detail missing ICD driver errors on instance creation

### DIFF
--- a/crates/ramshared-vulkan/src/lib.rs
+++ b/crates/ramshared-vulkan/src/lib.rs
@@ -670,7 +670,7 @@ mod tests {
                 "--",
                 "tests::open_fails_cleanly_without_icd_internal",
                 "--exact",
-                "--ignored"
+                "--ignored",
             ])
             .env("VK_ICD_FILENAMES", "/dev/null")
             .output()
@@ -684,7 +684,8 @@ mod tests {
         assert!(
             output.status.success(),
             "internal test failed, meaning it didn't get the correct error string. stdout: {}\nstderr: {}",
-            stdout, stderr
+            stdout,
+            stderr
         );
     }
 

--- a/crates/ramshared-vulkan/src/lib.rs
+++ b/crates/ramshared-vulkan/src/lib.rs
@@ -149,8 +149,17 @@ impl VulkanProvider {
         let app = vk::ApplicationInfo::default().api_version(vk::API_VERSION_1_1);
         let ci = vk::InstanceCreateInfo::default().application_info(&app);
         // SAFETY: `ci`/`app` valid during call; `None` = default allocator.
-        let instance = unsafe { entry.create_instance(&ci, None) }
-            .map_err(|e| vk_err("create_instance", e))?;
+        let instance = unsafe { entry.create_instance(&ci, None) }.map_err(|e| {
+            let es = format!("{:?}", e);
+            if es.contains("ERROR_INCOMPATIBLE_DRIVER") {
+                VramError::Provider(format!(
+                    "vulkan create_instance: {} (missing ICD drivers or required extensions)",
+                    es
+                ))
+            } else {
+                vk_err("create_instance", e)
+            }
+        })?;
 
         // From this point on, any error must destroy the instance (goto out_err idiom).
         match Self::after_instance(&instance, ordinal) {
@@ -648,5 +657,53 @@ mod tests {
             free0 >> 20,
             free1 >> 20
         );
+    }
+
+    #[test]
+    fn open_fails_cleanly_without_icd_subprocess() {
+        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+        let output = std::process::Command::new(cargo)
+            .args([
+                "test",
+                "-p",
+                "ramshared-vulkan",
+                "--",
+                "tests::open_fails_cleanly_without_icd_internal",
+                "--exact",
+                "--ignored"
+            ])
+            .env("VK_ICD_FILENAMES", "/dev/null")
+            .output()
+            .expect("failed to execute cargo test");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        // The internal test expects the error message to be correct and panics if not.
+        // It succeeds if the error message is correctly detailed.
+        assert!(
+            output.status.success(),
+            "internal test failed, meaning it didn't get the correct error string. stdout: {}\nstderr: {}",
+            stdout, stderr
+        );
+    }
+
+    #[test]
+    #[ignore = "run via open_fails_cleanly_without_icd_subprocess"]
+    fn open_fails_cleanly_without_icd_internal() {
+        let res = VulkanProvider::open(0);
+        let err = match res {
+            Err(e) => e,
+            Ok(_) => panic!("should fail to open Vulkan without ICD"),
+        };
+        if let VramError::Provider(msg) = err {
+            assert!(
+                msg.contains("missing ICD drivers or required extensions"),
+                "expected detailed ICD error message, got: {}",
+                msg
+            );
+        } else {
+            panic!("expected VramError::Provider, got {:?}", err);
+        }
     }
 }

--- a/docs/governance/rust-slice-coverage.json
+++ b/docs/governance/rust-slice-coverage.json
@@ -218,11 +218,25 @@
           "source": "crates/ramshared-cuda/src/lib.rs",
           "package": "ramshared-cuda",
           "test_module": "tests",
-          "cargo_test": ["cargo", "test", "-p", "ramshared-cuda", "--lib"],
+          "cargo_test": [
+            "cargo",
+            "test",
+            "-p",
+            "ramshared-cuda",
+            "--lib"
+          ],
           "ignored_gpu_tests": [
             {
               "name": "gpu_roundtrip_256mib",
-              "command": ["cargo", "test", "-p", "ramshared-cuda", "--", "--ignored", "--test-threads=1"],
+              "command": [
+                "cargo",
+                "test",
+                "-p",
+                "ramshared-cuda",
+                "--",
+                "--ignored",
+                "--test-threads=1"
+              ],
               "evidence": "validation.md"
             }
           ]
@@ -245,15 +259,21 @@
         "--report-json",
         "tmp/memory-broker-wsl2d-backend-cov.json"
       ],
-      "packages": ["ramshared-wsl2d"],
-      "files": ["crates/ramshared-wsl2d/src/backend.rs"],
+      "packages": [
+        "ramshared-wsl2d"
+      ],
+      "files": [
+        "crates/ramshared-wsl2d/src/backend.rs"
+      ],
       "min": 80
     },
     {
       "id": "memory-broker-wsl2d-backend-gpu-test-relocation",
       "kind": "rust-ignored-test-relocation",
       "spec": "docs/specs/no-milestone/memory-broker/SPEC.md",
-      "files": ["crates/ramshared-wsl2d/src/backend.rs"],
+      "files": [
+        "crates/ramshared-wsl2d/src/backend.rs"
+      ],
       "base_revision": "69f7469fa999b7d079341ee6bf8ebb006d517b51",
       "base_source_sha256": "b58d99366164b7e898baa42492fead82416a6169ec06ce16fb274b06b6d99663",
       "verification": {
@@ -277,14 +297,54 @@
         "ignored_gpu_tests": [
           {
             "name": "vram_backend_serves_nbd_write_then_read",
-            "command": ["cargo", "test", "-p", "ramshared-wsl2d", "--test", "backend_gpu", "vram_backend_serves_nbd_write_then_read", "--", "--ignored", "--test-threads=1"],
-            "historical_command": ["cargo", "test", "-p", "ramshared-wsl2d", "backend::tests::vram_backend_serves_nbd_write_then_read", "--", "--ignored", "--test-threads=1"],
+            "command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "--test",
+              "backend_gpu",
+              "vram_backend_serves_nbd_write_then_read",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
+            "historical_command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "backend::tests::vram_backend_serves_nbd_write_then_read",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
             "evidence": "validation.md"
           },
           {
             "name": "vram_gauge_outros_captures_real_graphics_usage",
-            "command": ["cargo", "test", "-p", "ramshared-wsl2d", "--test", "backend_gpu", "vram_gauge_outros_captures_real_graphics_usage", "--", "--ignored", "--test-threads=1"],
-            "historical_command": ["cargo", "test", "-p", "ramshared-wsl2d", "backend::tests::vram_gauge_outros_captures_real_graphics_usage", "--", "--ignored", "--test-threads=1"],
+            "command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "--test",
+              "backend_gpu",
+              "vram_gauge_outros_captures_real_graphics_usage",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
+            "historical_command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "backend::tests::vram_gauge_outros_captures_real_graphics_usage",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
             "evidence": "validation.md"
           }
         ]
@@ -705,6 +765,30 @@
       "files": [
         "crates/ramshared-wsl2d/src/autotier.rs",
         "crates/ramshared-dxg/src/lib.rs"
+      ],
+      "min": 80
+    },
+    {
+      "id": "vulkan-provider-coverage",
+      "kind": "rust-line-coverage",
+      "spec": "docs/specs/no-milestone/vulkan-backend-missing/SPEC.md",
+      "command": [
+        "node",
+        "tools/ci/check-rust-slice-coverage.mjs",
+        "-p",
+        "ramshared-vulkan",
+        "--files",
+        "crates/ramshared-vulkan/src/lib.rs",
+        "--min",
+        "80",
+        "--report-json",
+        "tmp/vulkan-provider-cov.json"
+      ],
+      "packages": [
+        "ramshared-vulkan"
+      ],
+      "files": [
+        "crates/ramshared-vulkan/src/lib.rs"
       ],
       "min": 80
     }

--- a/docs/specs/no-milestone/vulkan-backend-missing/SPEC.md
+++ b/docs/specs/no-milestone/vulkan-backend-missing/SPEC.md
@@ -1,0 +1,3 @@
+```
+node tools/ci/check-rust-slice-coverage.mjs -p ramshared-vulkan --files crates/ramshared-vulkan/src/lib.rs --min 80 --report-json tmp/vulkan-provider-cov.json
+```


### PR DESCRIPTION
## Resumo
Provides a more detailed error message during Vulkan instance creation when `create_instance` returns `ERROR_INCOMPATIBLE_DRIVER`. This explicitly points out that missing ICD drivers or required extensions are the root cause, rather than leaving the user with a generic ash error. A new subprocess-based integration test verifies this behavior cleanly without multi-threading environment pollution.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| fix(ramshared-vulkan): detail missing ICD driver errors on instance creation | Intercepts `ERROR_INCOMPATIBLE_DRIVER` in `VulkanProvider::open` to add descriptive text. Adds isolated test. | To improve DX and help debugging missing Vulkan loader components. | Uses a subprocess test to safely simulate `VK_ICD_FILENAMES=/dev/null` missing driver scenario. |

## Labels
type:refactor

## Validacao
cargo test --locked -p ramshared-vulkan && cargo clippy --locked -p ramshared-vulkan -- -D warnings

## Rollback trigger
If error translation falsely intercepts normal errors or the subprocess test is flaky.

---
*PR created automatically by Jules for task [1306156536268608059](https://jules.google.com/task/1306156536268608059) started by @emersonbusson*