### PR TITLE
feat(stress): clamp stress test thread count to system hardware thread limit

### DIFF
--- a/crates/ramshared-cli/src/stress.rs
+++ b/crates/ramshared-cli/src/stress.rs
@@ -35,6 +35,7 @@ pub struct StressOptions {
     pub cascade: bool,
     pub telemetry_log: String,
     pub json: bool,
+    pub threads: u64,
 }
 
 impl Default for StressOptions {
@@ -53,6 +54,7 @@ impl Default for StressOptions {
             cascade: false,
             telemetry_log: "/tmp/ramshared-stress-telemetry.log".to_string(),
             json: false,
+            threads: 1,
         }
     }
 }
@@ -195,10 +197,24 @@ pub fn parse_stress_args(args: &[String]) -> Result<StressOptions, String> {
             "--json" => {
                 opts.json = true;
             }
+            "--threads" => {
+                i += 1;
+                opts.threads = args
+                    .get(i)
+                    .ok_or_else(|| "--threads requires a value".to_string())?
+                    .parse()
+                    .map_err(|_| "invalid --threads value")?;
+            }
             other => return Err(format!("unknown stress argument: {other}")),
         }
         i += 1;
     }
+
+    let max_threads = std::thread::available_parallelism()
+        .map(|n| n.get() as u64)
+        .unwrap_or(1);
+
+    opts.threads = opts.threads.clamp(1, max_threads);
     opts.start_pct = opts.start_pct.clamp(1, 200);
     opts.target_pct = opts.target_pct.clamp(opts.start_pct, 200);
     opts.step_pct = opts.step_pct.clamp(1, 25);
@@ -1003,6 +1019,16 @@ mod tests {
         assert!(opts.battery);
         assert_eq!(opts.telemetry_log, "/tmp/test-telemetry.log");
         assert!(opts.json);
+    }
+
+    #[test]
+    fn clamps_thread_count_to_physical_limits() {
+        let args = vec!["--threads".to_string(), "999999".to_string()];
+        let opts = parse_stress_args(&args).unwrap_or_default();
+        let max_threads = std::thread::available_parallelism()
+            .map(|n| n.get() as u64)
+            .unwrap_or(1);
+        assert_eq!(opts.threads, max_threads);
     }
 
     #[test]


### PR DESCRIPTION
## Resumo
Add the `--threads` CLI argument to the RamShared stress benchmark and clamp the value to the physical system hardware thread limit (available logical processors) in accordance with the "Physical Limits Sanity Checks" principle.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | Add `--threads` parameter and clamping to stress test | Prevent out-of-bounds thread spawning | Validates logical core limit upfront |

## Labels
type:refactor, type:security, type:test

## Validacao
`cargo test -p ramshared-cli` and `cargo clippy -p ramshared-cli -- -D warnings`

## Rollback trigger
Unexpected panics during argument parsing or test failures on specific CI platforms.

do not merge

---
*PR created automatically by Jules for task [12202754023571634884](https://jules.google.com/task/12202754023571634884) started by @emersonbusson*