### PR TITLE
test(agent): generate FINDING_ONLY report for non-existent lib.rs structs

### DIFF
--- a/docs/jules/findings/FINDING_ONLY_L28_agent_090.txt
+++ b/docs/jules/findings/FINDING_ONLY_L28_agent_090.txt
@@ -1,0 +1,1 @@
+FINDING_ONLY: The target file `crates/ramshared-agent/src/lib.rs` strictly acts as a module root exposing other modules. It does not contain any "public agent types", "orphan structs", or "legacy methods" to document or clean up. Modification would introduce hallucinated code or violate the strictly defined module structure.


### PR DESCRIPTION
## Resumo

The instruction requested adding doc-comments and cleaning up unused agent types strictly confined to `crates/ramshared-agent/src/lib.rs`. Analysis revealed this file acts purely as a module root exporting submodules, containing exactly 14 lines with no structs, types, or methods. Modifying it to satisfy the prompt would introduce hallucinated code or violate the project's strictly defined module structure. In adherence with IMMUTABLE CONTRACT Rule 4, safe code modification is impossible, so this PR generates the required `FINDING_ONLY` artifact as evidence.

## Commits table

| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `test(agent): generate FINDING_ONLY report for non-existent lib.rs structs` | Generated a FINDING_ONLY report for `crates/ramshared-agent/src/lib.rs` | Refused hallucination; the strictly confined file contains no types/structs to document or clean | Added `docs/jules/findings/FINDING_ONLY_L28_agent_090.txt` with explanation |

## Labels

type:test
type:security

## Validacao

1. Verified file size (`wc -l crates/ramshared-agent/src/lib.rs`) and content (`cat`) showing only `pub mod` exports and `#![forbid(unsafe_code)]`.
2. Executed `cargo test --locked` and `cargo clippy --locked -- -D warnings`. Both verified that no workspace modifications were introduced outside the strict findings boundary. Note: Existing environmental test failures in `main.rs` due to missing `/proc/pressure/memory` on the runner do not relate to this no-op finding.

## Rollback trigger

Revert if the system design authority disputes the assertion that `lib.rs` is strictly a pure module root and insists logic should have been placed directly within it.

---
*PR created automatically by Jules for task [12871830849546570308](https://jules.google.com/task/12871830849546570308) started by @emersonbusson*