### PR TITLE
feat: validate peer block size is a power of two between 512 and 65536

### DIFF
--- a/crates/ramshared-block/src/handshake.rs
+++ b/crates/ramshared-block/src/handshake.rs
@@ -52,6 +52,7 @@ impl core::error::Error for HandshakeError {}
 pub struct Export {
     pub name: String,
     pub size: u64,
+    pub block_size: u32,
 }
 
 fn read_u32<R: Read>(r: &mut R) -> io::Result<u32> {
@@ -125,6 +126,17 @@ pub fn server_handshake<R: Read, W: Write>(
     exports: &[Export],
     tx_flags: u16,
 ) -> Result<usize, HandshakeError> {
+
+    // GUARD: Ensure all exports have valid hardware-aligned block sizes.
+    for export in exports {
+        if !export.block_size.is_power_of_two() || export.block_size < 512 || export.block_size > 65536 {
+            return Err(HandshakeError::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "peer block size out of bounds",
+            )));
+        }
+    }
+
     // Greeting: NBDMAGIC + IHAVEOPT + handshake flags.
     w.write_all(&NBDMAGIC.to_be_bytes())?;
     w.write_all(&IHAVEOPT.to_be_bytes())?;
@@ -232,6 +244,7 @@ mod tests {
         vec![Export {
             name: "default".to_string(),
             size,
+            block_size: 4096,
         }]
     }
 
@@ -305,10 +318,12 @@ mod tests {
             Export {
                 name: "s0".to_string(),
                 size: 4096,
+                block_size: 4096,
             },
             Export {
                 name: "s1".to_string(),
                 size: 8192,
+                block_size: 4096,
             },
         ];
         let mut r = client_stream(NBD_FLAG_C_NO_ZEROES, NBD_OPT_GO, &go_data(b"s1"));
@@ -355,10 +370,12 @@ mod tests {
             Export {
                 name: "s0".to_string(),
                 size: 4096,
+                block_size: 4096,
             },
             Export {
                 name: "s1".to_string(),
                 size: 8192,
+                block_size: 4096,
             },
         ];
         let mut r = client_stream(NBD_FLAG_C_NO_ZEROES, NBD_OPT_EXPORT_NAME, b"");
@@ -366,5 +383,23 @@ mod tests {
         let idx = server_handshake(&mut r, &mut out, &exports, 1).unwrap();
         assert_eq!(idx, 0);
         assert_eq!(u64::from_be_bytes(out[18..26].try_into().unwrap()), 4096);
+    }
+
+    #[test]
+    fn invalid_block_size_returns_err() {
+        let mut r = client_stream(NBD_FLAG_C_NO_ZEROES, NBD_OPT_EXPORT_NAME, b"");
+        let mut out = Vec::new();
+
+        let invalid_exports = vec![
+            Export { name: "default".to_string(), size: 4096, block_size: 511 }, // Too small
+            Export { name: "default".to_string(), size: 4096, block_size: 65537 }, // Too large
+            Export { name: "default".to_string(), size: 4096, block_size: 1000 }, // Not power of two
+            Export { name: "default".to_string(), size: 4096, block_size: 0 }, // Zero
+        ];
+
+        for invalid_export in invalid_exports {
+            let res = server_handshake(&mut r, &mut out, &[invalid_export], 1);
+            assert!(matches!(res, Err(HandshakeError::Io(e)) if e.kind() == std::io::ErrorKind::InvalidInput));
+        }
     }
 }

--- a/crates/ramshared-block/src/handshake.rs
+++ b/crates/ramshared-block/src/handshake.rs
@@ -126,10 +126,12 @@ pub fn server_handshake<R: Read, W: Write>(
     exports: &[Export],
     tx_flags: u16,
 ) -> Result<usize, HandshakeError> {
-
     // GUARD: Ensure all exports have valid hardware-aligned block sizes.
     for export in exports {
-        if !export.block_size.is_power_of_two() || export.block_size < 512 || export.block_size > 65536 {
+        if !export.block_size.is_power_of_two()
+            || export.block_size < 512
+            || export.block_size > 65536
+        {
             return Err(HandshakeError::Io(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "peer block size out of bounds",
@@ -391,15 +393,33 @@ mod tests {
         let mut out = Vec::new();
 
         let invalid_exports = vec![
-            Export { name: "default".to_string(), size: 4096, block_size: 511 }, // Too small
-            Export { name: "default".to_string(), size: 4096, block_size: 65537 }, // Too large
-            Export { name: "default".to_string(), size: 4096, block_size: 1000 }, // Not power of two
-            Export { name: "default".to_string(), size: 4096, block_size: 0 }, // Zero
+            Export {
+                name: "default".to_string(),
+                size: 4096,
+                block_size: 511,
+            }, // Too small
+            Export {
+                name: "default".to_string(),
+                size: 4096,
+                block_size: 65537,
+            }, // Too large
+            Export {
+                name: "default".to_string(),
+                size: 4096,
+                block_size: 1000,
+            }, // Not power of two
+            Export {
+                name: "default".to_string(),
+                size: 4096,
+                block_size: 0,
+            }, // Zero
         ];
 
         for invalid_export in invalid_exports {
             let res = server_handshake(&mut r, &mut out, &[invalid_export], 1);
-            assert!(matches!(res, Err(HandshakeError::Io(e)) if e.kind() == std::io::ErrorKind::InvalidInput));
+            assert!(
+                matches!(res, Err(HandshakeError::Io(e)) if e.kind() == std::io::ErrorKind::InvalidInput)
+            );
         }
     }
 }

--- a/crates/ramshared-wsl2d/src/conn.rs
+++ b/crates/ramshared-wsl2d/src/conn.rs
@@ -384,6 +384,7 @@ mod tests {
         Arc::new(vec![Export {
             name: "default".to_string(),
             size,
+            block_size: 4096,
         }])
     }
 

--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -2747,6 +2747,7 @@ fn run_nbd_with_startup<P: VramProvider, S: NbdRuntimeStarter>(
     let exports = std::sync::Arc::new(vec![ramshared_block::handshake::Export {
         name: "default".to_string(),
         size: device_size,
+        block_size: 4096,
     }]);
     let (jobs_tx, jobs_rx) = std::sync::mpsc::sync_channel::<WMsg>(CHAN_CAP);
     starter.start_acceptor(listener, exports, tx_flags, jobs_tx.clone())?;
@@ -3994,7 +3995,7 @@ fn broker_setup_with_acceptors(
         slice_map
             .exports()
             .into_iter()
-            .map(|(name, size)| ramshared_block::handshake::Export { name, size })
+            .map(|(name, size)| ramshared_block::handshake::Export { name, size, block_size: 4096 })
             .collect::<Vec<_>>(),
     );
 

--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -3995,7 +3995,11 @@ fn broker_setup_with_acceptors(
         slice_map
             .exports()
             .into_iter()
-            .map(|(name, size)| ramshared_block::handshake::Export { name, size, block_size: 4096 })
+            .map(|(name, size)| ramshared_block::handshake::Export {
+                name,
+                size,
+                block_size: 4096,
+            })
             .collect::<Vec<_>>(),
     );
 


### PR DESCRIPTION
Add physical hardware bounds checking on the NBD peer block size to enforce alignment mapping strictly to powers of two between 512 and 65536 bytes. Guard clauses use early-returns in server_handshake, throwing clear io::ErrorKind::InvalidInput, rather than nesting deep checks. Extends Export structs across ramshared-block and ramshared-wsl2d.

---
*PR created automatically by Jules for task [3236421187498727639](https://jules.google.com/task/3236421187498727639) started by @emersonbusson*