### PR TITLE
feat(sparse_vram): validate block indices against physical capacity map

### DIFF
--- a/crates/ramshared-block/src/sparse_vram.rs
+++ b/crates/ramshared-block/src/sparse_vram.rs
@@ -238,6 +238,12 @@ impl<'p, P: VramProvider + 'p> SparseVramBackend<'p, P> {
     }
 
     fn ensure_live(&mut self, idx: usize) -> Result<(), IoError> {
+        if idx >= self.chunks.len() {
+            return Err(IoError(format!(
+                "sparse chunk idx={idx} exceeds physical map len={}",
+                self.chunks.len()
+            )));
+        }
         if self.chunks[idx].mem.is_some() {
             return Ok(());
         }
@@ -660,6 +666,14 @@ mod tests {
         assert!(SparseVramBackend::new(&p, 0, 256 * 1024, 4096).is_err());
         assert!(SparseVramBackend::new(&p, 1024 * 1024, 0, 4096).is_err());
         assert!(SparseVramBackend::new(&p, 1024 * 1024, 1000, 4096).is_err());
+    }
+
+    #[test]
+    fn ensure_live_out_of_bounds_returns_io_error() {
+        let p = FakeProvider::new();
+        let mut be = SparseVramBackend::new(&p, 1024 * 1024, 256 * 1024, 4096).unwrap();
+        let err = be.ensure_live(9999).expect_err("should return IoError");
+        assert!(err.0.contains("exceeds physical map len"));
     }
 
     #[test]


### PR DESCRIPTION
## Resumo\nAdded physical limits guard clause in `crates/ramshared-block/src/sparse_vram.rs` to validate sparse block indices against the physical backing map before accessing slices. This prevents panics on invalid indices by proactively bubbling up explicit `IoError` limits instead.\n\n## Commits table\n| Commit | O que fez | Por que fez | Detalhes |\n|---|---|---|---|\n| feat(sparse_vram): validate block indices against physical capacity map | Added guard clause to `ensure_live` | To enforce Physical Limits Sanity Checks and avoid out of bound slice panics | `if idx >= self.chunks.len() { return Err(IoError(...)); }` |\n\n## Labels\ntype:security\n\n## Validacao\n```\ncargo test --package ramshared-block\ncargo clippy -- -D warnings\n```\n\n## Rollback trigger\nAny degradation in `cargo test` runs, unhandled `IoError` edge cases, or false positive bound checks.

---
*PR created automatically by Jules for task [12250009271567475418](https://jules.google.com/task/12250009271567475418) started by @emersonbusson*