### PR TITLE
refactor(broker): specific semantic errors for slice allocations

### DIFF
--- a/crates/ramshared-broker/src/slices.rs
+++ b/crates/ramshared-broker/src/slices.rs
@@ -14,8 +14,9 @@ pub struct SliceMap {
 /// Slice transition/lookup error.
 #[derive(Debug, PartialEq, Eq)]
 pub enum SliceError {
-    UnknownSlice,
+    IndexOutOfRange,
     BadState { have: SliceState },
+    AlreadyAllocated,
 }
 
 impl SliceMap {
@@ -50,14 +51,14 @@ impl SliceMap {
         self.slices
             .iter_mut()
             .find(|s| s.id == id)
-            .ok_or(SliceError::UnknownSlice)
+            .ok_or(SliceError::IndexOutOfRange)
     }
 
     /// `Free → Active(tenant)`. Err if non-`Free` (atomicity invariant; `Leased` rejects).
     pub fn assign(&mut self, id: SliceId, tenant: TenantId) -> Result<(), SliceError> {
         let s = self.get_mut(id)?;
         if s.state != SliceState::Free {
-            return Err(SliceError::BadState { have: s.state });
+            return Err(SliceError::AlreadyAllocated);
         }
         s.state = SliceState::Active;
         s.tenant = Some(tenant);
@@ -89,7 +90,7 @@ impl SliceMap {
     pub fn lease(&mut self, id: SliceId) -> Result<(), SliceError> {
         let s = self.get_mut(id)?;
         if s.state != SliceState::Free {
-            return Err(SliceError::BadState { have: s.state });
+            return Err(SliceError::AlreadyAllocated);
         }
         s.state = SliceState::Leased;
         Ok(())
@@ -162,9 +163,7 @@ mod tests {
         m.assign(0, 1).unwrap();
         assert_eq!(
             m.assign(0, 2),
-            Err(SliceError::BadState {
-                have: SliceState::Active
-            })
+            Err(SliceError::AlreadyAllocated)
         );
     }
 
@@ -175,9 +174,7 @@ mod tests {
         m.lease(0).unwrap();
         assert_eq!(
             m.assign(0, 1),
-            Err(SliceError::BadState {
-                have: SliceState::Leased
-            })
+            Err(SliceError::AlreadyAllocated)
         );
     }
 
@@ -205,8 +202,8 @@ mod tests {
     #[test]
     fn unknown_slice_is_error() {
         let mut m = SliceMap::new(1, 64);
-        assert_eq!(m.assign(9, 1), Err(SliceError::UnknownSlice));
-        assert_eq!(m.drain(9), Err(SliceError::UnknownSlice));
+        assert_eq!(m.assign(9, 1), Err(SliceError::IndexOutOfRange));
+        assert_eq!(m.drain(9), Err(SliceError::IndexOutOfRange));
         assert!(m.get(9).is_none());
     }
 }


### PR DESCRIPTION
refactor(broker): specific semantic errors for slice allocations

## Resumo
Refactored the `SliceError` enum to replace the generic `UnknownSlice` with `IndexOutOfRange` (-ERANGE) and added `AlreadyAllocated` (-EEXIST) for allocation collisions. Guard clauses in `get_mut`, `assign`, and `lease` now correctly return typed semantic errors, eliminating the ambiguous `BadState` return for collisions. Unit tests were updated to assert these precise semantic states.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(broker) | Refactored `SliceError` in `slices.rs` | Enforce semantic and specific errors (ERANGE, EEXIST) | Replaced `UnknownSlice` with `IndexOutOfRange` and returned `AlreadyAllocated` on `assign` / `lease` collisions. |

## Labels
type:refactor, type:test

## Validacao
Ran `cargo test -p ramshared-broker` and `cargo clippy -p ramshared-broker -- -D warnings`.

## Rollback trigger
Any failure indicating `IndexOutOfRange` or `AlreadyAllocated` regressions in downstream callers.

---
*PR created automatically by Jules for task [10894616766582524796](https://jules.google.com/task/10894616766582524796) started by @emersonbusson*