### PR TITLE
refactor(block): use typed semantic errors for block protocol

### DIFF
--- a/crates/ramshared-block/src/protocol.rs
+++ b/crates/ramshared-block/src/protocol.rs
@@ -75,7 +75,9 @@ impl fmt::Display for ProtocolError {
             ProtocolError::TruncatedPayload { got, need } => {
                 write!(f, "truncated payload: {got} < {need}")
             }
-            ProtocolError::InvalidHeader(m) => write!(f, "invalid request magic (header): {m:#010x}"),
+            ProtocolError::InvalidHeader(m) => {
+                write!(f, "invalid request magic (header): {m:#010x}")
+            }
             ProtocolError::ChecksumMismatch => write!(f, "checksum mismatch"),
         }
     }

--- a/crates/ramshared-block/src/protocol.rs
+++ b/crates/ramshared-block/src/protocol.rs
@@ -64,17 +64,19 @@ pub struct Request {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ProtocolError {
-    ShortBuffer { got: usize, need: usize },
-    BadMagic(u32),
+    TruncatedPayload { got: usize, need: usize },
+    InvalidHeader(u32),
+    ChecksumMismatch,
 }
 
 impl fmt::Display for ProtocolError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ProtocolError::ShortBuffer { got, need } => {
-                write!(f, "short buffer: {got} < {need}")
+            ProtocolError::TruncatedPayload { got, need } => {
+                write!(f, "truncated payload: {got} < {need}")
             }
-            ProtocolError::BadMagic(m) => write!(f, "invalid request magic: {m:#010x}"),
+            ProtocolError::InvalidHeader(m) => write!(f, "invalid request magic (header): {m:#010x}"),
+            ProtocolError::ChecksumMismatch => write!(f, "checksum mismatch"),
         }
     }
 }
@@ -94,14 +96,14 @@ fn be64(b: &[u8]) -> u64 {
 /// Parses the 28-byte header. Validates size and magic.
 pub fn parse_request(buf: &[u8]) -> Result<Request, ProtocolError> {
     if buf.len() < REQUEST_LEN {
-        return Err(ProtocolError::ShortBuffer {
+        return Err(ProtocolError::TruncatedPayload {
             got: buf.len(),
             need: REQUEST_LEN,
         });
     }
     let magic = be32(&buf[0..4]);
     if magic != NBD_REQUEST_MAGIC {
-        return Err(ProtocolError::BadMagic(magic));
+        return Err(ProtocolError::InvalidHeader(magic));
     }
     Ok(Request {
         flags: be16(&buf[4..6]),
@@ -153,7 +155,7 @@ mod tests {
         raw[0] = 0xff;
         assert!(matches!(
             parse_request(&raw),
-            Err(ProtocolError::BadMagic(_))
+            Err(ProtocolError::InvalidHeader(_))
         ));
     }
 
@@ -161,7 +163,7 @@ mod tests {
     fn rejects_short_buffer() {
         assert!(matches!(
             parse_request(&[0u8; 10]),
-            Err(ProtocolError::ShortBuffer { need: 28, .. })
+            Err(ProtocolError::TruncatedPayload { need: 28, .. })
         ));
     }
 


### PR DESCRIPTION
## Resumo
Refatorar `ProtocolError` em `protocol.rs` para utilizar nomes mais semânticos (`InvalidHeader` e `TruncatedPayload`) e adicionar `ChecksumMismatch`, de acordo com o princípio Specific & Semantic Errors.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | Renomeou enum variants e implementou ChecksumMismatch | Melhorar o tratamento de erro semântico | Adicionado erro `ChecksumMismatch`, alterado `ShortBuffer` para `TruncatedPayload` e `BadMagic` para `InvalidHeader`. |

## Labels
type:refactor

## Validacao
cargo test -p ramshared-block
cargo clippy -p ramshared-block -- -D warnings

## Rollback trigger
Se as alterações quebrarem a compilação ou se algum teste de block protocol falhar na master.

---
*PR created automatically by Jules for task [15858227917257489531](https://jules.google.com/task/15858227917257489531) started by @emersonbusson*