### PR TITLE
refactor(winsvc): flatten nested volume config validation guard block

### DIFF
--- a/crates/ramshared-winsvc/src/config.rs
+++ b/crates/ramshared-winsvc/src/config.rs
@@ -188,22 +188,6 @@ impl WinDriveConfig {
                 detail: format!("must be D..=Z, got {:?}", self.volume_letter),
             });
         }
-        if let Some(path) = &self.volume_mount_path {
-            let value = path.to_string_lossy().replace('/', "\\");
-            let prefix = r"C:\ProgramData\RamShared\mounts\";
-            if !value
-                .to_ascii_lowercase()
-                .starts_with(&prefix.to_ascii_lowercase())
-                || value[prefix.len()..].is_empty()
-                || value.contains("..")
-                || value.contains(['\'', ';', '\r', '\n'])
-            {
-                return Err(ConfigError::Invalid {
-                    field: "volume_mount_path",
-                    detail: format!("must be a child of {prefix}"),
-                });
-            }
-        }
         if self.tenant.is_empty() {
             return Err(ConfigError::Invalid {
                 field: "tenant",
@@ -216,6 +200,26 @@ impl WinDriveConfig {
                 detail: "must be in 1..=30".into(),
             });
         }
+
+        let Some(path) = &self.volume_mount_path else {
+            return Ok(());
+        };
+
+        let value = path.to_string_lossy().replace('/', "\\");
+        let prefix = r"C:\ProgramData\RamShared\mounts\";
+        if !value
+            .to_ascii_lowercase()
+            .starts_with(&prefix.to_ascii_lowercase())
+            || value[prefix.len()..].is_empty()
+            || value.contains("..")
+            || value.contains(['\'', ';', '\r', '\n'])
+        {
+            return Err(ConfigError::Invalid {
+                field: "volume_mount_path",
+                detail: format!("must be a child of {prefix}"),
+            });
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
## Resumo
Refactored `WinDriveConfig::validate` to comply with Guard Clauses architectural principle, removing the nested `if let Some(...) = ...` structure in favor of early return guards (`let Some(...) = ... else { return ... }`). This simplifies the logic tree and maintains root indentation for the happy path.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(winsvc): flatten nested volume config validation guard block | Flattened `if let Some` in `validate()`. | Enforce Guard Clause principle over nested blocks. | Early return with `let Some(path) = &self.volume_mount_path else { return Ok(()); }`. |

## Issue
CleanArch100/2026-08-30/guard_clause/winsvc/004

## Responsavel
Jules

## Labels
type:refactor, type:clean_architecture

## Validacao
`cargo test -p ramshared-winsvc`
`cargo clippy -- -D warnings`

## Rollback trigger
If the configuration loading starts failing randomly on windows services using `volume_mount_path`.

---
*PR created automatically by Jules for task [1999768122481700577](https://jules.google.com/task/1999768122481700577) started by @emersonbusson*