### PR TITLE
refactor(agent): apply guard clauses and safe duration diffs to watchdog

### DIFF
--- a/crates/ramshared-agent/src/watchdog.rs
+++ b/crates/ramshared-agent/src/watchdog.rs
@@ -24,12 +24,18 @@ impl Watchdog {
 
     /// Registers a signal from the broker (any message, including `Ack`).
     pub fn touch(&mut self, now: Instant) {
+        if now < self.last {
+            return;
+        }
         self.last = now;
     }
 
     /// `true` if `deadline` has passed since the last signal.
     pub fn expired(&self, now: Instant) -> bool {
-        now.duration_since(self.last) >= self.deadline
+        if now < self.last {
+            return false;
+        }
+        now.saturating_duration_since(self.last) >= self.deadline
     }
 }
 
@@ -52,6 +58,20 @@ mod tests {
         let wd = Watchdog::new(Duration::from_secs(90), t0);
         assert!(wd.expired(t0 + Duration::from_secs(90)));
         assert!(wd.expired(t0 + Duration::from_secs(120)));
+    }
+
+    #[test]
+    fn backward_clock_drift_does_not_panic() {
+        let t0 = Instant::now();
+        let mut wd = Watchdog::new(Duration::from_secs(90), t0);
+        let t_past = t0.checked_sub(Duration::from_secs(10)).unwrap_or(t0);
+
+        // Guard clause in expired should return false instead of panicking
+        assert!(!wd.expired(t_past));
+
+        // Guard clause in touch should ignore the past timestamp instead of panicking
+        wd.touch(t_past);
+        assert_eq!(wd.last, t0);
     }
 
     #[test]

--- a/docs/governance/rust-slice-coverage.json
+++ b/docs/governance/rust-slice-coverage.json
@@ -218,11 +218,25 @@
           "source": "crates/ramshared-cuda/src/lib.rs",
           "package": "ramshared-cuda",
           "test_module": "tests",
-          "cargo_test": ["cargo", "test", "-p", "ramshared-cuda", "--lib"],
+          "cargo_test": [
+            "cargo",
+            "test",
+            "-p",
+            "ramshared-cuda",
+            "--lib"
+          ],
           "ignored_gpu_tests": [
             {
               "name": "gpu_roundtrip_256mib",
-              "command": ["cargo", "test", "-p", "ramshared-cuda", "--", "--ignored", "--test-threads=1"],
+              "command": [
+                "cargo",
+                "test",
+                "-p",
+                "ramshared-cuda",
+                "--",
+                "--ignored",
+                "--test-threads=1"
+              ],
               "evidence": "validation.md"
             }
           ]
@@ -245,15 +259,21 @@
         "--report-json",
         "tmp/memory-broker-wsl2d-backend-cov.json"
       ],
-      "packages": ["ramshared-wsl2d"],
-      "files": ["crates/ramshared-wsl2d/src/backend.rs"],
+      "packages": [
+        "ramshared-wsl2d"
+      ],
+      "files": [
+        "crates/ramshared-wsl2d/src/backend.rs"
+      ],
       "min": 80
     },
     {
       "id": "memory-broker-wsl2d-backend-gpu-test-relocation",
       "kind": "rust-ignored-test-relocation",
       "spec": "docs/specs/no-milestone/memory-broker/SPEC.md",
-      "files": ["crates/ramshared-wsl2d/src/backend.rs"],
+      "files": [
+        "crates/ramshared-wsl2d/src/backend.rs"
+      ],
       "base_revision": "69f7469fa999b7d079341ee6bf8ebb006d517b51",
       "base_source_sha256": "b58d99366164b7e898baa42492fead82416a6169ec06ce16fb274b06b6d99663",
       "verification": {
@@ -277,14 +297,54 @@
         "ignored_gpu_tests": [
           {
             "name": "vram_backend_serves_nbd_write_then_read",
-            "command": ["cargo", "test", "-p", "ramshared-wsl2d", "--test", "backend_gpu", "vram_backend_serves_nbd_write_then_read", "--", "--ignored", "--test-threads=1"],
-            "historical_command": ["cargo", "test", "-p", "ramshared-wsl2d", "backend::tests::vram_backend_serves_nbd_write_then_read", "--", "--ignored", "--test-threads=1"],
+            "command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "--test",
+              "backend_gpu",
+              "vram_backend_serves_nbd_write_then_read",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
+            "historical_command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "backend::tests::vram_backend_serves_nbd_write_then_read",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
             "evidence": "validation.md"
           },
           {
             "name": "vram_gauge_outros_captures_real_graphics_usage",
-            "command": ["cargo", "test", "-p", "ramshared-wsl2d", "--test", "backend_gpu", "vram_gauge_outros_captures_real_graphics_usage", "--", "--ignored", "--test-threads=1"],
-            "historical_command": ["cargo", "test", "-p", "ramshared-wsl2d", "backend::tests::vram_gauge_outros_captures_real_graphics_usage", "--", "--ignored", "--test-threads=1"],
+            "command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "--test",
+              "backend_gpu",
+              "vram_gauge_outros_captures_real_graphics_usage",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
+            "historical_command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "backend::tests::vram_gauge_outros_captures_real_graphics_usage",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
             "evidence": "validation.md"
           }
         ]
@@ -324,7 +384,7 @@
         "-p",
         "ramshared-agent,ramshared-tier",
         "--files",
-        "crates/ramshared-agent/src/explain.rs,crates/ramshared-agent/src/local.rs,crates/ramshared-agent/src/win_mem.rs,crates/ramshared-tier/src/cascade.rs",
+        "crates/ramshared-agent/src/explain.rs,crates/ramshared-agent/src/local.rs,crates/ramshared-agent/src/win_mem.rs,crates/ramshared-tier/src/cascade.rs,crates/ramshared-agent/src/watchdog.rs",
         "--min",
         "80",
         "--report-json",
@@ -338,7 +398,8 @@
         "crates/ramshared-agent/src/explain.rs",
         "crates/ramshared-agent/src/local.rs",
         "crates/ramshared-agent/src/win_mem.rs",
-        "crates/ramshared-tier/src/cascade.rs"
+        "crates/ramshared-tier/src/cascade.rs",
+        "crates/ramshared-agent/src/watchdog.rs"
       ],
       "min": 80
     },

--- a/docs/specs/no-milestone/memory-broker/SPEC.md
+++ b/docs/specs/no-milestone/memory-broker/SPEC.md
@@ -510,7 +510,7 @@ node tools/ci/check-rust-slice-coverage.mjs \
 The bounded support-policy tests imported from the PR audit use:
 
 ```bash
-node tools/ci/check-rust-slice-coverage.mjs -p ramshared-agent,ramshared-tier --files crates/ramshared-agent/src/explain.rs,crates/ramshared-agent/src/local.rs,crates/ramshared-agent/src/win_mem.rs,crates/ramshared-tier/src/cascade.rs --min 80 --report-json tmp/memory-broker-support-safety-cov.json
+node tools/ci/check-rust-slice-coverage.mjs -p ramshared-agent,ramshared-tier --files crates/ramshared-agent/src/explain.rs,crates/ramshared-agent/src/local.rs,crates/ramshared-agent/src/win_mem.rs,crates/ramshared-tier/src/cascade.rs,crates/ramshared-agent/src/watchdog.rs --min 80 --report-json tmp/memory-broker-support-safety-cov.json
 ```
 
 The safe suite is necessary but not sufficient for a deployment claim. The


### PR DESCRIPTION
## Resumo
Refactored `Watchdog` in `ramshared-agent` to apply architectural guard clauses. This prevents panics caused by unexpected backward monotonic clock drift (such as during test mock suspension or OS anomalies). Instead of evaluating `duration_since` without bounds checks, it now validates limits upfront with an early return on inverted timestamps and uses `saturating_duration_since`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| (This commit) | Added early-return guard clauses and saturating time math to watchdog module. | To obey Guard Clauses architectural rule and physical limits rule, preventing arbitrary panics from monotonic clock inversion. | Replaced `duration_since` with early returns and `saturating_duration_since`. Added test `backward_clock_drift_does_not_panic`. |

## Issue
guard_clause/agent/025

## Responsavel
CleanArch100/2026-08-30/guard_clause/agent/025

## Labels
type:refactor, type:test

## Validacao
`cargo test -p ramshared-agent -- backward_clock_drift_does_not_panic` (passes)
`cargo clippy -- -D warnings` (passes)

## Rollback trigger
Revert if the agent ignores valid heartbeats, fails to timeout appropriately under actual load, or misinterprets standard temporal progression.

---
*PR created automatically by Jules for task [7940663141231982117](https://jules.google.com/task/7940663141231982117) started by @emersonbusson*