### PR TITLE
🧹 Refactor: Remove explicit dead_code allow in proto module

### DIFF
--- a/crates/ramshared-winsvc/src/proto.rs
+++ b/crates/ramshared-winsvc/src/proto.rs
@@ -2,8 +2,6 @@
 //!
 //! Sizes and golden layouts must match the C header. Change **both** in one commit.
 
-#![allow(dead_code)]
-
 pub const ABI_VERSION: u32 = 1;
 pub const MAX_QD: u32 = 256;
 pub const MAX_IO: u32 = 1 << 20;
@@ -131,5 +129,16 @@ mod tests {
         assert_eq!(MAX_QD, 256);
         assert_eq!(MAX_IO, 1 << 20);
         assert_eq!(RING_MAGIC, 0x5253_5244);
+        assert_eq!(OP_READ, 0);
+        assert_eq!(OP_WRITE, 1);
+        assert_eq!(OP_FLUSH, 2);
+        assert_eq!(ST_OK, 0);
+        assert_eq!(ST_EIO, 5);
+        assert_eq!(ST_EINVAL, 22);
+        assert_eq!(IOCTL_FN_REGISTER_QUEUE, 0);
+        assert_eq!(IOCTL_FN_UNREGISTER_QUEUE, 1);
+        assert_eq!(IOCTL_FN_COMMIT_AND_FETCH, 2);
+        assert_eq!(IOCTL_FN_CREATE_DISK, 3);
+        assert_eq!(IOCTL_FN_DESTROY_DISK, 4);
     }
 }

--- a/crates/ramshared-winsvc/src/windows_driver.rs
+++ b/crates/ramshared-winsvc/src/windows_driver.rs
@@ -30,7 +30,9 @@ use windows_sys::Win32::System::Threading::{
 
 use crate::driver_link::{DriverLinkError, QueueAccess};
 use crate::proto::{
-    ABI_VERSION, Cqe, DiskParams, MAX_IO, MAX_QD, RING_MAGIC, Register, RingHdr, Sqe,
+    ABI_VERSION, Cqe, DiskParams, IOCTL_FN_COMMIT_AND_FETCH, IOCTL_FN_CREATE_DISK,
+    IOCTL_FN_DESTROY_DISK, IOCTL_FN_REGISTER_QUEUE, IOCTL_FN_UNREGISTER_QUEUE, MAX_IO, MAX_QD,
+    RING_MAGIC, Register, RingHdr, Sqe,
 };
 
 /// CTL_CODE(FILE_DEVICE_MASS_STORAGE=0x2d, 0x800|N, METHOD_BUFFERED, FILE_READ|FILE_WRITE).
@@ -43,11 +45,11 @@ const fn ioctl_code(fn_n: u32) -> u32 {
     (FILE_DEVICE_MASS_STORAGE << 16) | (ACCESS << 14) | ((0x800 + fn_n) << 2) | METHOD_BUFFERED
 }
 
-const IOCTL_REGISTER: u32 = ioctl_code(0);
-const IOCTL_UNREGISTER: u32 = ioctl_code(1);
-const IOCTL_COMMIT: u32 = ioctl_code(2);
-const IOCTL_CREATE: u32 = ioctl_code(3);
-const IOCTL_DESTROY: u32 = ioctl_code(4);
+const IOCTL_REGISTER: u32 = ioctl_code(IOCTL_FN_REGISTER_QUEUE);
+const IOCTL_UNREGISTER: u32 = ioctl_code(IOCTL_FN_UNREGISTER_QUEUE);
+const IOCTL_COMMIT: u32 = ioctl_code(IOCTL_FN_COMMIT_AND_FETCH);
+const IOCTL_CREATE: u32 = ioctl_code(IOCTL_FN_CREATE_DISK);
+const IOCTL_DESTROY: u32 = ioctl_code(IOCTL_FN_DESTROY_DISK);
 
 const GENERIC_READ: u32 = 0x8000_0000;
 const GENERIC_WRITE: u32 = 0x4000_0000;


### PR DESCRIPTION
## Resumo

* 🎯 **What:** Removed module-level `#![allow(dead_code)]` from `crates/ramshared-winsvc/src/proto.rs`.
* 💡 **Why:** Improves code health and maintainability by ensuring unused code or accidental dead code is flagged by compiler warnings. Utilized `IOCTL_FN_*` constants in `windows_driver.rs` instead of magic numbers and expanded golden header test assertions in `proto.rs`.
* ✅ **Verification:** Passed `cargo check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test -p ramshared-winsvc`. All 124 unit tests passed without warnings.
* ✨ **Result:** Cleaner protocol module without blanket `dead_code` suppression.

## Commits table

| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| refactor(winsvc): remove explicit dead_code allow in proto module | Removed `#![allow(dead_code)]` and wired constants into `windows_driver.rs` & tests | Improve code health and prevent silent dead code regressions | Wired `IOCTL_FN_*` in `windows_driver.rs` and added assertions in `proto::tests::constants_match_header_docs` |

## Labels

`code-health`, `refactor`, `winsvc`

## Validacao

- `cargo check -p ramshared-winsvc`
- `cargo clippy -p ramshared-winsvc --all-targets -- -D warnings`
- `cargo test -p ramshared-winsvc`

## Rollback trigger

If compilation fails or protocol constant mismatches are detected on Windows target builds.

---
*PR created automatically by Jules for task [11015077368568893166](https://jules.google.com/task/11015077368568893166) started by @emersonbusson*