### PR TITLE
refactor(wsl2d): enforce early guard clauses for block request validation

### DIFF
--- a/crates/ramshared-wsl2d/src/ublk_server.rs
+++ b/crates/ramshared-wsl2d/src/ublk_server.rs
@@ -79,12 +79,19 @@ pub fn serve_request<B: BlockBackend + ?Sized>(
     }
 
     // Physical bounds guard
-    if req.offset.checked_add(req.len as u64).is_none_or(|end| end > backend.size_bytes()) {
+    if req
+        .offset
+        .checked_add(req.len as u64)
+        .is_none_or(|end| end > backend.size_bytes())
+    {
         return EIO;
     }
 
     // Command guard
-    if !matches!(req.cmd, Command::Read | Command::Write | Command::Flush | Command::Trim) {
+    if !matches!(
+        req.cmd,
+        Command::Read | Command::Write | Command::Flush | Command::Trim
+    ) {
         return EINVAL;
     }
 

--- a/crates/ramshared-wsl2d/src/ublk_server.rs
+++ b/crates/ramshared-wsl2d/src/ublk_server.rs
@@ -78,12 +78,25 @@ pub fn serve_request<B: BlockBackend + ?Sized>(
         return EINVAL; // request larger than the available buffer
     }
 
+    // Physical bounds guard
+    if req.offset.checked_add(req.len as u64).is_none_or(|end| end > backend.size_bytes()) {
+        return EIO;
+    }
+
+    // Command guard
+    if !matches!(req.cmd, Command::Read | Command::Write | Command::Flush | Command::Trim) {
+        return EINVAL;
+    }
+
+    if req.cmd == Command::Trim {
+        return 0; // discard: safe no-op in the MVP
+    }
+
     let served = match req.cmd {
         Command::Read => backend.read_at(req.offset, &mut buf[..len]).map(|()| len),
         Command::Write => backend.write_at(req.offset, &buf[..len]).map(|()| len),
         Command::Flush => backend.flush().map(|()| 0),
-        Command::Trim => return 0, // discard: safe no-op in the MVP
-        Command::Disc | Command::Unknown(_) => return EINVAL,
+        _ => unreachable!(),
     };
 
     match served {
@@ -387,13 +400,12 @@ fn dispatch_request<S: QueueServer>(
     // WRITE: kernel already copied bio->tag buffer; passes it in the yielded buffer.
     if req.cmd == Command::Write {
         let tag_buf = server.buffer_mut(tag)?;
-        if len <= tag_buf.len() {
-            buf.copy_from_slice(&tag_buf[..len]);
-        } else {
+        if len > tag_buf.len() {
             buf_pool.push(buf); // returns to pool before rejecting
             server.commit_and_fetch(tag, -22)?; // EINVAL
             return Ok(false);
         }
+        buf.copy_from_slice(&tag_buf[..len]);
     }
 
     let work = ublk::IoWork {

--- a/crates/ramshared-wsl2d/tests/ublk_server.rs
+++ b/crates/ramshared-wsl2d/tests/ublk_server.rs
@@ -54,3 +54,35 @@ fn serve_request_handles_flush_and_rejects_oversized_or_oob() {
         -5
     );
 }
+
+#[test]
+fn serve_request_guards_against_out_of_bounds_upfront() {
+    let mut backend = RamBackend::new(4096);
+    let mut buf = vec![0u8; 4096];
+
+    // Exact fit
+    assert_eq!(
+        ublk_server::serve_request(&req(Command::Read, 0, 4096), &mut backend, &mut buf),
+        4096
+    );
+    assert_eq!(
+        ublk_server::serve_request(&req(Command::Write, 2048, 2048), &mut backend, &mut buf),
+        2048
+    );
+
+    // Overflow offset + len
+    assert_eq!(
+        ublk_server::serve_request(&req(Command::Read, u64::MAX, 1024), &mut backend, &mut buf),
+        -5 // EIO
+    );
+
+    // Exceeds backend size bytes
+    assert_eq!(
+        ublk_server::serve_request(&req(Command::Read, 4096, 512), &mut backend, &mut buf),
+        -5 // EIO
+    );
+    assert_eq!(
+        ublk_server::serve_request(&req(Command::Write, 2048, 4096), &mut backend, &mut buf),
+        -5 // EIO
+    );
+}


### PR DESCRIPTION
## Resumo
Refatorado o tratamento de requisições de bloco no `ramshared-wsl2d` para implementar early guards rigorosos (Guard Clauses e Sanity Checks), removendo aninhamentos profundos de `if/else`, garantindo validação antecipada de bounds físicos e opcodes antes da delegação de execução para o backend de armazenamento.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | `refactor(wsl2d): enforce early guard clauses for block request validation` | Refatoração de `serve_request` e `dispatch_request` para incluir early returns | Garante check físico de limites e tratamento de comandos antecipadamente, de forma alinhada aos princípios CleanArch100 de programação defensiva e erros semânticos (EIO / EINVAL). |

## Issue
N/A - CleanArch100 guard clauses and bounds checking architectural enforcement

## Responsavel
Jules / CleanArch100 (2026-08-30)

## Labels
type:refactor, type:security, type:test

## Validacao
`cargo test -p ramshared-wsl2d --test ublk_server serve_request_guards_against_out_of_bounds_upfront`, `cargo test -p ramshared-wsl2d` e `cargo clippy -p ramshared-wsl2d -- -D warnings` executados com 0 regressões (todas asserções e regras de formatação atendidas com sucesso).

## Rollback trigger
Reverter se as requisições normais começarem a falhar intermitentemente por erros `EIO` induzidos por falsos positivos durante a soma `offset.checked_add(len)` no limite superior do backend.

---
*PR created automatically by Jules for task [14988834128201213499](https://jules.google.com/task/14988834128201213499) started by @emersonbusson*