### PR TITLE
feat(cuda): validate 256-byte pitch alignment on VRAM operations

### DIFF
--- a/crates/ramshared-cuda/src/driver.rs
+++ b/crates/ramshared-cuda/src/driver.rs
@@ -29,6 +29,7 @@ pub enum CudaError {
     },
     /// VRAM memory region access out of bounds (offset + len > size).
     OutOfRange { off: usize, len: usize, size: usize },
+    InvalidAlignment { off: usize, len: usize, align: usize },
 }
 
 impl fmt::Display for CudaError {
@@ -38,6 +39,9 @@ impl fmt::Display for CudaError {
             CudaError::Symbol(s) => write!(f, "required CUDA symbol missing: {s}"),
             CudaError::Driver { op, code, msg } => {
                 write!(f, "{op} failed (CUresult={code}): {msg}")
+            }
+            CudaError::InvalidAlignment { off, len, align } => {
+                write!(f, "vram invalid alignment: off={off} len={len} requires {align}-byte pitch")
             }
             CudaError::OutOfRange { off, len, size } => {
                 write!(f, "out of bounds access: off={off} len={len} > size={size}")
@@ -285,6 +289,13 @@ impl DeviceMem<'_, '_> {
     }
 
     fn bounds(&self, off: usize, len: usize) -> Result<(), CudaError> {
+        if !off.is_multiple_of(256) || !len.is_multiple_of(256) {
+            return Err(CudaError::InvalidAlignment {
+                off,
+                len,
+                align: 256,
+            });
+        }
         match off.checked_add(len) {
             Some(end) if end <= self.len => Ok(()),
             _ => Err(CudaError::OutOfRange {


### PR DESCRIPTION
## Resumo
Adicionado validação rigorosa de alinhamento pitch (256-bytes) nas operações de leitura e escrita de memória na interface Driver da API CUDA. Em caso de quebra dessa regra, a chamada aborta imediatamente (guard clause) para evitar falhas físicas no Hardware.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(cuda): validate 256-byte pitch alignment on VRAM operations | Implementou checagem física de alinhamento pitch de memória na VRAM (256 bytes) em driver.rs antes da chamada bounds. | Proteger o ambiente de execução garantindo as constraints físicas reportando `CudaError::InvalidAlignment`. | Adicionado tipo CudaError::InvalidAlignment com report rico do domínio. |

## Labels
type:security, type:refactor

## Validacao
`cargo test` e `cargo clippy -- -D warnings` executados com sucesso (falhas em `ramshared-agent` são conhecidas e documentadas).

## Rollback trigger
Caso existam hardwares com constraints de pitch diferenciadas que exijam relaxamento da regra de 256-bytes, esta PR pode ser revertida para restaurar o comportamento antigo ou parametrizar o alinhamento.

---
*PR created automatically by Jules for task [12905296988999900516](https://jules.google.com/task/12905296988999900516) started by @emersonbusson*