### PR TITLE
refactor(wsl2d): enforce -ERANGE semantic errors in ublk server

### DIFF
--- a/crates/ramshared-wsl2d/src/ublk_server.rs
+++ b/crates/ramshared-wsl2d/src/ublk_server.rs
@@ -29,6 +29,7 @@ use crate::{
 
 const EIO: i32 = -5;
 const EINVAL: i32 = -22;
+const ERANGE: i32 = -34;
 
 trait QueueServer {
     fn submit_initial_fetch(&mut self) -> io::Result<()>;
@@ -76,6 +77,12 @@ pub fn serve_request<B: BlockBackend + ?Sized>(
     let len = req.len as usize;
     if len > buf.len() {
         return EINVAL; // request larger than the available buffer
+    }
+
+    if matches!(req.cmd, Command::Read | Command::Write)
+        && req.offset.checked_add(req.len as u64).is_none_or(|end| end > backend.size_bytes())
+    {
+        return ERANGE;
     }
 
     let served = match req.cmd {

--- a/crates/ramshared-wsl2d/src/ublk_server.rs
+++ b/crates/ramshared-wsl2d/src/ublk_server.rs
@@ -80,7 +80,10 @@ pub fn serve_request<B: BlockBackend + ?Sized>(
     }
 
     if matches!(req.cmd, Command::Read | Command::Write)
-        && req.offset.checked_add(req.len as u64).is_none_or(|end| end > backend.size_bytes())
+        && req
+            .offset
+            .checked_add(req.len as u64)
+            .is_none_or(|end| end > backend.size_bytes())
     {
         return ERANGE;
     }

--- a/crates/ramshared-wsl2d/tests/ublk_server.rs
+++ b/crates/ramshared-wsl2d/tests/ublk_server.rs
@@ -1,3 +1,4 @@
+
 use ramshared_block::{Command, Request};
 use ramshared_wsl2d::{RamBackend, ublk_server};
 
@@ -48,9 +49,9 @@ fn serve_request_handles_flush_and_rejects_oversized_or_oob() {
         -22
     );
 
-    // READ outside the backend => -EIO.
+    // READ outside the backend => -ERANGE.
     assert_eq!(
         ublk_server::serve_request(&req(Command::Read, 51200, 512), &mut backend, &mut buf),
-        -5
+        -34 // -ERANGE
     );
 }


### PR DESCRIPTION
Mapped storage backend failures to semantic POSIX error codes by returning explicit `-ERANGE` (-34) for out-of-bounds offset bounds checking before passing control to the backend traits. Enforces safety and architectural invariants avoiding deeply nested conditions.

**Note:** Do not merge.

---
*PR created automatically by Jules for task [16240587156075360763](https://jules.google.com/task/16240587156075360763) started by @emersonbusson*