### PR TITLE
feat: enforce physical limits sanity checks in serve_request

### DIFF
--- a/crates/ramshared-wsl2d/src/ublk_server.rs
+++ b/crates/ramshared-wsl2d/src/ublk_server.rs
@@ -78,6 +78,14 @@ pub fn serve_request<B: BlockBackend + ?Sized>(
         return EINVAL; // request larger than the available buffer
     }
 
+    let bs = backend.block_size() as u64;
+    if bs == 0 || !req.offset.is_multiple_of(bs) || !(req.len as u64).is_multiple_of(bs) {
+        return EINVAL;
+    }
+    if req.offset.checked_add(req.len as u64).is_none_or(|end| end > backend.size_bytes()) {
+        return EINVAL;
+    }
+
     let served = match req.cmd {
         Command::Read => backend.read_at(req.offset, &mut buf[..len]).map(|()| len),
         Command::Write => backend.write_at(req.offset, &buf[..len]).map(|()| len),
@@ -915,6 +923,31 @@ mod join_tests {
         };
         assert_eq!(residency.demote_count(), 3);
         residency.join().expect("residency success");
+    }
+
+    #[test]
+    fn serve_request_refuses_unaligned_and_out_of_bounds() {
+        let mut backend = RamBackend::new(4096);
+        let mut buffer = vec![0u8; 8192];
+        let mut request = Request {
+            flags: 0,
+            cmd: Command::Read,
+            handle: 1,
+            offset: 0,
+            len: 4096,
+        };
+        assert_eq!(serve_request(&request, &mut backend, &mut buffer), 4096);
+
+        request.offset = 100; // Unaligned to 512
+        assert_eq!(serve_request(&request, &mut backend, &mut buffer), EINVAL);
+
+        request.offset = 0;
+        request.len = 100; // Length unaligned
+        assert_eq!(serve_request(&request, &mut backend, &mut buffer), EINVAL);
+
+        request.len = 4096;
+        request.offset = 4096; // Out of bounds (backend is 4096, offset 4096 + len 4096 = 8192 > 4096)
+        assert_eq!(serve_request(&request, &mut backend, &mut buffer), EINVAL);
     }
 
     #[test]

--- a/crates/ramshared-wsl2d/tests/ublk_server.rs
+++ b/crates/ramshared-wsl2d/tests/ublk_server.rs
@@ -48,9 +48,9 @@ fn serve_request_handles_flush_and_rejects_oversized_or_oob() {
         -22
     );
 
-    // READ outside the backend => -EIO.
+    // READ outside the backend => -EINVAL.
     assert_eq!(
         ublk_server::serve_request(&req(Command::Read, 51200, 512), &mut backend, &mut buf),
-        -5
+        -22
     );
 }

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,16 @@
+## Resumo
+Enforce physical sector alignment and max device capacity bounds in the ublk server. The changes apply strict physical limits sanity checks by ensuring I/O requests are aligned to the backend block size and do not exceed the backend capacity, returning -EINVAL on violation.
+
+## Commits table
+| Commit | O que fez | Por que fez | Detalhes |
+|---|---|---|---|
+| feat: enforce physical limits sanity checks in serve_request | Added strict block size alignment and bounds checks returning EINVAL. | Prevent OOB or misaligned operations from reaching the VRAM backend. | Modified `serve_request` and updated test cases in `ublk_server.rs` to expect EINVAL for such violations. |
+
+## Labels
+type:security, type:refactor
+
+## Validacao
+Ran `cargo test -p ramshared-wsl2d` and `cargo clippy -- -D warnings` successfully.
+
+## Rollback trigger
+Revert commit if any I/O regressions or unexpected failures occur during ublk operations.


### PR DESCRIPTION
Enforced physical sector alignment and max device capacity bounds in `serve_request`. The logic ensures requests are checked upfront and reject out-of-bounds inputs safely with -EINVAL, meeting defensive programming principles. Test files modified accordingly.

---
*PR created automatically by Jules for task [14292180358995957476](https://jules.google.com/task/14292180358995957476) started by @emersonbusson*