### PR TITLE
chore: add physical limits check for stride vs page size

### DIFF
--- a/crates/ramshared-integrity/src/pattern.rs
+++ b/crates/ramshared-integrity/src/pattern.rs
@@ -1,6 +1,8 @@
 //! Reproducible test patterns indexed by block number (SPEC §14.2 `test-integrity`).
 //! Deterministic: `verify_block` regenerates the expected pattern without keeping state.
 
+use std::fmt;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Pattern {
     Zero,
@@ -8,8 +10,30 @@ pub enum Pattern {
     Random,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum PatternError {
+    InvalidStride { stride: usize, page_size: usize },
+}
+
+impl fmt::Display for PatternError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PatternError::InvalidStride { stride, page_size } => {
+                write!(f, "pattern scanning stride ({stride}) does not evenly divide memory page size ({page_size})")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PatternError {}
+
 /// Fills `buf` with the deterministic pattern matching block index `idx`.
-pub fn fill_block(buf: &mut [u8], idx: u64, kind: Pattern) {
+pub fn fill_block(buf: &mut [u8], idx: u64, kind: Pattern) -> Result<(), PatternError> {
+    let stride = buf.len();
+    if stride == 0 || 4096 % stride != 0 {
+        return Err(PatternError::InvalidStride { stride, page_size: 4096 });
+    }
+
     match kind {
         Pattern::Zero => buf.iter_mut().for_each(|b| *b = 0),
         Pattern::Sequential => {
@@ -28,13 +52,19 @@ pub fn fill_block(buf: &mut [u8], idx: u64, kind: Pattern) {
             }
         }
     }
+    Ok(())
 }
 
 /// Returns `true` if `buf` matches the expected pattern for block index `idx`.
-pub fn verify_block(buf: &[u8], idx: u64, kind: Pattern) -> bool {
+pub fn verify_block(buf: &[u8], idx: u64, kind: Pattern) -> Result<bool, PatternError> {
+    let stride = buf.len();
+    if stride == 0 || 4096 % stride != 0 {
+        return Err(PatternError::InvalidStride { stride, page_size: 4096 });
+    }
+
     let mut expected = vec![0u8; buf.len()];
-    fill_block(&mut expected, idx, kind);
-    expected == buf
+    fill_block(&mut expected, idx, kind)?;
+    Ok(expected == buf)
 }
 
 #[cfg(test)]
@@ -45,26 +75,36 @@ mod tests {
     fn fill_then_verify_round_trips() {
         for kind in [Pattern::Zero, Pattern::Sequential, Pattern::Random] {
             let mut buf = vec![0u8; 4096];
-            fill_block(&mut buf, 42, kind);
-            assert!(verify_block(&buf, 42, kind), "{kind:?}");
+            fill_block(&mut buf, 42, kind).expect("valid stride");
+            assert!(verify_block(&buf, 42, kind).expect("valid stride"), "{kind:?}");
         }
     }
 
     #[test]
     fn corruption_breaks_verify() {
         let mut buf = vec![0u8; 4096];
-        fill_block(&mut buf, 7, Pattern::Random);
+        fill_block(&mut buf, 7, Pattern::Random).expect("valid stride");
         buf[1234] ^= 0x01;
-        assert!(!verify_block(&buf, 7, Pattern::Random));
+        assert!(!verify_block(&buf, 7, Pattern::Random).expect("valid stride"));
     }
 
     #[test]
     fn different_blocks_differ_and_wrong_index_fails() {
         let mut a = vec![0u8; 4096];
         let mut b = vec![0u8; 4096];
-        fill_block(&mut a, 1, Pattern::Random);
-        fill_block(&mut b, 2, Pattern::Random);
+        fill_block(&mut a, 1, Pattern::Random).expect("valid stride");
+        fill_block(&mut b, 2, Pattern::Random).expect("valid stride");
         assert_ne!(a, b); // pattern differs by block index
-        assert!(!verify_block(&a, 2, Pattern::Random)); // wrong index verification fails
+        assert!(!verify_block(&a, 2, Pattern::Random).expect("valid stride")); // wrong index verification fails
+    }
+
+    #[test]
+    fn invalid_stride_fails() {
+        let mut buf = vec![0u8; 1000];
+        let err = fill_block(&mut buf, 1, Pattern::Zero).expect_err("should fail");
+        assert_eq!(err, PatternError::InvalidStride { stride: 1000, page_size: 4096 });
+
+        let err2 = verify_block(&buf, 1, Pattern::Zero).expect_err("should fail");
+        assert_eq!(err2, PatternError::InvalidStride { stride: 1000, page_size: 4096 });
     }
 }

--- a/crates/ramshared-wsl2d/src/canary_probe.rs
+++ b/crates/ramshared-wsl2d/src/canary_probe.rs
@@ -65,10 +65,12 @@ impl<M: VramMemory> CanaryProbe<M> {
     /// detection is done per-request in the daemon).
     pub fn check_content(&mut self) -> Result<bool, VramError> {
         self.seq += 1;
-        fill_block(&mut self.wbuf, self.seq, Pattern::Random);
+        fill_block(&mut self.wbuf, self.seq, Pattern::Random)
+            .map_err(|e| VramError::Provider(e.to_string()))?;
         self.region.write_at(0, &self.wbuf)?;
         self.region.read_at(0, &mut self.rbuf)?;
-        Ok(verify_block(&self.rbuf, self.seq, Pattern::Random))
+        verify_block(&self.rbuf, self.seq, Pattern::Random)
+            .map_err(|e| VramError::Provider(e.to_string()))
     }
 
     /// Zeroes the canary-region (teardown §11, DT-12). The region is encapsulated


### PR DESCRIPTION
## Resumo
Adiciona verificações de limites físicos (sanity checks) para garantir que o tamanho dos blocos de memória (`stride`) usados no scanner de integridade dividam perfeitamente o tamanho da página padrão (4096 bytes). Rejeita blocos não alinhados com `PatternError::InvalidStride`.

## Commits table

| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| chore: add physical limits check for stride vs page size | Aplicou restrições de limites em `pattern.rs` | Segurança contra escritas malformadas | `PatternError::InvalidStride` implementado e tests atualizados. |

## Labels
type:security

## Validacao
`cargo test --workspace && cargo clippy --workspace -- -D warnings` executados com sucesso.

## Rollback trigger
Reverter a PR caso os testes de integração ou a inicialização dos *canaries* falhem devido à limitação de alinhamento 4096.

---
*PR created automatically by Jules for task [3291374780282037989](https://jules.google.com/task/3291374780282037989) started by @emersonbusson*