### PR TITLE
semantic ProtocolError enum for client IPC framing failures

### DIFF
--- a/crates/ramshared-agent/src/main.rs
+++ b/crates/ramshared-agent/src/main.rs
@@ -221,7 +221,9 @@ fn run_status(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
     for _ in 0..50 {
         let response = match read_msg(&mut r) {
             Ok(response) => response,
-            Err(ramshared_broker::protocol::ProtocolError::ConnectionClosed(error)) if matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock) => {
+            Err(ramshared_broker::protocol::ProtocolError::ConnectionClosed(error))
+                if matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock) =>
+            {
                 return Err(format!(
                     "broker status timed out after {}s",
                     STATUS_IO_TIMEOUT.as_secs()

--- a/crates/ramshared-agent/src/main.rs
+++ b/crates/ramshared-agent/src/main.rs
@@ -221,7 +221,7 @@ fn run_status(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
     for _ in 0..50 {
         let response = match read_msg(&mut r) {
             Ok(response) => response,
-            Err(error) if matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock) => {
+            Err(ramshared_broker::protocol::ProtocolError::ConnectionClosed(error)) if matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock) => {
                 return Err(format!(
                     "broker status timed out after {}s",
                     STATUS_IO_TIMEOUT.as_secs()

--- a/crates/ramshared-broker/src/protocol.rs
+++ b/crates/ramshared-broker/src/protocol.rs
@@ -215,10 +215,7 @@ mod tests {
         let e = super::ProtocolError::PayloadTooLarge;
         assert_eq!(e.to_string(), "payload too large (exceeds MAX_LINE_BYTES)");
 
-        let e = super::ProtocolError::ConnectionClosed(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "foo",
-        ));
+        let e = super::ProtocolError::ConnectionClosed(std::io::Error::other("foo"));
         assert_eq!(e.to_string(), "connection closed: foo");
     }
 

--- a/crates/ramshared-broker/src/protocol.rs
+++ b/crates/ramshared-broker/src/protocol.rs
@@ -129,37 +129,63 @@ pub struct SliceIo {
 }
 
 /// Serializes `msg` + `'\n'` and flushes (one message per line).
-pub fn write_msg<W: Write>(w: &mut W, msg: &Msg) -> std::io::Result<()> {
+#[derive(Debug)]
+pub enum ProtocolError {
+    BadMagic(String),
+    UnsupportedVersion(u32),
+    PayloadTooLarge,
+    ConnectionClosed(std::io::Error),
+}
+
+impl std::fmt::Display for ProtocolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadMagic(s) => write!(f, "bad magic: {s}"),
+            Self::UnsupportedVersion(v) => write!(f, "unsupported version: {v}"),
+            Self::PayloadTooLarge => write!(f, "payload too large (exceeds MAX_LINE_BYTES)"),
+            Self::ConnectionClosed(e) => write!(f, "connection closed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ProtocolError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ConnectionClosed(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+pub fn write_msg<W: Write>(w: &mut W, msg: &Msg) -> Result<(), ProtocolError> {
     let mut line = serde_json::to_vec(msg)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        .map_err(|e| ProtocolError::BadMagic(e.to_string()))?;
     line.push(b'\n');
-    w.write_all(&line)?;
-    w.flush()
+    w.write_all(&line).map_err(ProtocolError::ConnectionClosed)?;
+    w.flush().map_err(ProtocolError::ConnectionClosed)
 }
 
 /// Reads a line (up to [`MAX_LINE_BYTES`]) and deserializes it.
 ///
 /// `Ok(None)` on clean EOF; `Err` on giant line, invalid JSON or unknown shape.
 /// `take(MAX_LINE_BYTES + 1)` ensures we never read/allocate beyond the cap (anti-DoS).
-pub fn read_msg<R: BufRead>(r: &mut R) -> std::io::Result<Option<Msg>> {
+pub fn read_msg<R: BufRead>(r: &mut R) -> Result<Option<Msg>, ProtocolError> {
     let mut buf = Vec::new();
     let n = r
         .by_ref()
         .take(MAX_LINE_BYTES as u64 + 1)
-        .read_until(b'\n', &mut buf)?;
+        .read_until(b'\n', &mut buf)
+        .map_err(ProtocolError::ConnectionClosed)?;
     if n == 0 {
         return Ok(None); // clean EOF
     }
     let had_newline = buf.last() == Some(&b'\n');
     if !had_newline && buf.len() > MAX_LINE_BYTES {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "line exceeds MAX_LINE_BYTES",
-        ));
+        return Err(ProtocolError::PayloadTooLarge);
     }
     let line = buf.strip_suffix(b"\n").unwrap_or(&buf);
     let msg = serde_json::from_slice::<Msg>(line)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        .map_err(|e| ProtocolError::BadMagic(e.to_string()))?;
     Ok(Some(msg))
 }
 
@@ -176,6 +202,21 @@ mod tests {
         assert_eq!(buf.last(), Some(&b'\n'), "must end in a single line");
         let mut cur = Cursor::new(buf);
         read_msg(&mut cur).unwrap().unwrap()
+    }
+
+    #[test]
+    fn protocol_error_display() {
+        let e = super::ProtocolError::BadMagic("test".into());
+        assert_eq!(e.to_string(), "bad magic: test");
+
+        let e = super::ProtocolError::UnsupportedVersion(42);
+        assert_eq!(e.to_string(), "unsupported version: 42");
+
+        let e = super::ProtocolError::PayloadTooLarge;
+        assert_eq!(e.to_string(), "payload too large (exceeds MAX_LINE_BYTES)");
+
+        let e = super::ProtocolError::ConnectionClosed(std::io::Error::new(std::io::ErrorKind::Other, "foo"));
+        assert_eq!(e.to_string(), "connection closed: foo");
     }
 
     #[test]

--- a/crates/ramshared-broker/src/protocol.rs
+++ b/crates/ramshared-broker/src/protocol.rs
@@ -158,10 +158,10 @@ impl std::error::Error for ProtocolError {
 }
 
 pub fn write_msg<W: Write>(w: &mut W, msg: &Msg) -> Result<(), ProtocolError> {
-    let mut line = serde_json::to_vec(msg)
-        .map_err(|e| ProtocolError::BadMagic(e.to_string()))?;
+    let mut line = serde_json::to_vec(msg).map_err(|e| ProtocolError::BadMagic(e.to_string()))?;
     line.push(b'\n');
-    w.write_all(&line).map_err(ProtocolError::ConnectionClosed)?;
+    w.write_all(&line)
+        .map_err(ProtocolError::ConnectionClosed)?;
     w.flush().map_err(ProtocolError::ConnectionClosed)
 }
 
@@ -184,8 +184,8 @@ pub fn read_msg<R: BufRead>(r: &mut R) -> Result<Option<Msg>, ProtocolError> {
         return Err(ProtocolError::PayloadTooLarge);
     }
     let line = buf.strip_suffix(b"\n").unwrap_or(&buf);
-    let msg = serde_json::from_slice::<Msg>(line)
-        .map_err(|e| ProtocolError::BadMagic(e.to_string()))?;
+    let msg =
+        serde_json::from_slice::<Msg>(line).map_err(|e| ProtocolError::BadMagic(e.to_string()))?;
     Ok(Some(msg))
 }
 
@@ -215,7 +215,10 @@ mod tests {
         let e = super::ProtocolError::PayloadTooLarge;
         assert_eq!(e.to_string(), "payload too large (exceeds MAX_LINE_BYTES)");
 
-        let e = super::ProtocolError::ConnectionClosed(std::io::Error::new(std::io::ErrorKind::Other, "foo"));
+        let e = super::ProtocolError::ConnectionClosed(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "foo",
+        ));
         assert_eq!(e.to_string(), "connection closed: foo");
     }
 


### PR DESCRIPTION
Introduced a typed, semantic `ProtocolError` enum to replace generic string and io errors in client IPC parsing (`read_msg` and `write_msg`). Modified `ramshared-agent` call-sites appropriately. All tests and clippy checks pass.

---
*PR created automatically by Jules for task [2788203922614015296](https://jules.google.com/task/2788203922614015296) started by @emersonbusson*