### PR TITLE
refactor(winsvc): map Win32 driver errors to specific std::io::ErrorKind variants

### DIFF
--- a/crates/ramshared-winsvc/src/product_online.rs
+++ b/crates/ramshared-winsvc/src/product_online.rs
@@ -371,7 +371,7 @@ pub fn run_product_online(
                         }
                     }
                 }
-                Err(crate::windows_driver::IoctlError::Timeout) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {}
                 Err(e) => {
                     eprintln!("commit_and_fetch: {e}");
                     if last_progress.elapsed() > commit_watchdog {
@@ -595,7 +595,7 @@ pub fn run_product_online(
                     Ok(()) => {
                         let _ = dlink.commit_and_fetch(&mut backend);
                     }
-                    Err(crate::windows_driver::IoctlError::Timeout) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {}
                     Err(e) => {
                         teardown_diag(&format!("I/O pump during lock: {e}"));
                     }
@@ -1005,7 +1005,7 @@ where
                 .commit_and_fetch(backend)
                 .map(|_| ())
                 .map_err(|e| format!("I/O pump during host observation: {e}"))?,
-            Err(crate::windows_driver::IoctlError::Timeout) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {}
             Err(e) => return Err(format!("I/O pump during host observation: {e}")),
         }
     }
@@ -1050,7 +1050,7 @@ where
                     teardown_diag(&format!("FailedSafe I/O pump error: {e}"));
                 }
             }
-            Err(crate::windows_driver::IoctlError::Timeout) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {}
             Err(e) => teardown_diag(&format!("FailedSafe COMMIT error: {e}")),
         }
         if last_heartbeat.elapsed() >= Duration::from_secs(1) {

--- a/crates/ramshared-winsvc/src/windows_driver.rs
+++ b/crates/ramshared-winsvc/src/windows_driver.rs
@@ -52,37 +52,6 @@ const IOCTL_DESTROY: u32 = ioctl_code(4);
 const GENERIC_READ: u32 = 0x8000_0000;
 const GENERIC_WRITE: u32 = 0x4000_0000;
 
-/// IOCTL / mapping errors (stable classes only — no pointers in Display).
-#[derive(Debug)]
-pub enum IoctlError {
-    Open(String),
-    Ioctl(String),
-    Map(String),
-    Timeout,
-    Cancelled,
-    Invalid(String),
-}
-
-impl std::fmt::Display for IoctlError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            IoctlError::Open(s) => write!(f, "open: {s}"),
-            IoctlError::Ioctl(s) => write!(f, "ioctl: {s}"),
-            IoctlError::Map(s) => write!(f, "map: {s}"),
-            IoctlError::Timeout => write!(f, "timeout"),
-            IoctlError::Cancelled => write!(f, "cancelled"),
-            IoctlError::Invalid(s) => write!(f, "invalid: {s}"),
-        }
-    }
-}
-
-impl std::error::Error for IoctlError {}
-
-fn last_error_string(op: &str) -> String {
-    let e = unsafe { windows_sys::Win32::Foundation::GetLastError() };
-    format!("{op} win32={e}")
-}
-
 /// Contiguous page-aligned SQ/CQ/data regions for REGISTER (DT-4).
 ///
 /// Shared headers use aligned 32-bit words with Rust Release/Acquire publication.
@@ -107,21 +76,21 @@ impl WindowsMappedQueue {
         queue_depth: u32,
         max_io_bytes: u32,
         block_size: u32,
-    ) -> Result<Self, IoctlError> {
+    ) -> std::io::Result<Self> {
         if queue_depth == 0 || queue_depth > MAX_QD || !queue_depth.is_power_of_two() {
-            return Err(IoctlError::Invalid("queue_depth".into()));
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "queue_depth"));
         }
         if max_io_bytes == 0 || max_io_bytes > MAX_IO {
-            return Err(IoctlError::Invalid("max_io_bytes".into()));
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "max_io_bytes"));
         }
         if block_size != 512 && block_size != 4096 {
-            return Err(IoctlError::Invalid("block_size".into()));
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "block_size"));
         }
         let data_bytes = (queue_depth as usize)
             .checked_mul(max_io_bytes as usize)
-            .ok_or_else(|| IoctlError::Invalid("data area overflow".into()))?;
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "data area overflow"))?;
         if data_bytes > 4 * 1024 * 1024 {
-            return Err(IoctlError::Invalid("data area > 4 MiB".into()));
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "data area > 4 MiB"));
         }
         let sq_bytes = size_of::<RingHdr>() + (queue_depth as usize) * size_of::<Sqe>();
         let cq_bytes = size_of::<RingHdr>() + (queue_depth as usize) * size_of::<Cqe>();
@@ -313,14 +282,14 @@ unsafe fn init_ring_hdr(base: *mut u8, entries: u32) {
     }
 }
 
-fn alloc_region(bytes: usize) -> Result<*mut u8, IoctlError> {
+fn alloc_region(bytes: usize) -> std::io::Result<*mut u8> {
     if bytes == 0 {
-        return Err(IoctlError::Invalid("zero alloc".into()));
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "zero alloc"));
     }
     // SAFETY: VirtualAlloc returns page-aligned RW region or null.
     let p = unsafe { VirtualAlloc(ptr::null(), bytes, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE) };
     if p.is_null() {
-        return Err(IoctlError::Map(last_error_string("VirtualAlloc")));
+        return Err(std::io::Error::last_os_error());
     }
     // Best-effort lock to reduce page-out during MDL probe.
     unsafe {
@@ -347,7 +316,7 @@ pub struct WindowsDriverLink {
 }
 
 impl WindowsDriverLink {
-    pub fn open() -> Result<Self, IoctlError> {
+    pub fn open() -> std::io::Result<Self> {
         let path: Vec<u16> = "\\\\.\\RamSharedCtl\0".encode_utf16().collect();
         // SAFETY: path is NUL-terminated wide string.
         let handle = unsafe {
@@ -362,16 +331,15 @@ impl WindowsDriverLink {
             )
         };
         if handle == INVALID_HANDLE_VALUE {
-            return Err(IoctlError::Open(last_error_string(
-                "CreateFile RamSharedCtl",
-            )));
+            return Err(std::io::Error::last_os_error());
         }
         let event = unsafe { CreateEventW(ptr::null(), 1, 0, ptr::null()) };
         if event.is_null() {
+            let err = std::io::Error::last_os_error();
             unsafe {
                 CloseHandle(handle);
             }
-            return Err(IoctlError::Open(last_error_string("CreateEvent")));
+            return Err(err);
         }
         Ok(Self {
             handle,
@@ -380,29 +348,29 @@ impl WindowsDriverLink {
         })
     }
 
-    pub fn create_disk(&mut self, params: &DiskParams) -> Result<(), IoctlError> {
+    pub fn create_disk(&mut self, params: &DiskParams) -> std::io::Result<()> {
         if params.reserved != 0 {
-            return Err(IoctlError::Invalid("disk reserved non-zero".into()));
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "disk reserved non-zero"));
         }
         let bytes = struct_bytes(params);
         self.ioctl_sync(IOCTL_CREATE, Some(&bytes), None)
     }
 
-    pub fn register_queue(&mut self, reg: &Register) -> Result<(), IoctlError> {
+    pub fn register_queue(&mut self, reg: &Register) -> std::io::Result<()> {
         if reg.reserved != 0 {
-            return Err(IoctlError::Invalid("register reserved non-zero".into()));
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "register reserved non-zero"));
         }
         if reg.disk_id != 0 {
-            return Err(IoctlError::Invalid("disk_id must be 0".into()));
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "disk_id must be 0"));
         }
         let bytes = struct_bytes(reg);
         self.ioctl_sync(IOCTL_REGISTER, Some(&bytes), None)
     }
 
     /// One pending COMMIT_AND_FETCH only (DT-4). Timeout uses CancelIoEx + GetOverlappedResult.
-    pub fn commit_and_fetch(&mut self, timeout: Duration) -> Result<(), IoctlError> {
+    pub fn commit_and_fetch(&mut self, timeout: Duration) -> std::io::Result<()> {
         if self.pending {
-            return Err(IoctlError::Invalid("commit already pending".into()));
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "commit already pending"));
         }
         unsafe {
             let _ = ResetEvent(self.event);
@@ -426,7 +394,7 @@ impl WindowsDriverLink {
         if ok == FALSE {
             let err = unsafe { windows_sys::Win32::Foundation::GetLastError() };
             if err != ERROR_IO_PENDING {
-                return Err(IoctlError::Ioctl(format!("COMMIT win32={err}")));
+                return Err(std::io::Error::from_raw_os_error(err as i32));
             }
             self.pending = true;
             let ms = timeout.as_millis().min(u32::MAX as u128) as u32;
@@ -434,17 +402,17 @@ impl WindowsDriverLink {
                 unsafe { WaitForSingleObject(self.event, if ms == 0 { INFINITE } else { ms }) };
             if wr == WAIT_TIMEOUT {
                 self.cancel_and_drain(&ov);
-                return Err(IoctlError::Timeout);
+                return Err(std::io::Error::new(std::io::ErrorKind::TimedOut, "timeout"));
             }
             if wr != WAIT_OBJECT_0 {
                 self.cancel_and_drain(&ov);
-                return Err(IoctlError::Ioctl(format!("WaitForSingleObject={wr}")));
+                return Err(std::io::Error::new(std::io::ErrorKind::Other, format!("WaitForSingleObject={wr}")));
             }
             let mut xfer = 0u32;
             let gor = unsafe { GetOverlappedResult(self.handle, &ov, &mut xfer, 0) };
             self.pending = false;
             if gor == FALSE {
-                return Err(IoctlError::Ioctl(last_error_string("GetOverlappedResult")));
+                return Err(std::io::Error::last_os_error());
             }
             Ok(())
         } else {
@@ -454,22 +422,22 @@ impl WindowsDriverLink {
         }
     }
 
-    pub fn cancel_fetch(&mut self) -> Result<(), IoctlError> {
+    pub fn cancel_fetch(&mut self) -> std::io::Result<()> {
         if !self.pending {
             return Ok(());
         }
         // A pending operation must only be cancelled by its owner while its
         // OVERLAPPED remains in scope. commit_and_fetch drains before return.
-        Err(IoctlError::Invalid(
-            "pending fetch cannot be cancelled without its OVERLAPPED owner".into(),
+        Err(std::io::Error::new(std::io::ErrorKind::InvalidInput,
+            "pending fetch cannot be cancelled without its OVERLAPPED owner",
         ))
     }
 
-    pub fn unregister_queue(&mut self) -> Result<(), IoctlError> {
+    pub fn unregister_queue(&mut self) -> std::io::Result<()> {
         self.ioctl_sync(IOCTL_UNREGISTER, None, None)
     }
 
-    pub fn destroy_disk(&mut self) -> Result<(), IoctlError> {
+    pub fn destroy_disk(&mut self) -> std::io::Result<()> {
         self.ioctl_sync(IOCTL_DESTROY, None, None)
     }
 
@@ -478,7 +446,7 @@ impl WindowsDriverLink {
         code: u32,
         input: Option<&[u8]>,
         _output: Option<&mut [u8]>,
-    ) -> Result<(), IoctlError> {
+    ) -> std::io::Result<()> {
         unsafe {
             let _ = ResetEvent(self.event);
         }
@@ -506,17 +474,17 @@ impl WindowsDriverLink {
         }
         let err = unsafe { windows_sys::Win32::Foundation::GetLastError() };
         if err != ERROR_IO_PENDING {
-            return Err(IoctlError::Ioctl(format!("ioctl win32={err}")));
+            return Err(std::io::Error::from_raw_os_error(err as i32));
         }
         let wr = unsafe { WaitForSingleObject(self.event, 30_000) };
         if wr != WAIT_OBJECT_0 {
             self.cancel_and_drain(&ov);
-            return Err(IoctlError::Timeout);
+            return Err(std::io::Error::new(std::io::ErrorKind::TimedOut, "timeout"));
         }
         let mut xfer = 0u32;
         let gor = unsafe { GetOverlappedResult(self.handle, &ov, &mut xfer, 0) };
         if gor == FALSE {
-            return Err(IoctlError::Ioctl(last_error_string("GetOverlappedResult")));
+            return Err(std::io::Error::last_os_error());
         }
         Ok(())
     }

--- a/crates/ramshared-winsvc/src/windows_driver.rs
+++ b/crates/ramshared-winsvc/src/windows_driver.rs
@@ -72,25 +72,35 @@ pub struct WindowsMappedQueue {
 unsafe impl Send for WindowsMappedQueue {}
 
 impl WindowsMappedQueue {
-    pub fn try_new(
-        queue_depth: u32,
-        max_io_bytes: u32,
-        block_size: u32,
-    ) -> std::io::Result<Self> {
+    pub fn try_new(queue_depth: u32, max_io_bytes: u32, block_size: u32) -> std::io::Result<Self> {
         if queue_depth == 0 || queue_depth > MAX_QD || !queue_depth.is_power_of_two() {
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "queue_depth"));
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "queue_depth",
+            ));
         }
         if max_io_bytes == 0 || max_io_bytes > MAX_IO {
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "max_io_bytes"));
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "max_io_bytes",
+            ));
         }
         if block_size != 512 && block_size != 4096 {
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "block_size"));
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "block_size",
+            ));
         }
         let data_bytes = (queue_depth as usize)
             .checked_mul(max_io_bytes as usize)
-            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "data area overflow"))?;
+            .ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::InvalidInput, "data area overflow")
+            })?;
         if data_bytes > 4 * 1024 * 1024 {
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "data area > 4 MiB"));
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "data area > 4 MiB",
+            ));
         }
         let sq_bytes = size_of::<RingHdr>() + (queue_depth as usize) * size_of::<Sqe>();
         let cq_bytes = size_of::<RingHdr>() + (queue_depth as usize) * size_of::<Cqe>();
@@ -284,7 +294,10 @@ unsafe fn init_ring_hdr(base: *mut u8, entries: u32) {
 
 fn alloc_region(bytes: usize) -> std::io::Result<*mut u8> {
     if bytes == 0 {
-        return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "zero alloc"));
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "zero alloc",
+        ));
     }
     // SAFETY: VirtualAlloc returns page-aligned RW region or null.
     let p = unsafe { VirtualAlloc(ptr::null(), bytes, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE) };
@@ -350,7 +363,10 @@ impl WindowsDriverLink {
 
     pub fn create_disk(&mut self, params: &DiskParams) -> std::io::Result<()> {
         if params.reserved != 0 {
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "disk reserved non-zero"));
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "disk reserved non-zero",
+            ));
         }
         let bytes = struct_bytes(params);
         self.ioctl_sync(IOCTL_CREATE, Some(&bytes), None)
@@ -358,10 +374,16 @@ impl WindowsDriverLink {
 
     pub fn register_queue(&mut self, reg: &Register) -> std::io::Result<()> {
         if reg.reserved != 0 {
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "register reserved non-zero"));
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "register reserved non-zero",
+            ));
         }
         if reg.disk_id != 0 {
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "disk_id must be 0"));
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "disk_id must be 0",
+            ));
         }
         let bytes = struct_bytes(reg);
         self.ioctl_sync(IOCTL_REGISTER, Some(&bytes), None)
@@ -370,7 +392,10 @@ impl WindowsDriverLink {
     /// One pending COMMIT_AND_FETCH only (DT-4). Timeout uses CancelIoEx + GetOverlappedResult.
     pub fn commit_and_fetch(&mut self, timeout: Duration) -> std::io::Result<()> {
         if self.pending {
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "commit already pending"));
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "commit already pending",
+            ));
         }
         unsafe {
             let _ = ResetEvent(self.event);
@@ -406,7 +431,10 @@ impl WindowsDriverLink {
             }
             if wr != WAIT_OBJECT_0 {
                 self.cancel_and_drain(&ov);
-                return Err(std::io::Error::new(std::io::ErrorKind::Other, format!("WaitForSingleObject={wr}")));
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("WaitForSingleObject={wr}"),
+                ));
             }
             let mut xfer = 0u32;
             let gor = unsafe { GetOverlappedResult(self.handle, &ov, &mut xfer, 0) };
@@ -428,7 +456,8 @@ impl WindowsDriverLink {
         }
         // A pending operation must only be cancelled by its owner while its
         // OVERLAPPED remains in scope. commit_and_fetch drains before return.
-        Err(std::io::Error::new(std::io::ErrorKind::InvalidInput,
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
             "pending fetch cannot be cancelled without its OVERLAPPED owner",
         ))
     }

--- a/docs/governance/rust-slice-coverage.json
+++ b/docs/governance/rust-slice-coverage.json
@@ -156,7 +156,7 @@
         "-p",
         "ramshared-winsvc",
         "--files",
-        "crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs,crates/ramshared-winsvc/src/windows_driver.rs",
+        "crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/host_safety.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/windows_driver.rs",
         "--min",
         "80"
       ],
@@ -164,13 +164,13 @@
         "ramshared-winsvc"
       ],
       "files": [
-        "crates/ramshared-winsvc/src/config.rs",
-        "crates/ramshared-winsvc/src/evidence.rs",
-        "crates/ramshared-winsvc/src/driver_link.rs",
         "crates/ramshared-winsvc/src/broker_tenant.rs",
+        "crates/ramshared-winsvc/src/config.rs",
+        "crates/ramshared-winsvc/src/driver_link.rs",
+        "crates/ramshared-winsvc/src/evidence.rs",
+        "crates/ramshared-winsvc/src/host_safety.rs",
         "crates/ramshared-winsvc/src/runtime.rs",
         "crates/ramshared-winsvc/src/service.rs",
-        "crates/ramshared-winsvc/src/host_safety.rs",
         "crates/ramshared-winsvc/src/windows_driver.rs"
       ],
       "min": 80

--- a/docs/governance/rust-slice-coverage.json
+++ b/docs/governance/rust-slice-coverage.json
@@ -156,7 +156,7 @@
         "-p",
         "ramshared-winsvc",
         "--files",
-        "crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs",
+        "crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs,crates/ramshared-winsvc/src/windows_driver.rs",
         "--min",
         "80"
       ],
@@ -170,7 +170,8 @@
         "crates/ramshared-winsvc/src/broker_tenant.rs",
         "crates/ramshared-winsvc/src/runtime.rs",
         "crates/ramshared-winsvc/src/service.rs",
-        "crates/ramshared-winsvc/src/host_safety.rs"
+        "crates/ramshared-winsvc/src/host_safety.rs",
+        "crates/ramshared-winsvc/src/windows_driver.rs"
       ],
       "min": 80
     },
@@ -218,11 +219,25 @@
           "source": "crates/ramshared-cuda/src/lib.rs",
           "package": "ramshared-cuda",
           "test_module": "tests",
-          "cargo_test": ["cargo", "test", "-p", "ramshared-cuda", "--lib"],
+          "cargo_test": [
+            "cargo",
+            "test",
+            "-p",
+            "ramshared-cuda",
+            "--lib"
+          ],
           "ignored_gpu_tests": [
             {
               "name": "gpu_roundtrip_256mib",
-              "command": ["cargo", "test", "-p", "ramshared-cuda", "--", "--ignored", "--test-threads=1"],
+              "command": [
+                "cargo",
+                "test",
+                "-p",
+                "ramshared-cuda",
+                "--",
+                "--ignored",
+                "--test-threads=1"
+              ],
               "evidence": "validation.md"
             }
           ]
@@ -245,15 +260,21 @@
         "--report-json",
         "tmp/memory-broker-wsl2d-backend-cov.json"
       ],
-      "packages": ["ramshared-wsl2d"],
-      "files": ["crates/ramshared-wsl2d/src/backend.rs"],
+      "packages": [
+        "ramshared-wsl2d"
+      ],
+      "files": [
+        "crates/ramshared-wsl2d/src/backend.rs"
+      ],
       "min": 80
     },
     {
       "id": "memory-broker-wsl2d-backend-gpu-test-relocation",
       "kind": "rust-ignored-test-relocation",
       "spec": "docs/specs/no-milestone/memory-broker/SPEC.md",
-      "files": ["crates/ramshared-wsl2d/src/backend.rs"],
+      "files": [
+        "crates/ramshared-wsl2d/src/backend.rs"
+      ],
       "base_revision": "69f7469fa999b7d079341ee6bf8ebb006d517b51",
       "base_source_sha256": "b58d99366164b7e898baa42492fead82416a6169ec06ce16fb274b06b6d99663",
       "verification": {
@@ -277,14 +298,54 @@
         "ignored_gpu_tests": [
           {
             "name": "vram_backend_serves_nbd_write_then_read",
-            "command": ["cargo", "test", "-p", "ramshared-wsl2d", "--test", "backend_gpu", "vram_backend_serves_nbd_write_then_read", "--", "--ignored", "--test-threads=1"],
-            "historical_command": ["cargo", "test", "-p", "ramshared-wsl2d", "backend::tests::vram_backend_serves_nbd_write_then_read", "--", "--ignored", "--test-threads=1"],
+            "command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "--test",
+              "backend_gpu",
+              "vram_backend_serves_nbd_write_then_read",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
+            "historical_command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "backend::tests::vram_backend_serves_nbd_write_then_read",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
             "evidence": "validation.md"
           },
           {
             "name": "vram_gauge_outros_captures_real_graphics_usage",
-            "command": ["cargo", "test", "-p", "ramshared-wsl2d", "--test", "backend_gpu", "vram_gauge_outros_captures_real_graphics_usage", "--", "--ignored", "--test-threads=1"],
-            "historical_command": ["cargo", "test", "-p", "ramshared-wsl2d", "backend::tests::vram_gauge_outros_captures_real_graphics_usage", "--", "--ignored", "--test-threads=1"],
+            "command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "--test",
+              "backend_gpu",
+              "vram_gauge_outros_captures_real_graphics_usage",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
+            "historical_command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "backend::tests::vram_gauge_outros_captures_real_graphics_usage",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
             "evidence": "validation.md"
           }
         ]

--- a/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
+++ b/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
@@ -489,7 +489,7 @@ those shared sources as evidence without creating a second coverage owner.
 - [x] `cargo clippy -p ramshared-cuda -p ramshared-block -p ramshared-winsvc --all-targets -- -D warnings`
 - [x] `cargo test -p ramshared-cuda -p ramshared-block -p ramshared-winsvc`
 - [x] `cargo build -p ramshared-winsvc --target x86_64-pc-windows-msvc`
-- [x] `node tools/ci/check-rust-slice-coverage.mjs -p ramshared-winsvc --files crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs,crates/ramshared-winsvc/src/windows_driver.rs --min 80`
+- [x] `node tools/ci/check-rust-slice-coverage.mjs -p ramshared-winsvc --files crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/host_safety.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/windows_driver.rs --min 80`
   (also CUDA probe cover ≥80% when `crates/ramshared-cuda/src/probe.rs` is in the gate set)
 - [ ] If pure planning logic changes in `crates/ramshared-cuda/src/driver.rs`, include that file in a
   separate `ramshared-cuda` cover gate at >=80%; hardware-only lines remain live-E2E evidence.

--- a/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
+++ b/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
@@ -489,7 +489,7 @@ those shared sources as evidence without creating a second coverage owner.
 - [x] `cargo clippy -p ramshared-cuda -p ramshared-block -p ramshared-winsvc --all-targets -- -D warnings`
 - [x] `cargo test -p ramshared-cuda -p ramshared-block -p ramshared-winsvc`
 - [x] `cargo build -p ramshared-winsvc --target x86_64-pc-windows-msvc`
-- [x] `node tools/ci/check-rust-slice-coverage.mjs -p ramshared-winsvc --files crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs --min 80`
+- [x] `node tools/ci/check-rust-slice-coverage.mjs -p ramshared-winsvc --files crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs,crates/ramshared-winsvc/src/windows_driver.rs --min 80`
   (also CUDA probe cover ≥80% when `crates/ramshared-cuda/src/probe.rs` is in the gate set)
 - [ ] If pure planning logic changes in `crates/ramshared-cuda/src/driver.rs`, include that file in a
   separate `ramshared-cuda` cover gate at >=80%; hardware-only lines remain live-E2E evidence.


### PR DESCRIPTION
## Resumo
Map DeviceIoControl error codes to semantic std::io::ErrorKind.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | Replace IoctlError with std::io::Result | CleanArch100/2026-08-30/semantic_error | Specific & Semantic Errors |

## Labels
type:refactor

## Validacao
cargo test -p ramshared-winsvc
cargo clippy -p ramshared-winsvc -- -D warnings

## Rollback trigger
If Windows event loop degrades due to error mapping mismatch.

---
*PR created automatically by Jules for task [17354762138811797738](https://jules.google.com/task/17354762138811797738) started by @emersonbusson*