### PR TITLE
refactor(tier): flatten nested if-else in tier demotion cascade with guard clauses

### DIFF
--- a/crates/ramshared-tier/src/cascade.rs
+++ b/crates/ramshared-tier/src/cascade.rs
@@ -57,12 +57,14 @@ impl SafetyNet {
 /// (`mem_available >= vram_size`).
 pub fn vram_safety_net(vhdx_present: bool, mem_available: u64, vram_size: u64) -> SafetyNet {
     if vhdx_present {
-        SafetyNet::VhdxBelow
-    } else if mem_available >= vram_size {
-        SafetyNet::RamHeadroom
-    } else {
-        SafetyNet::None
+        return SafetyNet::VhdxBelow;
     }
+
+    if mem_available >= vram_size {
+        return SafetyNet::RamHeadroom;
+    }
+
+    SafetyNet::None
 }
 
 /// Errors that can occur during tier resizing.
@@ -90,10 +92,10 @@ pub fn validate_tier_resize(
     physical_limit_bytes: u64,
 ) -> Result<(), ResizeError> {
     if requested_bytes > physical_limit_bytes {
-        Err(ResizeError::ExceedsPhysicalLimit)
-    } else {
-        Ok(())
+        return Err(ResizeError::ExceedsPhysicalLimit);
     }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -164,5 +166,12 @@ mod tests {
             validate_tier_resize(2 * GIB, GIB),
             Err(ResizeError::ExceedsPhysicalLimit)
         );
+    }
+
+    #[test]
+    fn vhdx_present_returns_early_ignoring_ram() {
+        // Even with insufficient RAM, vhdx_present triggers an early return.
+        let net = vram_safety_net(true, 0, GIB);
+        assert_eq!(net, SafetyNet::VhdxBelow);
     }
 }


### PR DESCRIPTION
## Resumo
Refactored `vram_safety_net` and `validate_tier_resize` in `crates/ramshared-tier/src/cascade.rs` to replace deeply nested `if/else` logic with early-return guard clauses, adhering to the CleanArch100 Guard Clauses principle.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| refactor(tier): flatten nested if-else in tier demotion cascade with guard clauses | Used early returns for prerequisites in `cascade.rs`. | To eliminate nested if/else logic and ensure the happy path stays at root indentation without deep nesting, aligning with architectural principles. | Modified `vram_safety_net` and `validate_tier_resize`. Added a unit test `vhdx_present_returns_early_ignoring_ram` to verify behavior. |

## Issue
CleanArch100/2026-08-30/guard_clause/tier/001

## Responsavel
Jules

## Labels
type:refactor

## Validacao
Executed `cargo test --manifest-path crates/ramshared-tier/Cargo.toml` and `cargo clippy --manifest-path crates/ramshared-tier/Cargo.toml -- -D warnings` with zero regressions and zero warnings.

## Rollback trigger
Revert if there is a failure in tier cascade logic or any unit test regressions regarding tier demotion evaluations.

---
*PR created automatically by Jules for task [14657356172943398526](https://jules.google.com/task/14657356172943398526) started by @emersonbusson*