### PR TITLE
refactor(tier): implement guard clauses for state machine transition prerequisites in n3_state.rs

### DIFF
--- a/crates/ramshared-tier/src/n3_state.rs
+++ b/crates/ramshared-tier/src/n3_state.rs
@@ -1911,9 +1911,18 @@ mod additional_tests {
         let lease_id = LeaseId::new(b"lease-1").unwrap();
         machine.remember_generation(lease_id.clone(), 10);
 
-        assert_eq!(machine.validate_generation(&lease_id, 10), Err(FailureReason::StaleGeneration));
-        assert_eq!(machine.validate_generation(&lease_id, 9), Err(FailureReason::StaleGeneration));
-        assert_eq!(machine.validate_generation(&lease_id, 12), Err(FailureReason::GenerationGap));
+        assert_eq!(
+            machine.validate_generation(&lease_id, 10),
+            Err(FailureReason::StaleGeneration)
+        );
+        assert_eq!(
+            machine.validate_generation(&lease_id, 9),
+            Err(FailureReason::StaleGeneration)
+        );
+        assert_eq!(
+            machine.validate_generation(&lease_id, 12),
+            Err(FailureReason::GenerationGap)
+        );
         assert_eq!(machine.validate_generation(&lease_id, 11), Ok(()));
     }
 }

--- a/crates/ramshared-tier/src/n3_state.rs
+++ b/crates/ramshared-tier/src/n3_state.rs
@@ -1830,7 +1830,7 @@ mod tests {
         );
 
         // Let's create a constrained state by observing an empty budget
-        let event_id = EventId::new(b"event-1").unwrap();
+        let event_id = EventId::new(b"event-1").unwrap_or_else(|_| panic!("failed to create event_id"));
         let adapter_id = AdapterId::new(b"adapter-1").unwrap();
 
         let observation = HostObservation::new(
@@ -1879,8 +1879,8 @@ mod tests {
     #[test]
     fn test_invalid_revoke_transition() {
         let mut machine = LeaseMachine::new();
-        let lease_id = LeaseId::new(b"lease-1").unwrap();
-        let event_id = EventId::new(b"event-1").unwrap();
+        let lease_id = LeaseId::new(b"lease-1").unwrap_or_else(|_| panic!("failed to create lease_id"));
+        let event_id = EventId::new(b"event-1").unwrap_or_else(|_| panic!("failed to create event_id"));
 
         let revoke = Revoke::host(lease_id, 1, event_id, 200);
 
@@ -1908,7 +1908,7 @@ mod additional_tests {
     #[test]
     fn test_guard_clauses_generation_validation() {
         let mut machine = LeaseMachine::new();
-        let lease_id = LeaseId::new(b"lease-1").unwrap();
+        let lease_id = LeaseId::new(b"lease-1").unwrap_or_else(|_| panic!("failed to create lease_id"));
         machine.remember_generation(lease_id.clone(), 10);
 
         assert_eq!(

--- a/crates/ramshared-tier/src/n3_state.rs
+++ b/crates/ramshared-tier/src/n3_state.rs
@@ -1750,7 +1750,9 @@ impl LeaseMachine {
             if generation != previous.saturating_add(1) {
                 return Err(FailureReason::GenerationGap);
             }
-        } else if self.generation_history.len() >= MAX_GENERATION_HISTORY {
+            return Ok(());
+        }
+        if self.generation_history.len() >= MAX_GENERATION_HISTORY {
             return Err(FailureReason::MalformedRecord);
         }
         Ok(())
@@ -1763,7 +1765,9 @@ impl LeaseMachine {
             .find(|(known_lease, _)| known_lease == &lease_id)
         {
             *previous = generation;
-        } else if self.generation_history.len() < MAX_GENERATION_HISTORY {
+            return;
+        }
+        if self.generation_history.len() < MAX_GENERATION_HISTORY {
             self.generation_history.push((lease_id, generation));
         }
     }
@@ -1779,19 +1783,18 @@ impl LeaseMachine {
             .find(|seen| seen.event_id == event_id)
         {
             if seen.fingerprint == fingerprint {
-                EventRegistration::Duplicate
-            } else {
-                EventRegistration::Conflict
+                return EventRegistration::Duplicate;
             }
-        } else if self.seen_events.len() >= MAX_PROTOCOL_EVENT_HISTORY {
-            EventRegistration::Overflow
-        } else {
-            self.seen_events.push(SeenEvent {
-                event_id,
-                fingerprint,
-            });
-            EventRegistration::New
+            return EventRegistration::Conflict;
         }
+        if self.seen_events.len() >= MAX_PROTOCOL_EVENT_HISTORY {
+            return EventRegistration::Overflow;
+        }
+        self.seen_events.push(SeenEvent {
+            event_id,
+            fingerprint,
+        });
+        EventRegistration::New
     }
 }
 
@@ -1895,5 +1898,22 @@ mod tests {
             machine.lease_state(),
             LeaseState::Failed(FailureReason::InvalidTransition)
         );
+    }
+}
+
+#[cfg(test)]
+mod additional_tests {
+    use super::*;
+
+    #[test]
+    fn test_guard_clauses_generation_validation() {
+        let mut machine = LeaseMachine::new();
+        let lease_id = LeaseId::new(b"lease-1").unwrap();
+        machine.remember_generation(lease_id.clone(), 10);
+
+        assert_eq!(machine.validate_generation(&lease_id, 10), Err(FailureReason::StaleGeneration));
+        assert_eq!(machine.validate_generation(&lease_id, 9), Err(FailureReason::StaleGeneration));
+        assert_eq!(machine.validate_generation(&lease_id, 12), Err(FailureReason::GenerationGap));
+        assert_eq!(machine.validate_generation(&lease_id, 11), Ok(()));
     }
 }


### PR DESCRIPTION
## Resumo
Refactored `validate_generation`, `remember_generation`, and `register_event` in `crates/ramshared-tier/src/n3_state.rs` to implement guard clauses, eliminating deeply nested `if/else` paths. This ensures the codebase adheres to the CleanArchitecture-100 guard clauses principle and keeps the happy path at the root level. Also, added a new unit test for guard clauses logic in `crates/ramshared-tier/src/n3_state.rs`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(tier): implement guard clauses for state machine transition prerequisites in n3_state.rs | Replaced nested `if/else` with guard clauses and early returns | To follow CleanArchitecture-100 guard clauses principle | `crates/ramshared-tier/src/n3_state.rs` |

## Issue
N/A

## Responsavel
Jules (CleanArch100/2026-08-30/guard_clause/tier/003)

## Labels
type:refactor

## Validacao
`cargo test -p ramshared-tier` and `cargo clippy -- -D warnings`

## Rollback trigger
Revert if any valid lease transitions are rejected or if state synchronization bugs appear.

---
*PR created automatically by Jules for task [10716755963858910072](https://jules.google.com/task/10716755963858910072) started by @emersonbusson*