### PR TITLE
⚡ perf(tier): eliminate LeaseId clones during restart restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/crates/ramshared-tier/src/n3_state.rs
+++ b/crates/ramshared-tier/src/n3_state.rs
@@ -267,6 +267,11 @@ impl RestartRecord {
         &self.checkpoints
     }
 
+    /// Consumes the record and returns its canonical lease-generation checkpoints.
+    pub fn into_checkpoints(self) -> Vec<GenerationCheckpoint> {
+        self.checkpoints
+    }
+
     fn validate(&self) -> Result<(), FailureReason> {
         if self.schema_version != N3_SCHEMA_VERSION {
             return Err(FailureReason::UnknownSchema);
@@ -1214,13 +1219,14 @@ impl LeaseMachine {
             return Err(self.fail_restart_restore(FailureReason::InvalidTransition));
         }
 
+        let host_epoch = record.host_epoch();
         let generation_history = record
-            .checkpoints()
-            .iter()
-            .map(|checkpoint| (checkpoint.lease_id.clone(), checkpoint.generation))
+            .into_checkpoints()
+            .into_iter()
+            .map(|checkpoint| (checkpoint.lease_id, checkpoint.generation))
             .collect();
         self.generation_history = generation_history;
-        self.restored_restart_epoch = Some(record.host_epoch());
+        self.restored_restart_epoch = Some(host_epoch);
         Ok(())
     }
 

--- a/crates/ramshared-tier/tests/n3_state.rs
+++ b/crates/ramshared-tier/tests/n3_state.rs
@@ -742,3 +742,28 @@ fn revoke_identity_completion_and_cleanup_fail_closed() {
     machine.restart();
     assert_eq!(machine.lease_state(), LeaseState::Absent);
 }
+
+#[test]
+fn test_restore_restart_record_into_checkpoints() {
+    let checkpoint = GenerationCheckpoint {
+        lease_id: LeaseId::from(opaque(b"lease-checkpoint-1")),
+        generation: 42,
+    };
+    let record = RestartRecord::host(10, vec![checkpoint.clone()])
+        .unwrap_or_else(|error| panic!("bounded host restart record: {error:?}"));
+
+    assert_eq!(record.checkpoints(), &[checkpoint]);
+    let checkpoints = record.clone().into_checkpoints();
+    assert_eq!(checkpoints.len(), 1);
+    assert_eq!(
+        checkpoints[0].lease_id,
+        LeaseId::from(opaque(b"lease-checkpoint-1"))
+    );
+    assert_eq!(checkpoints[0].generation, 42);
+
+    let mut machine = LeaseMachine::new();
+    machine
+        .restore_restart_record(record)
+        .unwrap_or_else(|error| panic!("restore_restart_record failed: {error:?}"));
+    assert_eq!(machine.restored_restart_epoch(), Some(10));
+}


### PR DESCRIPTION
## Resumo

This change optimizes memory allocation in `crates/ramshared-tier/src/n3_state.rs` during restart record restoration (`restore_restart_record`).

### 💡 What
Added `RestartRecord::into_checkpoints(self) -> Vec<GenerationCheckpoint>` and updated `restore_restart_record` to consume the checkpoints vector via `into_checkpoints().into_iter()`.

### 🎯 Why
Previously, `restore_restart_record` iterated over `record.checkpoints().iter()` and invoked `checkpoint.lease_id.clone()` for every checkpoint entry. Since `restore_restart_record` takes `record` by value, cloning each `LeaseId` (which wraps a `Vec<u8>` allocation) was entirely redundant. Consuming `record` via `into_checkpoints()` allows moving `LeaseId` directly into `self.generation_history`.

### 📊 Measured Improvement
Eliminated heap allocations/clones for every checkpoint in `RestartRecord` during `restore_restart_record`, converting $O(N)$ heap allocations to zero additional allocations beyond vector collection.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `perf(tier): eliminate LeaseId clones during restart restore` | Added `into_checkpoints()` to `RestartRecord` and used move semantics in `restore_restart_record` | Eliminate unnecessary `LeaseId` vector clones on host record restoration | Zero heap allocations for lease identities during restore |

## Labels
- `performance`
- `ramshared-tier`

## Validacao
- `cargo test --offline -p ramshared-tier`
- `cargo test --offline -p ramshared-tier --test n3_state`
- `cargo clippy --offline -p ramshared-tier`
- `cargo fmt --check`

## Rollback trigger
Roll back if restart record state restoration fails or exhibits non-deterministic lease generation behavior.

---
*PR created automatically by Jules for task [1128927692962813969](https://jules.google.com/task/1128927692962813969) started by @emersonbusson*