### PR TITLE
refactor(wsl2d): enforce semantic errors for cgroup memory parsing

### DIFF
--- a/crates/ramshared-wsl2d/src/residency.rs
+++ b/crates/ramshared-wsl2d/src/residency.rs
@@ -43,6 +43,28 @@ pub enum Verdict {
     Demote(DemoteReason),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResidencyError {
+    ProcfsMissing,
+    MalformedMetric,
+}
+
+impl std::fmt::Display for ResidencyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ProcfsMissing => write!(f, "procfs missing (-ENOENT)"),
+            Self::MalformedMetric => write!(f, "malformed metric (-EINVAL)"),
+        }
+    }
+}
+
+impl std::error::Error for ResidencyError {}
+
+pub fn parse_cgroup_metric(content: Option<&str>) -> Result<u64, ResidencyError> {
+    let s = content.ok_or(ResidencyError::ProcfsMissing)?;
+    s.trim().parse::<u64>().map_err(|_| ResidencyError::MalformedMetric)
+}
+
 /// Canary state: baseline (median right after `VramAllocated`) + streak of
 /// consecutive samples above the latency threshold.
 pub struct Canary {
@@ -267,5 +289,27 @@ mod sampler_tests {
         assert_eq!(s.sample(Some(true), low), Verdict::Ok); // 1
         assert_eq!(s.sample(Some(true), low), Verdict::Ok); // 2
         assert_eq!(s.bad_streak(), 2);
+    }
+
+    #[test]
+    fn parse_cgroup_metric_missing() {
+        assert_eq!(parse_cgroup_metric(None), Err(ResidencyError::ProcfsMissing));
+    }
+
+    #[test]
+    fn parse_cgroup_metric_malformed() {
+        assert_eq!(parse_cgroup_metric(Some("")), Err(ResidencyError::MalformedMetric));
+        assert_eq!(parse_cgroup_metric(Some("abc")), Err(ResidencyError::MalformedMetric));
+    }
+
+    #[test]
+    fn parse_cgroup_metric_valid() {
+        assert_eq!(parse_cgroup_metric(Some("1234")), Ok(1234));
+    }
+
+    #[test]
+    fn residency_error_display() {
+        assert_eq!(ResidencyError::ProcfsMissing.to_string(), "procfs missing (-ENOENT)");
+        assert_eq!(ResidencyError::MalformedMetric.to_string(), "malformed metric (-EINVAL)");
     }
 }

--- a/docs/governance/rust-slice-coverage.json
+++ b/docs/governance/rust-slice-coverage.json
@@ -218,11 +218,25 @@
           "source": "crates/ramshared-cuda/src/lib.rs",
           "package": "ramshared-cuda",
           "test_module": "tests",
-          "cargo_test": ["cargo", "test", "-p", "ramshared-cuda", "--lib"],
+          "cargo_test": [
+            "cargo",
+            "test",
+            "-p",
+            "ramshared-cuda",
+            "--lib"
+          ],
           "ignored_gpu_tests": [
             {
               "name": "gpu_roundtrip_256mib",
-              "command": ["cargo", "test", "-p", "ramshared-cuda", "--", "--ignored", "--test-threads=1"],
+              "command": [
+                "cargo",
+                "test",
+                "-p",
+                "ramshared-cuda",
+                "--",
+                "--ignored",
+                "--test-threads=1"
+              ],
               "evidence": "validation.md"
             }
           ]
@@ -245,15 +259,21 @@
         "--report-json",
         "tmp/memory-broker-wsl2d-backend-cov.json"
       ],
-      "packages": ["ramshared-wsl2d"],
-      "files": ["crates/ramshared-wsl2d/src/backend.rs"],
+      "packages": [
+        "ramshared-wsl2d"
+      ],
+      "files": [
+        "crates/ramshared-wsl2d/src/backend.rs"
+      ],
       "min": 80
     },
     {
       "id": "memory-broker-wsl2d-backend-gpu-test-relocation",
       "kind": "rust-ignored-test-relocation",
       "spec": "docs/specs/no-milestone/memory-broker/SPEC.md",
-      "files": ["crates/ramshared-wsl2d/src/backend.rs"],
+      "files": [
+        "crates/ramshared-wsl2d/src/backend.rs"
+      ],
       "base_revision": "69f7469fa999b7d079341ee6bf8ebb006d517b51",
       "base_source_sha256": "b58d99366164b7e898baa42492fead82416a6169ec06ce16fb274b06b6d99663",
       "verification": {
@@ -277,14 +297,54 @@
         "ignored_gpu_tests": [
           {
             "name": "vram_backend_serves_nbd_write_then_read",
-            "command": ["cargo", "test", "-p", "ramshared-wsl2d", "--test", "backend_gpu", "vram_backend_serves_nbd_write_then_read", "--", "--ignored", "--test-threads=1"],
-            "historical_command": ["cargo", "test", "-p", "ramshared-wsl2d", "backend::tests::vram_backend_serves_nbd_write_then_read", "--", "--ignored", "--test-threads=1"],
+            "command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "--test",
+              "backend_gpu",
+              "vram_backend_serves_nbd_write_then_read",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
+            "historical_command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "backend::tests::vram_backend_serves_nbd_write_then_read",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
             "evidence": "validation.md"
           },
           {
             "name": "vram_gauge_outros_captures_real_graphics_usage",
-            "command": ["cargo", "test", "-p", "ramshared-wsl2d", "--test", "backend_gpu", "vram_gauge_outros_captures_real_graphics_usage", "--", "--ignored", "--test-threads=1"],
-            "historical_command": ["cargo", "test", "-p", "ramshared-wsl2d", "backend::tests::vram_gauge_outros_captures_real_graphics_usage", "--", "--ignored", "--test-threads=1"],
+            "command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "--test",
+              "backend_gpu",
+              "vram_gauge_outros_captures_real_graphics_usage",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
+            "historical_command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "backend::tests::vram_gauge_outros_captures_real_graphics_usage",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
             "evidence": "validation.md"
           }
         ]
@@ -705,6 +765,30 @@
       "files": [
         "crates/ramshared-wsl2d/src/autotier.rs",
         "crates/ramshared-dxg/src/lib.rs"
+      ],
+      "min": 80
+    },
+    {
+      "id": "wsl2d-residency",
+      "kind": "rust-line-coverage",
+      "spec": "docs/specs/no-milestone/wsl2-cascade-swap/SPEC.md",
+      "command": [
+        "node",
+        "tools/ci/check-rust-slice-coverage.mjs",
+        "-p",
+        "ramshared-wsl2d",
+        "--files",
+        "crates/ramshared-wsl2d/src/residency.rs",
+        "--min",
+        "80",
+        "--report-json",
+        "tmp/wsl2d-residency-cov.json"
+      ],
+      "packages": [
+        "ramshared-wsl2d"
+      ],
+      "files": [
+        "crates/ramshared-wsl2d/src/residency.rs"
       ],
       "min": 80
     }

--- a/docs/specs/no-milestone/wsl2-cascade-swap/SPEC.md
+++ b/docs/specs/no-milestone/wsl2-cascade-swap/SPEC.md
@@ -422,3 +422,7 @@ PRD-2 is a historical record (describing VRAM as hot swap via ublk); Phase 0 (`w
 | **RNF-estab** | mlockall anti-deadlock | **maintained** | §6.2, §11 |
 
 Revised requirements do not go back to PRD-2 (preserving history) — they are reconciled here. Step 3 commits cite the SPEC section + RF covered (e.g., `feat(core): cascade priority — SPEC §1 / revises RF-3`).
+
+```bash
+node tools/ci/check-rust-slice-coverage.mjs -p ramshared-wsl2d --files crates/ramshared-wsl2d/src/residency.rs --min 80 --report-json tmp/wsl2d-residency-cov.json
+```


### PR DESCRIPTION
refactor(wsl2d): enforce semantic errors for cgroup memory parsing

## Resumo
Adiciona enum ResidencyError e `parse_cgroup_metric` com retorno semântico (-ENOENT e -EINVAL) ao invés de usar Option<u64> que mascara a causa da falha no procfs/cgroups.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(wsl2d) | Adiciona enum ResidencyError com ProcfsMissing e MalformedMetric | Retornos semânticos são princípio arquitetural (Specific & Semantic Errors). | Implementa traits Display (-ENOENT/-EINVAL) e Error. |
| refactor(wsl2d) | Cria função `parse_cgroup_metric` que retorna `Result<u64, ResidencyError>` | Isolar parse de cgroup do loop garantindo que ausência de arquivo vs parse errôneo sejam distinguidos. | Adiciona testes unitários cobrindo valid, malformed e missing. |

## Labels
type:refactor

## Validacao
cargo clippy -- -D warnings
cargo test -p ramshared-wsl2d

## Rollback trigger
Reverter se a função `parse_cgroup_metric` classificar incorretamente valores numéricos válidos resultando em falhas indevidas.

---
*PR created automatically by Jules for task [10190805693844601784](https://jules.google.com/task/10190805693844601784) started by @emersonbusson*