### PR TITLE
feat(agent): implement physical limit sanity checks for swap resize

### DIFF
--- a/crates/ramshared-agent/src/swap.rs
+++ b/crates/ramshared-agent/src/swap.rs
@@ -11,6 +11,45 @@ use std::process::Command;
 
 use ramshared_broker::protocol::NbdEndpoint;
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum ResizeError {
+    TooSmall(u64),
+    ExceedsDiskSpace { size: u64, max: u64 },
+}
+
+impl std::fmt::Display for ResizeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResizeError::TooSmall(size) => {
+                write!(f, "swap size {} bytes is below 64 MiB minimum", size)
+            }
+            ResizeError::ExceedsDiskSpace { size, max } => {
+                write!(
+                    f,
+                    "swap size {} bytes exceeds physical disk space {} bytes",
+                    size, max
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ResizeError {}
+
+pub fn validate_swap_resize(size_bytes: u64, disk_space_bytes: u64) -> std::result::Result<(), ResizeError> {
+    const MIN_SWAP_BYTES: u64 = 64 * 1024 * 1024;
+    if size_bytes < MIN_SWAP_BYTES {
+        return Err(ResizeError::TooSmall(size_bytes));
+    }
+    if size_bytes > disk_space_bytes {
+        return Err(ResizeError::ExceedsDiskSpace {
+            size: size_bytes,
+            max: disk_space_bytes,
+        });
+    }
+    Ok(())
+}
+
 /// Assembles `nbd-client` argv to attach `export` to `dev` (DT-14: `-timeout 30`, no
 /// `-persist`). Unix uses `-unix <path>`; TCP uses positional `<host> <port>`.
 pub fn nbd_args(endpoint: &NbdEndpoint, export: &str, dev: &str) -> Vec<String> {
@@ -217,5 +256,29 @@ mod tests {
         assert!(res.is_err());
         let err = res.unwrap_err();
         assert!(err.starts_with("swapoff: "));
+    }
+
+    #[test]
+    fn validate_swap_resize_too_small() {
+        let err = validate_swap_resize(63 * 1024 * 1024, 1024 * 1024 * 1024).expect_err("should fail below 64 MiB");
+        assert_eq!(err, ResizeError::TooSmall(63 * 1024 * 1024));
+    }
+
+    #[test]
+    fn validate_swap_resize_exceeds_disk() {
+        let err = validate_swap_resize(128 * 1024 * 1024, 64 * 1024 * 1024).expect_err("should fail if size exceeds disk");
+        assert_eq!(
+            err,
+            ResizeError::ExceedsDiskSpace {
+                size: 128 * 1024 * 1024,
+                max: 64 * 1024 * 1024
+            }
+        );
+    }
+
+    #[test]
+    fn validate_swap_resize_success() {
+        validate_swap_resize(128 * 1024 * 1024, 1024 * 1024 * 1024).expect("should succeed within bounds");
+        validate_swap_resize(64 * 1024 * 1024, 64 * 1024 * 1024).expect("should succeed at exact bounds");
     }
 }

--- a/docs/jules/findings/FINDING_057.md
+++ b/docs/jules/findings/FINDING_057.md
@@ -1,0 +1,16 @@
+# Finding: Scope Integration Violation in Swap Adjustments
+
+**Date:** 2026-08-30
+**Agent Identity:** CleanArch100/2026-08-30/sanity_check/agent/057
+
+## Issue
+I was tasked with implementing a guard clause to perform physical limit sanity checks on dynamic swap size adjustments (enforcing a minimum of 64 MiB and a maximum of physical disk space) specifically targeting `crates/ramshared-agent/src/swap.rs`.
+
+While the pure functional logic (`validate_swap_resize` and `ResizeError`) has been implemented securely within `crates/ramshared-agent/src/swap.rs`, the actual execution context that *performs* dynamic swap size adjustments does not exist in this file. The target file `swap.rs` is strictly limited to NBD attachment, detachment, `mkswap`, and `swapon`/`swapoff` routines (`attach_swap`, `detach_swap`, etc).
+
+There are no dynamic resize handlers or `adjust` routines within `swap.rs` where I can hook the `validate_swap_resize` function into an active execution path.
+
+## Rationale
+To fully integrate the guard clause, modifications outside the strict target file scope `crates/ramshared-agent/src/swap.rs` would be required, which violates the strict target file constraints. According to my execution directives ("If safe code is not possible, produce FINDING_ONLY with evidence in docs/jules/findings/"), this file scope limitation prevents me from completing the integration safely without breaking the sandbox rules.
+
+Therefore, I am returning early with this finding report to highlight the architectural gap while committing the pure validation logic that was safely added to the target file.


### PR DESCRIPTION
## Resumo
Adiciona validação de limites físicos para ajustes dinâmicos de tamanho de swap, aplicando o princípio de Guard Clauses. Garante que o swap não seja inferior a 64 MiB e não ultrapasse o espaço em disco. Inclui testes unitários. Relata violação de escopo de arquivo no `FINDING_057.md` porque o contexto de execução não está presente em `swap.rs`.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(agent) | Adiciona enum `ResizeError` e função `validate_swap_resize` | Validar os limites físicos para swap. | Implementa erro semântico específico. |
| test(agent) | Adiciona testes unitários para a validação | Garantir cobertura (TDD). | Testes validam o limite inferior e superior. |
| docs(findings) | Adiciona relatório `FINDING_057.md` | Documentar violação arquitetural (trap). | `swap.rs` não possui o contexto para integrar o guard clause. |

## Labels
type:refactor, type:security, type:test

## Validacao
`cargo test -p ramshared-agent && cargo clippy -p ramshared-agent -- -D warnings` executados com sucesso.

## Rollback trigger
Se os limites forem demasiadamente restritivos em ambientes com restrições de disco severas.

---
*PR created automatically by Jules for task [18433997119208445994](https://jules.google.com/task/18433997119208445994) started by @emersonbusson*