### PR TITLE
refactor(vram): add semantic error variants to VramError

### DIFF
--- a/crates/ramshared-vram/src/lib.rs
+++ b/crates/ramshared-vram/src/lib.rs
@@ -87,6 +87,11 @@ mod tests {
 
     #[test]
     fn test_vram_error_display() {
+        assert_eq!(VramError::Provider("test".to_string()).to_string(), "vram provider: test");
+        assert_eq!(
+            VramError::OutOfRange { off: 0, len: 10, size: 5 }.to_string(),
+            "vram out-of-range: off=0 len=10 size=5"
+        );
         assert_eq!(VramError::OutOfMemory.to_string(), "vram out of memory");
         assert_eq!(
             VramError::InvalidAlignment.to_string(),

--- a/crates/ramshared-vram/src/lib.rs
+++ b/crates/ramshared-vram/src/lib.rs
@@ -19,6 +19,12 @@ pub enum VramError {
     Provider(String),
     /// Attempted access out of the allocated memory range.
     OutOfRange { off: u64, len: u64, size: u64 },
+    /// Allocation failed due to out-of-memory.
+    OutOfMemory,
+    /// Invalid alignment for VRAM operation.
+    InvalidAlignment,
+    /// VRAM operation failed because resource is busy.
+    Busy,
 }
 
 impl fmt::Display for VramError {
@@ -28,6 +34,9 @@ impl fmt::Display for VramError {
             VramError::OutOfRange { off, len, size } => {
                 write!(f, "vram out-of-range: off={off} len={len} size={size}")
             }
+            VramError::OutOfMemory => write!(f, "vram out of memory"),
+            VramError::InvalidAlignment => write!(f, "vram invalid alignment"),
+            VramError::Busy => write!(f, "vram busy"),
         }
     }
 }
@@ -70,4 +79,16 @@ pub trait VramProvider {
 
     /// Returns free and total VRAM capacities in bytes (used by the residency canary — DT-3/9/11).
     fn mem_info(&self) -> Result<(u64, u64), VramError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vram_error_display() {
+        assert_eq!(VramError::OutOfMemory.to_string(), "vram out of memory");
+        assert_eq!(VramError::InvalidAlignment.to_string(), "vram invalid alignment");
+        assert_eq!(VramError::Busy.to_string(), "vram busy");
+    }
 }

--- a/crates/ramshared-vram/src/lib.rs
+++ b/crates/ramshared-vram/src/lib.rs
@@ -88,7 +88,10 @@ mod tests {
     #[test]
     fn test_vram_error_display() {
         assert_eq!(VramError::OutOfMemory.to_string(), "vram out of memory");
-        assert_eq!(VramError::InvalidAlignment.to_string(), "vram invalid alignment");
+        assert_eq!(
+            VramError::InvalidAlignment.to_string(),
+            "vram invalid alignment"
+        );
         assert_eq!(VramError::Busy.to_string(), "vram busy");
     }
 }

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -30,6 +30,7 @@ Process: [`SSDV3-PROMPTS.md`](SSDV3-PROMPTS.md) · rules: [`.claude/rules/ssdv3.
 | [`microsoft-native-vram-memory-tier`](specs/no-milestone/microsoft-native-vram-memory-tier/) | Microsoft-native VRAM memory tier — host-authoritative N3 RFC | Microsoft-native N3 — Design | #196 | UNQUALIFIED | — |
 | [`public-repository-hygiene`](specs/no-milestone/public-repository-hygiene/) | Public repository candidate integrity | — | — | PARTIAL | — |
 | [`release-promotion-publication`](specs/no-milestone/release-promotion-publication/) | Protected beta release promotion and publication | v0.9.0-beta.1 — WSL2 NBD | #195, #219, #221, #223, #225, #227, #229 | SPEC | — |
+| [`vram-provider`](specs/no-milestone/vram-provider/) | (no title) | — | — | SPEC | — |
 | [`vram-reclaim-pressure-matrix`](specs/no-milestone/vram-reclaim-pressure-matrix/) | PRD - VRAM reclaim pressure matrix | — | — | UNQUALIFIED | — |
 | [`windows-autonomous-broker-service`](specs/no-milestone/windows-autonomous-broker-service/) | Autonomous Windows broker service packaging and supervision | — | #156 | UNQUALIFIED | — |
 | [`windows-storport-cuda-vram`](specs/no-milestone/windows-storport-cuda-vram/) | Windows StorPort I/O backed by CUDA VRAM | — | #28 | UNQUALIFIED | — |

--- a/docs/governance/capability-observations.generated.json
+++ b/docs/governance/capability-observations.generated.json
@@ -707,6 +707,30 @@
         "registry_state": null
       },
       "documented_surface": {
+        "implementation_paths": [],
+        "test_paths": []
+      },
+      "documents": {
+        "implementation": null,
+        "prd": null,
+        "spec": "docs/specs/no-milestone/vram-provider/SPEC.md"
+      },
+      "observation_state": "OBSERVED",
+      "promotion": {
+        "authority": "docs/governance/claims.json",
+        "permitted": false,
+        "reason": "Only the qualified claims registry may publish capability state."
+      },
+      "slug": "vram-provider"
+    },
+    {
+      "claim_reconciliation": {
+        "claim_present": false,
+        "observation_is_not_a_claim": true,
+        "registry_path": "docs/governance/claims.json",
+        "registry_state": null
+      },
+      "documented_surface": {
         "implementation_paths": [
           "scripts/safety/cascade_pressure_integrity_worker.py"
         ],

--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -10,7 +10,9 @@
       "canonicalSource": "README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -20,7 +22,9 @@
       "canonicalSource": "ARCHITECTURE.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -30,7 +34,9 @@
       "canonicalSource": "CHANGELOG.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -40,7 +46,9 @@
       "canonicalSource": "CONTRIBUTING.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -50,7 +58,9 @@
       "canonicalSource": "MANIFESTO.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -60,7 +70,9 @@
       "canonicalSource": "ROADMAP.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -70,7 +82,9 @@
       "canonicalSource": "trovaldo.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -80,7 +94,9 @@
       "canonicalSource": "SECURITY.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -90,7 +106,9 @@
       "canonicalSource": "validation.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -100,7 +118,9 @@
       "canonicalSource": "TASK.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -110,7 +130,9 @@
       "canonicalSource": "superprompt.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -120,7 +142,9 @@
       "canonicalSource": "AGENTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -130,7 +154,9 @@
       "canonicalSource": "CLAUDE.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -140,7 +166,9 @@
       "canonicalSource": ".claude/rules/documentation.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -150,7 +178,9 @@
       "canonicalSource": "docs/DOCUMENTATION-PARITY.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -160,7 +190,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -170,7 +202,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -180,7 +214,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -190,7 +226,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -200,7 +238,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -210,7 +250,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -220,7 +262,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -230,7 +274,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -240,7 +286,9 @@
       "canonicalSource": "validation.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -250,7 +298,9 @@
       "canonicalSource": "validation.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -260,7 +310,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -270,7 +322,9 @@
       "canonicalSource": "docs/BENCHMARKS.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -280,7 +334,9 @@
       "canonicalSource": "docs/reliability/GAP-REGISTER.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -290,7 +346,9 @@
       "canonicalSource": "docs/ci/CI-TOPOLOGY.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -300,7 +358,9 @@
       "canonicalSource": "docs/decisions/README.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -310,7 +370,9 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -320,7 +382,9 @@
       "canonicalSource": "docs/labs/LAB-DISK-GUARD.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -330,7 +394,9 @@
       "canonicalSource": "README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -340,7 +406,9 @@
       "canonicalSource": "docs/methodology/kahneman-disciplines.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -350,7 +418,9 @@
       "canonicalSource": "docs/packaging/INSTALLABLES.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -360,7 +430,9 @@
       "canonicalSource": "docs/postmortems/TEMPLATE.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -370,7 +442,9 @@
       "canonicalSource": "docs/reference/REFERENCE-INDEX.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -380,7 +454,9 @@
       "canonicalSource": "docs/security/THREAT-MODEL.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:25:34Z"
     },
     {
@@ -390,7 +466,9 @@
       "canonicalSource": "docs/reliability/GAP-REGISTER.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -400,7 +478,9 @@
       "canonicalSource": "docs/postmortems/TEMPLATE.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-20T14:49:00Z"
     },
     {
@@ -410,7 +490,9 @@
       "canonicalSource": "docs/reliability/GAP-REGISTER.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -420,7 +502,9 @@
       "canonicalSource": "README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 30,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-20T14:49:00Z"
     },
     {
@@ -430,7 +514,9 @@
       "canonicalSource": "ARCHITECTURE.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-26T13:15:00Z"
     },
     {
@@ -440,7 +526,9 @@
       "canonicalSource": "docs/reviews/README.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -450,7 +538,9 @@
       "canonicalSource": "docs/runbooks/windows-autonomous-broker.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -460,7 +550,9 @@
       "canonicalSource": "drivers/windows/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -470,7 +562,9 @@
       "canonicalSource": "scripts/windows/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     }
   ],

--- a/docs/governance/rust-slice-coverage.json
+++ b/docs/governance/rust-slice-coverage.json
@@ -218,11 +218,25 @@
           "source": "crates/ramshared-cuda/src/lib.rs",
           "package": "ramshared-cuda",
           "test_module": "tests",
-          "cargo_test": ["cargo", "test", "-p", "ramshared-cuda", "--lib"],
+          "cargo_test": [
+            "cargo",
+            "test",
+            "-p",
+            "ramshared-cuda",
+            "--lib"
+          ],
           "ignored_gpu_tests": [
             {
               "name": "gpu_roundtrip_256mib",
-              "command": ["cargo", "test", "-p", "ramshared-cuda", "--", "--ignored", "--test-threads=1"],
+              "command": [
+                "cargo",
+                "test",
+                "-p",
+                "ramshared-cuda",
+                "--",
+                "--ignored",
+                "--test-threads=1"
+              ],
               "evidence": "validation.md"
             }
           ]
@@ -245,15 +259,21 @@
         "--report-json",
         "tmp/memory-broker-wsl2d-backend-cov.json"
       ],
-      "packages": ["ramshared-wsl2d"],
-      "files": ["crates/ramshared-wsl2d/src/backend.rs"],
+      "packages": [
+        "ramshared-wsl2d"
+      ],
+      "files": [
+        "crates/ramshared-wsl2d/src/backend.rs"
+      ],
       "min": 80
     },
     {
       "id": "memory-broker-wsl2d-backend-gpu-test-relocation",
       "kind": "rust-ignored-test-relocation",
       "spec": "docs/specs/no-milestone/memory-broker/SPEC.md",
-      "files": ["crates/ramshared-wsl2d/src/backend.rs"],
+      "files": [
+        "crates/ramshared-wsl2d/src/backend.rs"
+      ],
       "base_revision": "69f7469fa999b7d079341ee6bf8ebb006d517b51",
       "base_source_sha256": "b58d99366164b7e898baa42492fead82416a6169ec06ce16fb274b06b6d99663",
       "verification": {
@@ -277,14 +297,54 @@
         "ignored_gpu_tests": [
           {
             "name": "vram_backend_serves_nbd_write_then_read",
-            "command": ["cargo", "test", "-p", "ramshared-wsl2d", "--test", "backend_gpu", "vram_backend_serves_nbd_write_then_read", "--", "--ignored", "--test-threads=1"],
-            "historical_command": ["cargo", "test", "-p", "ramshared-wsl2d", "backend::tests::vram_backend_serves_nbd_write_then_read", "--", "--ignored", "--test-threads=1"],
+            "command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "--test",
+              "backend_gpu",
+              "vram_backend_serves_nbd_write_then_read",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
+            "historical_command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "backend::tests::vram_backend_serves_nbd_write_then_read",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
             "evidence": "validation.md"
           },
           {
             "name": "vram_gauge_outros_captures_real_graphics_usage",
-            "command": ["cargo", "test", "-p", "ramshared-wsl2d", "--test", "backend_gpu", "vram_gauge_outros_captures_real_graphics_usage", "--", "--ignored", "--test-threads=1"],
-            "historical_command": ["cargo", "test", "-p", "ramshared-wsl2d", "backend::tests::vram_gauge_outros_captures_real_graphics_usage", "--", "--ignored", "--test-threads=1"],
+            "command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "--test",
+              "backend_gpu",
+              "vram_gauge_outros_captures_real_graphics_usage",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
+            "historical_command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "backend::tests::vram_gauge_outros_captures_real_graphics_usage",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
             "evidence": "validation.md"
           }
         ]
@@ -705,6 +765,30 @@
       "files": [
         "crates/ramshared-wsl2d/src/autotier.rs",
         "crates/ramshared-dxg/src/lib.rs"
+      ],
+      "min": 80
+    },
+    {
+      "id": "vram-semantic-errors",
+      "kind": "rust-line-coverage",
+      "spec": "docs/specs/no-milestone/vram-provider/SPEC.md",
+      "command": [
+        "node",
+        "tools/ci/check-rust-slice-coverage.mjs",
+        "-p",
+        "ramshared-vram",
+        "--files",
+        "crates/ramshared-vram/src/lib.rs",
+        "--min",
+        "80",
+        "--report-json",
+        "tmp/vram-provider-cov.json"
+      ],
+      "packages": [
+        "ramshared-vram"
+      ],
+      "files": [
+        "crates/ramshared-vram/src/lib.rs"
       ],
       "min": 80
     }

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 258,
-    "classified": 247,
+    "total": 259,
+    "classified": 248,
     "excluded": 11,
     "unclassified": 0,
     "ambiguous": 0
@@ -1873,6 +1873,18 @@
     },
     {
       "path": "docs/specs/no-milestone/release-promotion-publication/SPEC.md",
+      "disposition": "classified",
+      "ruleId": "ssdv3-specifications",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "ssdv3",
+      "canonicalSource": "docs/SSDV3-PROMPTS.md",
+      "lifecycle": "reviewable",
+      "freshnessDays": 90
+    },
+    {
+      "path": "docs/specs/no-milestone/vram-provider/SPEC.md",
       "disposition": "classified",
       "ruleId": "ssdv3-specifications",
       "verification": {

--- a/docs/specs/no-milestone/vram-provider/SPEC.md
+++ b/docs/specs/no-milestone/vram-provider/SPEC.md
@@ -1,0 +1,6 @@
+# VRAM Provider Abstraction
+
+## Validation
+```bash
+node tools/ci/check-rust-slice-coverage.mjs -p ramshared-vram --files crates/ramshared-vram/src/lib.rs --min 80 --report-json tmp/vram-provider-cov.json
+```


### PR DESCRIPTION
Adds OutOfMemory, InvalidAlignment, and Busy variants to the VramError enum to replace generic string errors for allocation and lock failures, improving programmatic error handling in dependent crates.

---
*PR created automatically by Jules for task [12550647806579861818](https://jules.google.com/task/12550647806579861818) started by @emersonbusson*