### PR TITLE
refactor: flatten sparse vRAM page lookup using guard clauses

### DIFF
--- a/crates/ramshared-block/src/sparse_vram.rs
+++ b/crates/ramshared-block/src/sparse_vram.rs
@@ -238,7 +238,10 @@ impl<'p, P: VramProvider + 'p> SparseVramBackend<'p, P> {
     }
 
     fn ensure_live(&mut self, idx: usize) -> Result<(), IoError> {
-        if self.chunks[idx].mem.is_some() {
+        let Some(chunk) = self.chunks.get(idx) else {
+            return Err(IoError(format!("sparse page table oob idx={idx} len={}", self.chunks.len())));
+        };
+        if chunk.mem.is_some() {
             return Ok(());
         }
         // Commit cap: do not fill past safe physical budget (capacity may be 6G on 6G GPU).
@@ -282,17 +285,19 @@ impl<'p, P: VramProvider + 'p> SparseVramBackend<'p, P> {
         }
         let len = self.chunk_bytes as usize;
         // Last chunk may be partial capacity — still alloc full chunk_bytes (simpler MVP).
-        match self.provider.alloc(len) {
-            Ok(mut m) => {
-                m.zero().map_err(|e| IoError(e.to_string()))?;
-                self.chunks[idx].mem = Some(m);
-                Ok(())
-            }
+        let mut m = match self.provider.alloc(len) {
+            Ok(m) => m,
             Err(e) => {
                 self.alloc_fails = self.alloc_fails.saturating_add(1);
-                Err(IoError(format!("sparse alloc chunk {idx}: {e}")))
+                return Err(IoError(format!("sparse alloc chunk {idx}: {e}")));
             }
-        }
+        };
+        m.zero().map_err(|e| IoError(e.to_string()))?;
+        let Some(chunk) = self.chunks.get_mut(idx) else {
+            return Err(IoError(format!("sparse page table oob idx={idx} len={}", self.chunks.len())));
+        };
+        chunk.mem = Some(m);
+        Ok(())
     }
 
     fn chunk_index(&self, off: u64) -> Result<usize, IoError> {
@@ -338,11 +343,14 @@ impl<'p, P: VramProvider + 'p> BlockBackend for SparseVramBackend<'p, P> {
             let rel = (abs - chunk_base) as usize;
             let room = (self.chunk_bytes as usize).saturating_sub(rel);
             let n = (buf.len() - done).min(room);
-            match &self.chunks[idx].mem {
-                None => buf[done..done + n].fill(0),
-                Some(m) => m
-                    .read_at(rel as u64, &mut buf[done..done + n])
-                    .map_err(|e: VramError| IoError(e.to_string()))?,
+            let Some(chunk) = self.chunks.get(idx) else {
+                return Err(IoError(format!("sparse page table oob idx={idx} len={}", self.chunks.len())));
+            };
+            if let Some(m) = &chunk.mem {
+                m.read_at(rel as u64, &mut buf[done..done + n])
+                    .map_err(|e: VramError| IoError(e.to_string()))?;
+            } else {
+                buf[done..done + n].fill(0);
             }
             done += n;
         }
@@ -374,16 +382,15 @@ impl<'p, P: VramProvider + 'p> BlockBackend for SparseVramBackend<'p, P> {
             let rel = (abs - chunk_base) as usize;
             let room = (self.chunk_bytes as usize).saturating_sub(rel);
             let n = (data.len() - done).min(room);
-            {
-                let m = self.chunks[idx]
-                    .mem
-                    .as_mut()
-                    .ok_or_else(|| IoError("sparse: mem missing after ensure".into()))?;
-                m.write_at(rel as u64, &data[done..done + n])
-                    .map_err(|e: VramError| IoError(e.to_string()))?;
-            }
-            self.chunks[idx].written = true;
-            self.chunks[idx].last_write = Some(now);
+            let Some(chunk) = self.chunks.get_mut(idx) else {
+                return Err(IoError(format!("sparse page table oob idx={idx} len={}", self.chunks.len())));
+            };
+            let m = chunk.mem.as_mut().ok_or_else(|| IoError("sparse: mem missing after ensure".into()))?;
+            m.write_at(rel as u64, &data[done..done + n])
+                .map_err(|e: VramError| IoError(e.to_string()))?;
+
+            chunk.written = true;
+            chunk.last_write = Some(now);
             done += n;
         }
         Ok(())
@@ -518,6 +525,20 @@ mod tests {
         fn mem_info(&self) -> Result<(u64, u64), VramError> {
             Ok((8 << 30, 8 << 30))
         }
+    }
+
+    #[test]
+    fn page_table_bounds_guard_enforces_limit() {
+        let p = FakeProvider::new();
+        let mut be = SparseVramBackend::new(&p, 1024 * 1024, 256 * 1024, 4096).unwrap();
+        // Artificially truncate chunks array to simulate a broken page table
+        be.chunks.pop();
+        let off = 3 * 256 * 1024;
+        let err_read = be.read_at(off, &mut [0u8; 4096]).unwrap_err();
+        assert!(err_read.0.contains("sparse page table oob idx="));
+
+        let err_write = be.write_at(off, &[0u8; 4096]).unwrap_err();
+        assert!(err_write.0.contains("sparse page table oob idx="));
     }
 
     #[test]


### PR DESCRIPTION
## Resumo
Refactored `ensure_live`, `read_at`, and `write_at` in `sparse_vram.rs` to replace implicit indexing and nested `match` branches with early-return guard clauses, significantly improving defensive programming guarantees by checking page table bounds upfront.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor: flatten sparse vRAM page lookup using guard clauses | Flattened `ensure_live`, `read_at`, and `write_at` using `.get()` and `.get_mut()` with early returns. Added a defensive unit test. | To satisfy the 'Guard Clauses over nested if/else' and 'Defensive Programming' architectural principles by eliminating match pyramids and preventing implicit indexing panics. | Uses safe bounds checking and propagates explicit IoError variants for out-of-bounds access. |

## Issue
CleanArch100/2026-08-30/guard_clause/block/032

## Responsavel
Jules

## Labels
type:refactor

## Validacao
`cargo test -p ramshared-block` and `cargo clippy -- -D warnings`

## Rollback trigger
If any test fails or if there is a functional degradation in block storage behavior.

---
*PR created automatically by Jules for task [4013804713033420871](https://jules.google.com/task/4013804713033420871) started by @emersonbusson*