### PR TITLE
🧹 replace unwrap with expect in supervisor test fixtures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/crates/ramshared-cli/src/supervisor.rs
+++ b/crates/ramshared-cli/src/supervisor.rs
@@ -1319,15 +1319,15 @@ mod tests {
             assert_eq!(first.parent(), Some(std::path::Path::new("/dev/shm")));
             assert_eq!(second.parent(), Some(std::path::Path::new("/dev/shm")));
         }
-        fs::remove_dir_all(first).unwrap();
-        fs::remove_dir_all(second).unwrap();
+        fs::remove_dir_all(first).expect("failed to remove first fixture directory");
+        fs::remove_dir_all(second).expect("failed to remove second fixture directory");
     }
 
     fn run_isolated_guarded_transition_fixture() {
         let root = fixture();
         let state_path = root.join("supervisor-state.json");
         let ledger_root = root.join("admission");
-        let identity = OwnerIdentity::current().unwrap();
+        let identity = OwnerIdentity::current().expect("failed to get current owner identity");
         let decision = SupervisorDecision {
             state: SupervisorState::Guarded,
             actions: vec![SupervisorAction::CloseAdmission],


### PR DESCRIPTION
## Resumo
Replaced `.unwrap()` calls with `.expect(...)` in `crates/ramshared-cli/src/supervisor.rs` test helper fixtures (`supervisor_fixture_roots_are_unique_and_avoid_shared_disk_sync` and `run_isolated_guarded_transition_fixture`).

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Replace unwrap with expect in supervisor test fixtures | Improve test readability and error context on fixture cleanup or identity retrieval failure | Replaced `fs::remove_dir_all(...).unwrap()` and `OwnerIdentity::current().unwrap()` with descriptive `.expect(...)` calls |

## Labels
- code-health
- rust
- ramshared-cli

## Validacao
- `cargo test -p ramshared-cli --bin ramshared supervisor::tests::supervisor_fixture_roots_are_unique_and_avoid_shared_disk_sync`

## Rollback trigger
Rollback if test fixture teardown or owner identity retrieval in supervisor test suite panics without message formatting compatibility.

---
*PR created automatically by Jules for task [1161519131581356139](https://jules.google.com/task/1161519131581356139) started by @emersonbusson*