### PR TITLE
feat(dxg): map ioctl OS errors to typed DxgError variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,9 @@ dependencies = [
 [[package]]
 name = "ramshared-dxg"
 version = "0.1.0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "ramshared-integrity"

--- a/crates/ramshared-dxg/Cargo.toml
+++ b/crates/ramshared-dxg/Cargo.toml
@@ -10,3 +10,6 @@ publish.workspace = true
 [lints.clippy]
 unwrap_used = "deny"
 expect_used = "deny"
+
+[dependencies]
+libc = "0.2.189"

--- a/crates/ramshared-dxg/src/lib.rs
+++ b/crates/ramshared-dxg/src/lib.rs
@@ -81,6 +81,10 @@ pub trait GpuBudgetProvider {
 pub enum DxgError {
     Unavailable(String),
     Io(String),
+    DeviceNotFound,
+    UnsupportedHardware,
+    BufferOverflow,
+    PermissionDenied,
     NoAdapters,
     AmbiguousAdapters(usize),
     AdapterNotFound(AdapterLuid),
@@ -93,6 +97,10 @@ impl fmt::Display for DxgError {
         match self {
             Self::Unavailable(message) => write!(f, "dxg unavailable: {message}"),
             Self::Io(message) => write!(f, "dxg ioctl failed: {message}"),
+            Self::DeviceNotFound => write!(f, "dxg device not found"),
+            Self::UnsupportedHardware => write!(f, "dxg unsupported hardware"),
+            Self::BufferOverflow => write!(f, "dxg buffer overflow"),
+            Self::PermissionDenied => write!(f, "dxg permission denied"),
             Self::NoAdapters => write!(f, "dxg returned no adapters"),
             Self::AmbiguousAdapters(count) => {
                 write!(f, "dxg returned {count} adapters; explicit LUID required")
@@ -107,6 +115,16 @@ impl fmt::Display for DxgError {
 impl std::error::Error for DxgError {}
 
 impl DxgError {
+    pub fn from_sys_error(error: std::io::Error) -> Self {
+        match error.raw_os_error() {
+            Some(libc::ENODEV) => Self::DeviceNotFound,
+            Some(libc::ENOTTY) => Self::UnsupportedHardware,
+            Some(libc::EOVERFLOW) => Self::BufferOverflow,
+            Some(libc::EPERM) | Some(libc::EACCES) => Self::PermissionDenied,
+            _ => Self::Io(error.to_string()),
+        }
+    }
+
     pub fn permits_startup_fallback(&self) -> bool {
         matches!(self, Self::Unavailable(_))
     }
@@ -259,7 +277,7 @@ fn ioctl_mut<T>(file: &File, request: u64, value: &mut T) -> Result<(), DxgError
     // alive for the synchronous ioctl. The kernel validates nested pointers.
     let result = unsafe { ioctl(file.as_raw_fd(), request, value as *mut T) };
     if result < 0 {
-        Err(DxgError::Io(std::io::Error::last_os_error().to_string()))
+        Err(DxgError::from_sys_error(std::io::Error::last_os_error()))
     } else {
         Ok(())
     }
@@ -350,6 +368,32 @@ mod tests {
     }
 
     #[test]
+    fn ioctl_maps_kernel_errors_to_typed_variants() {
+        assert_eq!(
+            super::DxgError::from_sys_error(std::io::Error::from_raw_os_error(19)),
+            super::DxgError::DeviceNotFound
+        );
+        assert_eq!(
+            super::DxgError::from_sys_error(std::io::Error::from_raw_os_error(25)),
+            super::DxgError::UnsupportedHardware
+        );
+        assert_eq!(
+            super::DxgError::from_sys_error(std::io::Error::from_raw_os_error(75)),
+            super::DxgError::BufferOverflow
+        );
+        assert_eq!(
+            super::DxgError::from_sys_error(std::io::Error::from_raw_os_error(13)),
+            super::DxgError::PermissionDenied
+        );
+        assert_eq!(
+            super::DxgError::from_sys_error(std::io::Error::from_raw_os_error(1)),
+            super::DxgError::PermissionDenied
+        );
+        let unknown = super::DxgError::from_sys_error(std::io::Error::from_raw_os_error(9999));
+        assert!(matches!(unknown, super::DxgError::Io(_)));
+    }
+
+    #[test]
     fn all_error_messages_and_luid_are_stable() {
         let luid = AdapterLuid {
             low: 0x12,
@@ -364,6 +408,10 @@ mod tests {
             super::DxgError::AdapterNotFound(luid),
             super::DxgError::TooManyAdapters(65),
             super::DxgError::Malformed("field"),
+            super::DxgError::DeviceNotFound,
+            super::DxgError::UnsupportedHardware,
+            super::DxgError::BufferOverflow,
+            super::DxgError::PermissionDenied,
         ];
         for error in cases {
             assert!(!error.to_string().is_empty());

--- a/fix_pr_body.sh
+++ b/fix_pr_body.sh
@@ -1,1 +1,1 @@
-echo "Doing nothing, will fix via submit"
+echo "Fixing via submit"

--- a/fix_pr_body.sh
+++ b/fix_pr_body.sh
@@ -1,0 +1,1 @@
+echo "Doing nothing, will fix via submit"


### PR DESCRIPTION
## Resumo
Map raw OS error codes (-ENODEV, -ENOTTY, -EOVERFLOW, -EPERM, -EACCES) returned by the kernel driver IOCTL to strongly-typed semantic domain enum variants (`DeviceNotFound`, `UnsupportedHardware`, `BufferOverflow`, `PermissionDenied`) instead of returning generic IO errors. Now uses `libc` constants.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(dxg): map ioctl OS errors to DxgError variants | Adicionou novas variantes semanticas e logica de mapeamento | Melhorar o tratamento de erros arquitetural, evitando uso de strings soltas | `DxgError::from_sys_error` mapeia libc::ENODEV etc., ajustando `ioctl_mut`. Adicionados testes correspondentes. Adicionou `libc` nas dependencias de dx. |

## Labels
type:refactor

## Validacao
cargo test -p ramshared-dxg && cargo clippy -p ramshared-dxg -- -D warnings

## Rollback trigger
Se quebrar a compilação no Windows ou reportar comportamentos incorretos de acesso via kernel driver/WSL.

---
*PR created automatically by Jules for task [3084181021901483101](https://jules.google.com/task/3084181021901483101) started by @emersonbusson*