### PR TITLE
docs(tier): generate finding report for guard clause trap

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -214,6 +214,16 @@
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "validation",
+      "canonicalSource": "validation.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-08-30T00:00:00Z"
+    },
+    {
       "id": "ssdv3-inventory-and-checklists",
       "pattern": "docs/specs/**/PASSO0-*.md",
       "owner": "ssdv3",

--- a/docs/jules/findings/guard_clause_trap.md
+++ b/docs/jules/findings/guard_clause_trap.md
@@ -1,0 +1,47 @@
+# FINDING_ONLY: Guard Clause Refactoring Trap
+
+### 1. RULES
+Adhere to the CleanArchitecture-100 guard clauses principle and immutable contract. Crucially, as per the memory constraint: "If an instructed task requests modifications to non-existent logic or a fix where safe code modification is impossible, you must not hallucinate code. Instead, generate a FINDING_ONLY report with evidence of the logic's absence in the docs/jules/findings/ directory." The file `crates/ramshared-tier/src/priority.rs` already implements early-return guard clauses and contains no nested if/else priority sorting logic. Thus, this is an adversarial trap.
+
+### 2. MAIN_DIFF
+No changes will be made to the `ramshared-tier` crate. A `FINDING_ONLY` report is generated instead.
+The `docs/governance/document-lifecycle-policy.json` file is updated to register `docs/jules/findings/**/*.md`.
+
+### 3. FILES
+- `docs/jules/findings/guard_clause_trap.md` (New)
+- `docs/governance/document-lifecycle-policy.json` (Modified)
+
+### 4. INVARIANTS
+Do not hallucinate code. Maintain the exact required PR description format. Ensure all `docs/` files are properly registered and pass `docs-check.sh`.
+
+### 5. COUNTERFACTUAL
+If I were to attempt to refactor `validate_order` in `priority.rs`, I would be modifying code that already complies with the guard clause principle, either hallucinating a problem or performing a no-op change, which violates the exact objective and the instruction against hallucinating code.
+
+### 6. RED_TEST
+Since this is a `FINDING_ONLY` trap for non-existent logic, no RED_TEST can or should be implemented. We will execute `cargo test` to ensure the baseline remains GREEN.
+
+### 7. COVERAGE
+Code coverage is unaffected. Document coverage is maintained by running `node tools/ci/generate-documentation-inventory.mjs --write` and `./scripts/docs-check.sh`.
+
+### 8. REAL_PROOF
+The file `crates/ramshared-tier/src/priority.rs` contains the following `validate_order` implementation, which already utilizes guard clauses with early returns:
+
+```rust
+pub fn validate_order(p: TierPriorities) -> Result<(), OrderError> {
+    if p.zram <= p.vram {
+        return Err(OrderError::ZramNotAboveVram);
+    }
+    if p.vram <= p.vhdx {
+        return Err(OrderError::VramNotAboveVhdx);
+    }
+    Ok(())
+}
+```
+
+There is no deeply nested if/else logic or sorting algorithm within this file.
+
+### 9. ROLLBACK
+Rollback trigger: If the documentation check (`./scripts/docs-check.sh`) fails or `cargo test` reports any new failures related to the documentation inventory changes.
+
+### 10. PR_BOUNDARY
+The PR will strictly target `jules/inbox` and remain unmerged ("do not merge"). The PR body will contain `## Resumo`, `## Commits`, `## Labels`, `## Validacao`, and `## Rollback trigger` sections.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 258,
-    "classified": 247,
+    "total": 259,
+    "classified": 248,
     "excluded": 11,
     "unclassified": 0,
     "ambiguous": 0
@@ -568,6 +568,18 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/guard_clause_trap.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "validation",
+      "canonicalSource": "validation.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/DUALBOOT-KERNEL-TRUE.md",


### PR DESCRIPTION
## Resumo
This PR generates a `FINDING_ONLY` report to document an adversarial trap. The instruction requested refactoring nested priority sorting logic into guard clauses within `crates/ramshared-tier/src/priority.rs`. However, the function `validate_order` in that file already perfectly adheres to the guard clause principle, returning early and containing no nested logic. To avoid hallucinating code as per the immutable contract, a finding report has been generated. The documentation inventory registry was updated accordingly.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs(tier): generate finding report for guard clause trap | Created `docs/jules/findings/guard_clause_trap.md` | Document non-existent nested logic in priority.rs | Also updated `document-lifecycle-policy.json` and `DOCUMENTATION-INVENTORY.json` to register the new documentation path. |

## Issue
N/A

## Responsavel
@jules

## Labels
type:docs, type:test

## Validacao
`./scripts/docs-check.sh`
`cargo test -p ramshared-tier`
`cargo clippy -- -D warnings`

## Rollback trigger
If the documentation check (`./scripts/docs-check.sh`) fails or `cargo test` reports any new failures related to the documentation inventory changes.

---
*PR created automatically by Jules for task [4687745017573297921](https://jules.google.com/task/4687745017573297921) started by @emersonbusson*