### PR TITLE
fix(agent): safely handle watchdog timer backwards drift

### DIFF
--- a/crates/ramshared-agent/src/watchdog.rs
+++ b/crates/ramshared-agent/src/watchdog.rs
@@ -29,7 +29,7 @@ impl Watchdog {
 
     /// `true` if `deadline` has passed since the last signal.
     pub fn expired(&self, now: Instant) -> bool {
-        now.duration_since(self.last) >= self.deadline
+        now.saturating_duration_since(self.last) >= self.deadline
     }
 }
 
@@ -63,5 +63,16 @@ mod tests {
         // 80s + 89s = 169s from start, but only 89s since last touch → still alive.
         assert!(!wd.expired(t1 + Duration::from_secs(89)));
         assert!(wd.expired(t1 + Duration::from_secs(90)));
+    }
+
+    #[test]
+    fn time_travel_backwards_does_not_panic() {
+        let t0 = Instant::now();
+        let mut wd = Watchdog::new(Duration::from_secs(90), t0);
+        let t1 = t0 + Duration::from_secs(10);
+        wd.touch(t1);
+
+        // If monotonic clock fluctuates slightly backward, we should safely return false, not panic
+        assert!(!wd.expired(t0));
     }
 }


### PR DESCRIPTION
## Resumo
Replaced `duration_since` with `saturating_duration_since` in the agent's `Watchdog::expired` method to prevent daemon crashes due to backward monotonic clock drift. Added a unit test to verify it evaluates safely to `false` instead of panicking.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| fix(agent): use saturating_duration_since for watchdog timer | Updated `Watchdog::expired` to use `saturating_duration_since` and added a test case. | Prevents panics from backward monotonic clock drift (`Instant` anomalies) dropping the daemon. | Safely saturates to 0 duration and correctly returns `false` when time travels backwards. |

## Labels
type:test, type:fix

## Validacao
`cargo test --manifest-path crates/ramshared-agent/Cargo.toml --lib`
`cargo clippy --manifest-path crates/ramshared-agent/Cargo.toml --lib -- -D warnings`

## Rollback trigger
If the agent watchdog stops terminating legitimately dead sessions.

---
*PR created automatically by Jules for task [12609945462686599414](https://jules.google.com/task/12609945462686599414) started by @emersonbusson*