### PR TITLE
feat(tier): sanity check tier purge age against system uptime

### DIFF
--- a/crates/ramshared-tier/src/priority.rs
+++ b/crates/ramshared-tier/src/priority.rs
@@ -72,6 +72,36 @@ pub fn validate_order(p: TierPriorities) -> Result<(), OrderError> {
     Ok(())
 }
 
+/// Errors related to purging aged memory regions.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PurgeAgeError {
+    /// Attempted to purge data older than system uptime, which is physically impossible.
+    AgeExceedsUptime,
+}
+
+impl fmt::Display for PurgeAgeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PurgeAgeError::AgeExceedsUptime => {
+                f.write_str("invalid purge age: cannot exceed system uptime")
+            }
+        }
+    }
+}
+
+impl core::error::Error for PurgeAgeError {}
+
+/// Validates that a requested purge age is physically possible given the system uptime.
+///
+/// Enforces physical bounds: one cannot purge data that claims to be older than the system
+/// has been alive.
+pub fn validate_purge_age(purge_age_seconds: u64, uptime_seconds: u64) -> Result<(), PurgeAgeError> {
+    if purge_age_seconds > uptime_seconds {
+        return Err(PurgeAgeError::AgeExceedsUptime);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -113,5 +143,16 @@ mod tests {
             vhdx: -2,
         };
         assert_eq!(validate_order(p), Err(OrderError::ZramNotAboveVram));
+    }
+
+    #[test]
+    fn rejects_purge_age_exceeding_uptime() {
+        assert_eq!(validate_purge_age(100, 50), Err(PurgeAgeError::AgeExceedsUptime));
+    }
+
+    #[test]
+    fn accepts_valid_purge_age() {
+        assert!(validate_purge_age(50, 100).is_ok());
+        assert!(validate_purge_age(100, 100).is_ok());
     }
 }


### PR DESCRIPTION
## Resumo
Applies the "Physical Limits Sanity Checks" architectural principle to the tier configuration logic. It prevents the system from trusting numerical values blindly by validating that any requested memory purge retention threshold (purge age) does not exceed the actual system uptime.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(tier): sanity check tier purge age against system uptime | Added `validate_purge_age` and `PurgeAgeError` | To prevent the system from attempting to purge data older than system boot time | Pure domain logic with early-return guard clauses and tests |

## Issue
N/A - Context: CleanArchitecture-100/2026-08-30/sanity_check/tier/036

## Responsavel
Jules

## Labels
type:refactor, type:security, type:test

## Validacao
`cargo test -p ramshared-tier` and `cargo clippy -p ramshared-tier -- -D warnings`

## Rollback trigger
If test regressions occur in `ramshared-tier` cascade validations or purge age rejection fails unexpectedly under valid system bounds.

---
*PR created automatically by Jules for task [6311094572899529106](https://jules.google.com/task/6311094572899529106) started by @emersonbusson*