### PR TITLE
refactor: map diagnose errors to specific exit codes

### DIFF
--- a/crates/ramshared-cli/src/diagnose.rs
+++ b/crates/ramshared-cli/src/diagnose.rs
@@ -109,14 +109,16 @@ fn parse_args(args: &[String]) -> Result<(PathBuf, bool), DiagnoseError> {
             other => {
                 return Err(DiagnoseError::InvalidArgs(format!(
                     "unsupported diagnose argument: {other}"
-                )))
+                )));
             }
         }
         i += 1;
     }
     Ok((
         path.ok_or_else(|| {
-            DiagnoseError::InvalidArgs("usage: ramshared diagnose --events PATH [--json]".to_string())
+            DiagnoseError::InvalidArgs(
+                "usage: ramshared diagnose --events PATH [--json]".to_string(),
+            )
         })?,
         json,
     ))

--- a/crates/ramshared-cli/src/diagnose.rs
+++ b/crates/ramshared-cli/src/diagnose.rs
@@ -38,6 +38,33 @@ struct Event {
     flag: Option<String>,
 }
 
+#[derive(Debug)]
+pub enum DiagnoseError {
+    InvalidArgs(String),
+    Io(String),
+    ParseJson(String),
+}
+
+impl std::fmt::Display for DiagnoseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidArgs(msg) => write!(f, "{msg}"),
+            Self::Io(msg) => write!(f, "{msg}"),
+            Self::ParseJson(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl DiagnoseError {
+    pub fn exit_code(&self) -> u8 {
+        match self {
+            Self::InvalidArgs(_) => 22, // EINVAL
+            Self::Io(_) => 2,           // ENOENT
+            Self::ParseJson(_) => 22,   // EINVAL for malformed json
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default, PartialEq)]
 struct Diagnosis {
     samples: usize,
@@ -52,9 +79,10 @@ struct Diagnosis {
     recommendations: Vec<String>,
 }
 
-pub fn run(args: &[String]) -> Result<(), String> {
+pub fn run(args: &[String]) -> Result<(), DiagnoseError> {
     let (path, json) = parse_args(args)?;
-    let text = fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let text = fs::read_to_string(&path)
+        .map_err(|e| DiagnoseError::Io(format!("read {}: {e}", path.display())))?;
     let diagnosis = diagnose_jsonl(&text)?;
     if json {
         println!("{}", render_json(&diagnosis));
@@ -64,7 +92,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
     Ok(())
 }
 
-fn parse_args(args: &[String]) -> Result<(PathBuf, bool), String> {
+fn parse_args(args: &[String]) -> Result<(PathBuf, bool), DiagnoseError> {
     let mut path = None;
     let mut json = false;
     let mut i = 0;
@@ -73,30 +101,36 @@ fn parse_args(args: &[String]) -> Result<(PathBuf, bool), String> {
             "--json" => json = true,
             "--events" => {
                 i += 1;
-                let value = args
-                    .get(i)
-                    .ok_or_else(|| "--events requires a path".to_string())?;
+                let value = args.get(i).ok_or_else(|| {
+                    DiagnoseError::InvalidArgs("--events requires a path".to_string())
+                })?;
                 path = Some(PathBuf::from(value));
             }
-            other => return Err(format!("unsupported diagnose argument: {other}")),
+            other => {
+                return Err(DiagnoseError::InvalidArgs(format!(
+                    "unsupported diagnose argument: {other}"
+                )))
+            }
         }
         i += 1;
     }
     Ok((
-        path.ok_or_else(|| "usage: ramshared diagnose --events PATH [--json]".to_string())?,
+        path.ok_or_else(|| {
+            DiagnoseError::InvalidArgs("usage: ramshared diagnose --events PATH [--json]".to_string())
+        })?,
         json,
     ))
 }
 
-fn diagnose_jsonl(text: &str) -> Result<Diagnosis, String> {
+fn diagnose_jsonl(text: &str) -> Result<Diagnosis, DiagnoseError> {
     let mut events = Vec::new();
     for (idx, line) in text.lines().enumerate() {
         let line = line.trim();
         if line.is_empty() {
             continue;
         }
-        let event: Event =
-            serde_json::from_str(line).map_err(|e| format!("line {}: {e}", idx + 1))?;
+        let event: Event = serde_json::from_str(line)
+            .map_err(|e| DiagnoseError::ParseJson(format!("line {}: {e}", idx + 1)))?;
         events.push(event);
     }
     Ok(diagnose_events(&events))

--- a/crates/ramshared-cli/src/main.rs
+++ b/crates/ramshared-cli/src/main.rs
@@ -440,7 +440,13 @@ impl CliActionRunner for SystemCliActions {
         _stdout: &mut dyn Write,
         stderr: &mut dyn Write,
     ) -> ExitCode {
-        to_exit(diagnose::run(args), stderr)
+        match diagnose::run(args) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                let _ = writeln!(stderr, "{e}");
+                ExitCode::from(e.exit_code())
+            }
+        }
     }
 
     fn stress(

--- a/crates/ramshared-cli/tests/cli_dispatch.rs
+++ b/crates/ramshared-cli/tests/cli_dispatch.rs
@@ -258,3 +258,15 @@ fn cli_stress_battery_and_seismic_log() {
         let _ = fs::remove_file(log_path);
     }
 }
+
+#[test]
+fn cli_diagnose_errors_semantic_codes() {
+    let missing_args = run_cli(&["diagnose"]);
+    assert_eq!(missing_args.status.code(), Some(22)); // EINVAL
+
+    let missing_file = run_cli(&["diagnose", "--events", "/does/not/exist.jsonl"]);
+    assert_eq!(missing_file.status.code(), Some(2)); // ENOENT
+
+    let invalid_flag = run_cli(&["diagnose", "--invalid-flag"]);
+    assert_eq!(invalid_flag.status.code(), Some(22)); // EINVAL
+}


### PR DESCRIPTION
## Resumo
Refactored the `ramshared diagnose` command to return semantic, typed errors rather than generic strings. Implemented a `DiagnoseError` enum that maps specific failure modes (invalid arguments, I/O errors, JSON parsing errors) to correct POSIX exit codes (e.g., `EINVAL` (22), `ENOENT` (2)). This satisfies the "Specific & Semantic Error Returns" architectural principle.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor: map diagnose errors to specific exit codes | Introduced `DiagnoseError` and updated `diagnose::run` and `SystemCliActions::diagnose` to use it. Added negative tests to verify the exit codes. | To eliminate generic error strings and ensure the CLI returns semantic failure codes for proper script integrations. | Modified `diagnose.rs`, `main.rs`, and `cli_dispatch.rs`. |

## Labels
type:refactor

## Validacao
Ran `cargo test -p ramshared-cli diagnose` and `cargo clippy -- -D warnings`. Both passed successfully. Tests were added to ensure missing arguments return exit code 22 and missing files return exit code 2.

## Rollback trigger
If the new exit codes unexpectedly break downstream shell scripts that incorrectly rely on the old generic exit code `1` instead of POSIX standards, or if there is a behavioral regression in error handling. Do not merge until reviewed.

---
*PR created automatically by Jules for task [2519883688392518517](https://jules.google.com/task/2519883688392518517) started by @emersonbusson*