### PR TITLE
feat: map Windows named pipe errors to semantic WinBrokerError

### DIFF
--- a/crates/ramshared-winbroker/src/lib.rs
+++ b/crates/ramshared-winbroker/src/lib.rs
@@ -20,6 +20,46 @@ pub enum BrokerPhase {
     Failed,
 }
 
+#[derive(Debug)]
+pub enum WinBrokerError {
+    PipeBusy,
+    NoData,
+    BrokenPipe,
+    Other(std::io::Error),
+}
+
+impl std::error::Error for WinBrokerError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Other(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for WinBrokerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PipeBusy => write!(f, "Pipe is busy (-EBUSY)"),
+            Self::NoData => write!(f, "No data available (-ENODATA)"),
+            Self::BrokenPipe => write!(f, "Broken pipe (-EPIPE)"),
+            Self::Other(error) => write!(f, "Broker I/O error: {}", error),
+        }
+    }
+}
+
+impl From<std::io::Error> for WinBrokerError {
+    fn from(error: std::io::Error) -> Self {
+        match error.raw_os_error() {
+            Some(231) => Self::PipeBusy,     // ERROR_PIPE_BUSY
+            Some(232) => Self::NoData,       // ERROR_NO_DATA
+            Some(109) => Self::BrokenPipe,   // ERROR_BROKEN_PIPE
+            _ => Self::Other(error),
+        }
+    }
+}
+
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct BrokerConfigV1 {
@@ -243,6 +283,24 @@ mod tests {
             tenant: tenant.into(),
             transport: TransportKind::WinDrive,
         }
+    }
+
+    #[test]
+    fn winbrokererror_mapping() {
+        use super::WinBrokerError;
+        use std::io;
+
+        let e = io::Error::from_raw_os_error(231);
+        assert!(matches!(WinBrokerError::from(e), WinBrokerError::PipeBusy));
+
+        let e = io::Error::from_raw_os_error(232);
+        assert!(matches!(WinBrokerError::from(e), WinBrokerError::NoData));
+
+        let e = io::Error::from_raw_os_error(109);
+        assert!(matches!(WinBrokerError::from(e), WinBrokerError::BrokenPipe));
+
+        let e = io::Error::from_raw_os_error(5); // Access denied
+        assert!(matches!(WinBrokerError::from(e), WinBrokerError::Other(_)));
     }
 
     #[test]


### PR DESCRIPTION
Introduces WinBrokerError enum to explicitly map Windows named pipe errors (ERROR_PIPE_BUSY, ERROR_NO_DATA, ERROR_BROKEN_PIPE) into semantic variants in crates/ramshared-winbroker/src/lib.rs, resolving generic error returns.

---
*PR created automatically by Jules for task [14828645724191330328](https://jules.google.com/task/14828645724191330328) started by @emersonbusson*