### PR TITLE
fix(ci): pin rust-toolchain action in release-packaging workflow

### DIFF
--- a/.github/workflows/release-packaging.yml
+++ b/.github/workflows/release-packaging.yml
@@ -29,7 +29,9 @@ jobs:
             rpm dpkg-dev binutils build-essential
 
       - name: Set up Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # action pinned
+        with:
+          toolchain: 1.98.0
 
       - name: Build Release Binaries
         run: cargo build --release --locked


### PR DESCRIPTION
## Resumo

Pins exact SHA hash for dtolnay/rust-toolchain in release-packaging.yml workflow to comply with repository security policy.

## Commits

- fix(ci): pin rust-toolchain action in release-packaging workflow

## Issue

Refs #156

## Responsavel

@emersonbusson

## Labels

type:maintenance, area:ci

## Validacao

[✓] Documentation governance: ./scripts/docs-check.sh (29/29 suites PASS)
[✓] GitHub Actions syntax validated against pinned actions

## Rollback trigger

Failing package build workflow.