### PR TITLE
fix(ci): pin action SHA hashes in release-packaging workflow

### DIFF
--- a/.github/workflows/release-packaging.yml
+++ b/.github/workflows/release-packaging.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Build Dependencies
         run: |
@@ -56,7 +56,7 @@ jobs:
           cat SHA256SUMS.txt
 
       - name: Upload Package Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: distribution-packages
           path: artifacts/packages/


### PR DESCRIPTION
## Resumo

Pins exact SHA hashes for actions/checkout and actions/upload-artifact in release-packaging.yml workflow to resolve GitHub Actions startup failures.

## Commits

- fix(ci): pin action SHA hashes in release-packaging workflow

## Issue

Refs #156

## Responsavel

@emersonbusson

## Labels

type:maintenance, area:ci

## Validacao

[✓] Documentation governance: ./scripts/docs-check.sh (29/29 suites PASS)
[✓] GitHub Actions syntax validated against pinned actions

## Rollback trigger

Failing package build workflow or checksum generation error.