### PR TITLE
🔒 fix(winsvc): sanitize volume letter in PowerShell host residue script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,6 @@ dependencies = [
 name = "ramshared-cuda"
 version = "0.1.0"
 dependencies = [
- "libc",
  "ramshared-vram",
  "windows-sys",
 ]

--- a/crates/ramshared-winsvc/src/main.rs
+++ b/crates/ramshared-winsvc/src/main.rs
@@ -893,6 +893,7 @@ mod windows_svc {
         Ok(())
     }
 
+
     fn observe_host_residue(
         root: &std::path::Path,
         manifest: &ramshared_winsvc::package::ProductManifestV1,
@@ -901,18 +902,7 @@ mod windows_svc {
         let config = WinDriveConfig::from_reader(&std::fs::read(
             root.join(&manifest.artifact(ArtifactRole::WinsvcConfig)?.relative_path),
         )?)?;
-        let letter = config.volume_letter.to_ascii_uppercase();
-        let script = format!(
-            concat!(
-                "$ErrorActionPreference='Stop';",
-                "$d=@(Get-CimInstance Win32_DiskDrive|?{{",
-                "$_.Model -match 'RAMSHARE|VRAMDISK' -or $_.Caption -match 'RAMSHARE|VRAMDISK'}});",
-                "$p=@(Get-CimInstance Win32_PageFileUsage|?{{",
-                "$_.Name -match '^{letter}:\\\\'}});",
-                "Write-Output ($d.Count.ToString()+'|'+$p.Count.ToString())"
-            ),
-            letter = letter
-        );
+        let script = build_residue_script(config.volume_letter)?;
         let mut child = std::process::Command::new("powershell.exe")
             .args(["-NoProfile", "-NonInteractive", "-Command", &script])
             .stdout(std::process::Stdio::piped())
@@ -1106,6 +1096,45 @@ mod windows_svc {
                 CloseHandle(self.handle);
             }
         }
+    }
+}
+
+pub fn build_residue_script(letter: char) -> Result<String, Box<dyn std::error::Error>> {
+    let uppercase_letter = letter.to_ascii_uppercase();
+    if !uppercase_letter.is_ascii_uppercase() {
+        return Err("invalid volume letter for host residue query".into());
+    }
+    let escaped_letter = uppercase_letter.to_string().replace('\'', "''");
+    Ok(format!(
+        concat!(
+            "$ErrorActionPreference='Stop';",
+            "$d=@(Get-CimInstance Win32_DiskDrive|?{{",
+            "$_.Model -match 'RAMSHARE|VRAMDISK' -or $_.Caption -match 'RAMSHARE|VRAMDISK'}});",
+            "$p=@(Get-CimInstance Win32_PageFileUsage|?{{",
+            "$_.Name -match '^{letter}:\\\\'}});",
+            "Write-Output ($d.Count.ToString()+'|'+$p.Count.ToString())"
+        ),
+        letter = escaped_letter
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observe_host_residue_script_escaping() {
+        let valid_script = build_residue_script('D').unwrap();
+        assert!(valid_script.contains("$_.Name -match '^D:\\\\'"));
+
+        let lowercase_script = build_residue_script('z').unwrap();
+        assert!(lowercase_script.contains("$_.Name -match '^Z:\\\\'"));
+
+        let invalid_char = build_residue_script('1');
+        assert!(invalid_char.is_err());
+
+        let injected_char = build_residue_script('\'');
+        assert!(injected_char.is_err());
     }
 }
 

--- a/crates/ramshared-winsvc/src/main.rs
+++ b/crates/ramshared-winsvc/src/main.rs
@@ -893,7 +893,6 @@ mod windows_svc {
         Ok(())
     }
 
-
     fn observe_host_residue(
         root: &std::path::Path,
         manifest: &ramshared_winsvc::package::ProductManifestV1,
@@ -902,7 +901,7 @@ mod windows_svc {
         let config = WinDriveConfig::from_reader(&std::fs::read(
             root.join(&manifest.artifact(ArtifactRole::WinsvcConfig)?.relative_path),
         )?)?;
-        let script = build_residue_script(config.volume_letter)?;
+        let script = crate::build_residue_script(config.volume_letter)?;
         let mut child = std::process::Command::new("powershell.exe")
             .args(["-NoProfile", "-NonInteractive", "-Command", &script])
             .stdout(std::process::Stdio::piped())

--- a/crates/ramshared-winsvc/src/main.rs
+++ b/crates/ramshared-winsvc/src/main.rs
@@ -1117,26 +1117,6 @@ pub fn build_residue_script(letter: char) -> Result<String, Box<dyn std::error::
     ))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn observe_host_residue_script_escaping() {
-        let valid_script = build_residue_script('D').unwrap();
-        assert!(valid_script.contains("$_.Name -match '^D:\\\\'"));
-
-        let lowercase_script = build_residue_script('z').unwrap();
-        assert!(lowercase_script.contains("$_.Name -match '^Z:\\\\'"));
-
-        let invalid_char = build_residue_script('1');
-        assert!(invalid_char.is_err());
-
-        let injected_char = build_residue_script('\'');
-        assert!(injected_char.is_err());
-    }
-}
-
 #[cfg(windows)]
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -1197,5 +1177,26 @@ fn main() {
             };
             std::process::exit(code);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn observe_host_residue_script_escaping() {
+        let valid_script = build_residue_script('D').unwrap();
+        assert!(valid_script.contains("$_.Name -match '^D:\\\\'"));
+
+        let lowercase_script = build_residue_script('z').unwrap();
+        assert!(lowercase_script.contains("$_.Name -match '^Z:\\\\'"));
+
+        let invalid_char = build_residue_script('1');
+        assert!(invalid_char.is_err());
+
+        let injected_char = build_residue_script('\'');
+        assert!(injected_char.is_err());
     }
 }


### PR DESCRIPTION
# 🔒 Fix PowerShell Command Injection in `observe_host_residue`

## 🎯 What
Fixes a potential PowerShell command injection vulnerability in `crates/ramshared-winsvc/src/main.rs:916` where `volume_letter` from `WinDriveConfig` was interpolated directly into a PowerShell script string.

## ⚠️ Risk
If an untrusted configuration file contains non-alphabetic or single-quote characters in `volume_letter`, it could result in command injection when `observe_host_residue` spawns `powershell.exe`.

## 🛡️ Solution
- Extracted script construction into `build_residue_script(letter: char)`.
- Enforced strict validation ensuring `letter.to_ascii_uppercase().is_ascii_uppercase()`, rejecting any non-drive letter characters.
- Escaped single quotes (`'`) as `''` prior to script string interpolation.
- Added unit tests `observe_host_residue_script_escaping` covering valid letters, lowercase letters, invalid characters, and single quotes.

---
*PR created automatically by Jules for task [8331569384585353264](https://jules.google.com/task/8331569384585353264) started by @emersonbusson*