### PR TITLE
fix(wsl2d): label dxgkrnl anti-bug comment in run_ublk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -4586,7 +4586,7 @@ fn run_ublk_with_runtime(
             .into());
     }
     runtime.guard_not_wsl2()?;
-    // MCL_CURRENT only: MCL_FUTURE races dxgkrnl mapping and can hang the host.
+    // dxgkrnl ANTI-BUG: MCL_CURRENT only: MCL_FUTURE races dxgkrnl mapping and can hang the host.
     runtime.lock_memory(force, false)?;
     runtime.install_shutdown_handler()?;
 


### PR DESCRIPTION
Aligned the comment reference in crates/ramshared-wsl2d/src/main.rs by explicitly adding the `dxgkrnl ANTI-BUG:` tag to the MCL_CURRENT memory locking comment in `run_ublk_with_runtime`. All tests pass.

---
*PR created automatically by Jules for task [14530392254516648356](https://jules.google.com/task/14530392254516648356) started by @emersonbusson*