### PR TITLE
docs: add FINDING_ONLY report for vram dispatcher scope trap

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -4,6 +4,16 @@
   "registeredAt": "2026-08-11T15:15:12Z",
   "routes": [
     {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/*.md",
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/",
+      "lifecycle": "reviewable",
+      "freshnessDays": 365,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-08-30T00:00:00Z"
+    },
+    {
       "id": "root-product-documents",
       "pattern": "README.md",
       "owner": "product-documentation",

--- a/docs/jules/findings/vram-dispatcher-flatten-guard-clauses.md
+++ b/docs/jules/findings/vram-dispatcher-flatten-guard-clauses.md
@@ -1,0 +1,11 @@
+# FINDING_ONLY: crates/ramshared-vram scope trap
+
+## Executive Summary
+The prompt requested flattening a `vRAM allocation dispatcher using early-return guard clauses` and `Replace nested provider matching with guard clauses checking allocation size and alignment upfront` in `crates/ramshared-vram/src/lib.rs`.
+
+However, `crates/ramshared-vram/src/lib.rs` strictly contains the abstract trait definitions (`VramMemory`, `VramProvider`) and the `VramError` error type. There is no implementation of a vRAM allocation dispatcher or nested provider matching within this file.
+
+## Details
+Modifying `crates/ramshared-vram/src/lib.rs` to implement a concrete allocation dispatcher would violate the abstraction design and strict file-scope constraints. The concrete provider implementations live in backend-specific crates (e.g., `ramshared-cuda` or `ramshared-vulkan`).
+
+As per the immutable contract, since the targeted logic does not exist and safe code modification within the target scope is impossible to fulfill the request, a `FINDING_ONLY` report is generated.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 258,
-    "classified": 247,
+    "total": 259,
+    "classified": 248,
     "excluded": 11,
     "unclassified": 0,
     "ambiguous": 0
@@ -568,6 +568,18 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/vram-dispatcher-flatten-guard-clauses.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/",
+      "lifecycle": "reviewable",
+      "freshnessDays": 365
     },
     {
       "path": "docs/labs/DUALBOOT-KERNEL-TRUE.md",


### PR DESCRIPTION
## Resumo
Adicionado um report `FINDING_ONLY` detalhando por que a lógica de "vRAM allocation dispatcher" não pode ser refatorada em `crates/ramshared-vram/src/lib.rs`. O arquivo alvo contém apenas definições abstratas de traits e não possui a lógica concreta de alocação ou roteamento de provedor. A modificação para introduzir um dispatcher concreto violaria a regra de escopo estrito e a abstração de interface, que é tratada pelas implementações nos crates específicos como `ramshared-cuda`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|--------|-----------|-------------|----------|
| `docs: add FINDING_ONLY report for vram dispatcher scope trap` | Criou o report de escopo em `docs/jules/findings/` e o registrou. | Para cumprir a regra contratual de documentar impossibilidades arquiteturais via `FINDING_ONLY`. | O documento foi registrado no `document-lifecycle-policy.json` e o `DOCUMENTATION-INVENTORY.json` foi atualizado. |

## Issue
- N/A

## Responsavel
- Jules

## Labels
- `type:docs`

## Validacao
```bash
cargo test -p ramshared-vram && cargo clippy -p ramshared-vram -- -D warnings
node tools/ci/generate-documentation-inventory.mjs --write && ./scripts/docs-check.sh
```

## Rollback trigger
Se a constatação de que o dispatcher não existe em `ramshared-vram` for considerada incorreta, reverta este PR para remover o relatório.

---
*PR created automatically by Jules for task [6978947546529535237](https://jules.google.com/task/6978947546529535237) started by @emersonbusson*