### PR TITLE
feat(probe): sanity check GPU compute capability and total memory limits

### DIFF
--- a/crates/ramshared-cuda/src/probe.rs
+++ b/crates/ramshared-cuda/src/probe.rs
@@ -5,6 +5,9 @@
 /// Probe pattern size (4 KiB).
 pub const PROBE_PATTERN_LEN: usize = 4096;
 
+/// Maximum plausible total GPU memory (1 TiB).
+pub const MAX_TOTAL_MEMORY_BYTES: usize = 1024 * 1024 * 1024 * 1024;
+
 /// Plan three 4 KiB-aligned offsets: `0`, `align_down(size/2, 4096)`, `size-4096`.
 ///
 /// Requires `size >= 3 * 4096` so the three positions are distinct on the 64 MiB floor.
@@ -42,6 +45,18 @@ fn align_down(v: usize, align: usize) -> usize {
     v / align * align
 }
 
+/// Validates GPU hardware capabilities and total memory against physical sanity limits.
+pub fn validate_hardware_specs(major: i32, minor: i32, total_memory: usize) -> Result<(), ProbePlanError> {
+    if !(1..=99).contains(&major) || !(0..=99).contains(&minor) {
+        return Err(ProbePlanError::InvalidComputeCapability { major, minor });
+    }
+    if total_memory == 0 || total_memory > MAX_TOTAL_MEMORY_BYTES {
+        return Err(ProbePlanError::InvalidTotalMemory { size: total_memory });
+    }
+    Ok(())
+}
+
+
 /// Errors from pure probe planning (no CUDA).
 #[derive(Debug, PartialEq, Eq)]
 pub enum ProbePlanError {
@@ -55,6 +70,13 @@ pub enum ProbePlanError {
         size: usize,
         mid: usize,
         last: usize,
+    },
+    InvalidComputeCapability {
+        major: i32,
+        minor: i32,
+    },
+    InvalidTotalMemory {
+        size: usize,
     },
 }
 
@@ -72,6 +94,15 @@ impl std::fmt::Display for ProbePlanError {
                     f,
                     "probe offsets not distinct size={size} mid={mid} last={last}"
                 )
+            }
+            ProbePlanError::InvalidComputeCapability { major, minor } => {
+                write!(
+                    f,
+                    "invalid compute capability major={major} minor={minor}"
+                )
+            }
+            ProbePlanError::InvalidTotalMemory { size } => {
+                write!(f, "invalid total memory size {size}")
             }
         }
     }
@@ -111,5 +142,35 @@ mod tests {
             plan_probe_offsets(4096),
             Err(ProbePlanError::TooSmall { .. })
         ));
+    }
+
+    #[test]
+    fn reject_invalid_compute_capability() {
+        assert!(matches!(
+            validate_hardware_specs(0, 0, 1024),
+            Err(ProbePlanError::InvalidComputeCapability { major: 0, minor: 0 })
+        ));
+        assert!(matches!(
+            validate_hardware_specs(100, 0, 1024),
+            Err(ProbePlanError::InvalidComputeCapability { major: 100, minor: 0 })
+        ));
+        assert!(matches!(
+            validate_hardware_specs(1, -1, 1024),
+            Err(ProbePlanError::InvalidComputeCapability { major: 1, minor: -1 })
+        ));
+        assert!(validate_hardware_specs(8, 9, 1024).is_ok());
+    }
+
+    #[test]
+    fn reject_invalid_total_memory() {
+        assert!(matches!(
+            validate_hardware_specs(8, 9, 0),
+            Err(ProbePlanError::InvalidTotalMemory { size: 0 })
+        ));
+        assert!(matches!(
+            validate_hardware_specs(8, 9, MAX_TOTAL_MEMORY_BYTES + 1),
+            Err(ProbePlanError::InvalidTotalMemory { size: _ })
+        ));
+        assert!(validate_hardware_specs(8, 9, 1024).is_ok());
     }
 }


### PR DESCRIPTION
## Resumo
Implementadas verificações de sanidade física (Physical Limits Sanity Checks) em `crates/ramshared-cuda/src/probe.rs` para as especificações da GPU (capacidade de computação e tamanho total de memória). A lógica agora utiliza Guard Clauses para validar limites físicos estritos (ex: memória <= 1 TiB, major/minor > 0) e retorna erros semânticos tipados (`ProbePlanError::InvalidComputeCapability`, `ProbePlanError::InvalidTotalMemory`). Testes unitários foram adicionados.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(probe): add physical limits sanity checks for GPU specs | Adicionou função de validação, limites máximos (1 TiB) e variantes de erro no enum. | Para garantir conformidade com os Princípios Arquiteturais (Guard Clauses, Sanity Checks, Semantic Errors). | Evita que valores absurdos do driver quebrem lógicas subsequentes. |

## Labels
type:feat, scope:probe, type:test

## Validacao
`cargo test -p ramshared-cuda` (passou em todos)
`cargo clippy -p ramshared-cuda -- -D warnings` (passou sem avisos após ajustes em `contains`)

## Rollback trigger
Se os limites físicos estritos definidos (ex: `MAX_TOTAL_MEMORY_BYTES` de 1 TiB ou validações de compute capability) causarem falhas em testes E2E com hardware real por rejeitarem configurações válidas de GPUs exóticas ou emuladas.

---
*PR created automatically by Jules for task [17825837883398387299](https://jules.google.com/task/17825837883398387299) started by @emersonbusson*