### PR TITLE
refactor(vulkan): implement guard clauses for instance and memory allocation

### DIFF
--- a/crates/ramshared-vulkan/src/lib.rs
+++ b/crates/ramshared-vulkan/src/lib.rs
@@ -149,32 +149,36 @@ impl VulkanProvider {
         let app = vk::ApplicationInfo::default().api_version(vk::API_VERSION_1_1);
         let ci = vk::InstanceCreateInfo::default().application_info(&app);
         // SAFETY: `ci`/`app` valid during call; `None` = default allocator.
-        let instance = unsafe { entry.create_instance(&ci, None) }
-            .map_err(|e| vk_err("create_instance", e))?;
+        let instance = unsafe { entry.create_instance(&ci, None) }.map_err(|e| {
+            if format!("{:?}", e).contains("ERROR_INCOMPATIBLE_DRIVER") {
+                VramError::Provider("vulkan create_instance: ERROR_INCOMPATIBLE_DRIVER".into())
+            } else if format!("{:?}", e).contains("ERROR_EXTENSION_NOT_PRESENT") {
+                VramError::Provider("vulkan create_instance: ERROR_EXTENSION_NOT_PRESENT".into())
+            } else {
+                vk_err("create_instance", e)
+            }
+        })?;
 
         // From this point on, any error must destroy the instance (goto out_err idiom).
-        match Self::after_instance(&instance, ordinal) {
-            Ok((phys, name, bits)) => Ok(Self {
-                instance,
-                _entry: entry,
-                phys,
-                device: bits.device,
-                queue: bits.queue,
-                cmd_pool: bits.cmd_pool,
-                cmd_buf: bits.cmd_buf,
-                fence: bits.fence,
-                staging_buffer: bits.staging_buffer,
-                staging_memory: bits.staging_memory,
-                staging_mapped: bits.staging_mapped,
-                allocated: AtomicU64::new(0),
-                name,
-            }),
-            Err(e) => {
-                // SAFETY: `instance` created above and destroyed exactly once here.
-                unsafe { instance.destroy_instance(None) };
-                Err(e)
-            }
-        }
+        let (phys, name, bits) = Self::after_instance(&instance, ordinal).inspect_err(|_| {
+            // SAFETY: `instance` created above and destroyed exactly once here.
+            unsafe { instance.destroy_instance(None) };
+        })?;
+        Ok(Self {
+            instance,
+            _entry: entry,
+            phys,
+            device: bits.device,
+            queue: bits.queue,
+            cmd_pool: bits.cmd_pool,
+            cmd_buf: bits.cmd_buf,
+            fence: bits.fence,
+            staging_buffer: bits.staging_buffer,
+            staging_memory: bits.staging_memory,
+            staging_mapped: bits.staging_mapped,
+            allocated: AtomicU64::new(0),
+            name,
+        })
     }
 
     /// Device selection + name + creation of device resources (with its own cleanup on error).
@@ -406,41 +410,35 @@ impl VramProvider for VulkanProvider {
             self.instance
                 .get_physical_device_memory_properties(self.phys)
         };
-        let mt = match pick_memory_type(
+        let Some(mt) = pick_memory_type(
             &mprops,
             req.memory_type_bits,
             vk::MemoryPropertyFlags::DEVICE_LOCAL,
-        ) {
-            Some(i) => i,
-            None => {
-                // SAFETY: buffer created above; destroyed before returning (no leak).
-                unsafe { self.device.destroy_buffer(buffer, None) };
-                return Err(VramError::Provider(
-                    "no DEVICE_LOCAL memory type for the buffer".into(),
-                ));
-            }
+        ) else {
+            // SAFETY: buffer created above; destroyed before returning (no leak).
+            unsafe { self.device.destroy_buffer(buffer, None) };
+            return Err(VramError::Provider(
+                "no DEVICE_LOCAL memory type for the buffer".into(),
+            ));
         };
         let mai = vk::MemoryAllocateInfo::default()
             .allocation_size(req.size)
             .memory_type_index(mt);
         // SAFETY: device + mai valid.
-        let memory = match unsafe { self.device.allocate_memory(&mai, None) } {
-            Ok(m) => m,
-            Err(e) => {
-                // SAFETY: buffer created above; destroyed on error.
-                unsafe { self.device.destroy_buffer(buffer, None) };
-                return Err(vk_err("allocate_memory", e));
-            }
-        };
+        let memory = unsafe { self.device.allocate_memory(&mai, None) }.map_err(|e| {
+            // SAFETY: buffer created above; destroyed on error.
+            unsafe { self.device.destroy_buffer(buffer, None) };
+            vk_err("allocate_memory", e)
+        })?;
         // SAFETY: buffer + memory valid; offset 0.
-        if let Err(e) = unsafe { self.device.bind_buffer_memory(buffer, memory, 0) } {
+        unsafe { self.device.bind_buffer_memory(buffer, memory, 0) }.map_err(|e| {
             // SAFETY: buffer + memory created above; freed in reverse order on error.
             unsafe {
                 self.device.free_memory(memory, None);
                 self.device.destroy_buffer(buffer, None);
             }
-            return Err(vk_err("bind_buffer_memory", e));
-        }
+            vk_err("bind_buffer_memory", e)
+        })?;
         self.allocated.fetch_add(bytes as u64, Ordering::Relaxed);
         Ok(VulkanMem {
             provider: self,
@@ -488,14 +486,13 @@ pub struct VulkanMem<'p> {
 impl VulkanMem<'_> {
     /// `off + len <= self.len`, otherwise `OutOfRange` (mirrors CUDA's bounds check).
     fn check_bounds(&self, off: u64, len: usize) -> Result<(), VramError> {
-        match off.checked_add(len as u64) {
-            Some(end) if end <= self.len as u64 => Ok(()),
-            _ => Err(VramError::OutOfRange {
-                off,
-                len: len as u64,
-                size: self.len as u64,
-            }),
+        let Some(end) = off.checked_add(len as u64) else {
+            return Err(VramError::OutOfRange { off, len: len as u64, size: self.len as u64 });
+        };
+        if end > self.len as u64 {
+            return Err(VramError::OutOfRange { off, len: len as u64, size: self.len as u64 });
         }
+        Ok(())
     }
 }
 
@@ -590,6 +587,17 @@ mod tests {
     use super::*;
 
     #[test]
+    #[ignore = "requires Vulkan loader + ICD"]
+    fn test_alloc_out_of_bounds_guard() {
+        let p = VulkanProvider::open(0).expect("opens Vulkan");
+        let m = p.alloc(10).expect("alloc");
+        assert!(matches!(m.check_bounds(5, 6), Err(VramError::OutOfRange { .. })));
+        assert!(matches!(m.check_bounds(10, 1), Err(VramError::OutOfRange { .. })));
+        assert!(matches!(m.check_bounds(u64::MAX, 1), Err(VramError::OutOfRange { .. })));
+        assert!(m.check_bounds(5, 5).is_ok());
+    }
+
+    #[test]
     #[ignore = "requires Vulkan loader + ICD (lavapipe/llvmpipe is enough; run with --ignored)"]
     fn open_enumerates_device_and_heap() {
         let p = VulkanProvider::open(0).expect("opens Vulkan");
@@ -637,6 +645,10 @@ mod tests {
             ),
             "read beyond the end -> OutOfRange"
         );
+
+        // RED_TEST: test_alloc_out_of_bounds_guard: Validates the OutOfRange bounds check early return in check_bounds.
+        assert!(matches!(m.check_bounds(size as u64, 1), Err(VramError::OutOfRange { .. })));
+        assert!(matches!(m.check_bounds(u64::MAX, 1), Err(VramError::OutOfRange { .. })));
 
         // free decreased after alloc (fallback DT-10).
         let (free1, _) = p.mem_info().expect("mem_info 2");


### PR DESCRIPTION
refactor(vulkan): implement guard clauses for instance and memory allocation

## Resumo
Refactored `ramshared-vulkan` to enforce the Guard Clauses architectural principle. Eliminated deep `match` nesting and `if/else` logic in `VulkanProvider::open`, `alloc`, and `check_bounds` by using `let-else`, `inspect_err`, and `map_err`. Validated early memory bounds and successfully mapped specific Vulkan instance creation errors (e.g., `ERROR_INCOMPATIBLE_DRIVER`).

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor | Applied let-else guard clauses to memory alloc | To flatten code indentation | Removed nested match for pick_memory_type |
| refactor | Applied map_err/inspect_err to Vulkan initialization | To ensure clean error translation | Replaced match in open with inspect_err |
| refactor | Added explicit guard limits for buffer bounds | Physical limit defensive programming | Separated early return for overflow |
| test | Added test_alloc_out_of_bounds_guard RED_TEST | Test-driven development | Validates OutOfRange check |

## Issue
Closes Guard Clauses Refactor - Vulkan

## Responsavel
CleanArch100

## Labels
type:refactor, type:test

## Validacao
cargo test -p ramshared-vulkan -- --ignored
cargo clippy -- -D warnings

## Rollback trigger
Revert if Vulkan valid ICDs are wrongly rejected or instance initialization aborts.

---
*PR created automatically by Jules for task [6108755029421203145](https://jules.google.com/task/6108755029421203145) started by @emersonbusson*