### PR TITLE
refactor: semantic ChecksumMismatchError for hash mismatches

### DIFF
--- a/crates/ramshared-integrity/src/hash.rs
+++ b/crates/ramshared-integrity/src/hash.rs
@@ -27,15 +27,17 @@ pub enum ChecksumMismatchError {
         computed: u64,
     },
     /// The block index is out of physical bounds.
-    OutOfBounds {
-        idx: usize,
-    },
+    OutOfBounds { idx: usize },
 }
 
 impl fmt::Display for ChecksumMismatchError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Mismatch { idx, expected, computed } => {
+            Self::Mismatch {
+                idx,
+                expected,
+                computed,
+            } => {
                 write!(
                     f,
                     "checksum mismatch at block {idx}: expected {expected:#x}, got {computed:#x}"

--- a/crates/ramshared-integrity/src/hash.rs
+++ b/crates/ramshared-integrity/src/hash.rs
@@ -1,6 +1,9 @@
 //! Block hashing (FNV-1a 64) + pre-allocated checksum table (SPEC §8.1).
 //! **Not cryptographic** — meant for detecting memory corruption and torn reads, not security.
 
+use std::error::Error;
+use std::fmt;
+
 const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
 const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
 
@@ -13,6 +16,39 @@ pub fn block_hash(data: &[u8]) -> u64 {
     }
     h
 }
+
+/// Semantic error for block verification failures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChecksumMismatchError {
+    /// The computed hash does not match the expected hash.
+    Mismatch {
+        idx: usize,
+        expected: u64,
+        computed: u64,
+    },
+    /// The block index is out of physical bounds.
+    OutOfBounds {
+        idx: usize,
+    },
+}
+
+impl fmt::Display for ChecksumMismatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Mismatch { idx, expected, computed } => {
+                write!(
+                    f,
+                    "checksum mismatch at block {idx}: expected {expected:#x}, got {computed:#x}"
+                )
+            }
+            Self::OutOfBounds { idx } => {
+                write!(f, "block index {idx} out of bounds")
+            }
+        }
+    }
+}
+
+impl Error for ChecksumMismatchError {}
 
 /// Checksum table indexed by block number, **pre-allocated** (prevents allocations in the hot path,
 /// SPEC §8). `None` indicates the block has not been written yet.
@@ -29,24 +65,32 @@ impl ChecksumTable {
 
     /// Records the hash of a written block. Returns `false` if `idx` is out of bounds.
     pub fn record(&mut self, idx: usize, data: &[u8]) -> bool {
-        match self.sums.get_mut(idx) {
-            Some(slot) => {
-                *slot = Some(block_hash(data));
-                true
-            }
-            None => false,
-        }
+        let Some(slot) = self.sums.get_mut(idx) else {
+            return false;
+        };
+        *slot = Some(block_hash(data));
+        true
     }
 
     /// Verifies the read block against the recorded hash.
-    /// `None` = never written (ok); `Some(true)` = matches; `Some(false)` =
-    /// mismatch (corruption/torn read) -> the caller returns an I/O error.
-    pub fn verify(&self, idx: usize, data: &[u8]) -> Option<bool> {
-        match self.sums.get(idx) {
-            Some(Some(expected)) => Some(*expected == block_hash(data)),
-            Some(None) => None,
-            None => Some(false), // out of bounds = invalid
+    /// Returns `Ok(true)` if it matches, `Ok(false)` if never written.
+    /// Returns `Err(ChecksumMismatchError)` on mismatch or out of bounds.
+    pub fn verify(&self, idx: usize, data: &[u8]) -> Result<bool, ChecksumMismatchError> {
+        let Some(slot) = self.sums.get(idx) else {
+            return Err(ChecksumMismatchError::OutOfBounds { idx });
+        };
+        let Some(expected) = slot else {
+            return Ok(false);
+        };
+        let computed = block_hash(data);
+        if *expected != computed {
+            return Err(ChecksumMismatchError::Mismatch {
+                idx,
+                expected: *expected,
+                computed,
+            });
         }
+        Ok(true)
     }
 }
 
@@ -68,7 +112,7 @@ mod tests {
         let mut t = ChecksumTable::new(8);
         let data = vec![0xABu8; 4096];
         assert!(t.record(3, &data));
-        assert_eq!(t.verify(3, &data), Some(true));
+        assert_eq!(t.verify(3, &data), Ok(true));
     }
 
     #[test]
@@ -78,14 +122,27 @@ mod tests {
         t.record(3, &data);
         let mut corrupt = data.clone();
         corrupt[0] ^= 0xff;
-        assert_eq!(t.verify(3, &corrupt), Some(false));
+        let Err(err) = t.verify(3, &corrupt) else {
+            panic!("expected error on corruption");
+        };
+        assert_eq!(
+            err,
+            ChecksumMismatchError::Mismatch {
+                idx: 3,
+                expected: block_hash(&data),
+                computed: block_hash(&corrupt),
+            }
+        );
     }
 
     #[test]
     fn unwritten_block_is_none_oob_is_invalid() {
         let mut t = ChecksumTable::new(2);
-        assert_eq!(t.verify(0, &[0u8; 4096]), None); // never written
-        assert_eq!(t.verify(99, &[0u8; 4096]), Some(false)); // out of bounds
+        assert_eq!(t.verify(0, &[0u8; 4096]), Ok(false)); // never written
+        let Err(err) = t.verify(99, &[0u8; 4096]) else {
+            panic!("expected out of bounds error");
+        };
+        assert_eq!(err, ChecksumMismatchError::OutOfBounds { idx: 99 });
         assert!(!t.record(99, &[0u8; 4096]));
     }
 }


### PR DESCRIPTION
Introduces `ChecksumMismatchError` domain enum containing block offset,
expected hash, and computed hash. Updates `ChecksumTable::verify` to
return typed specific errors instead of generic Option<bool>. Refactors
verify and record to use guard clauses instead of match pyramids.

---
*PR created automatically by Jules for task [14758949868444227469](https://jules.google.com/task/14758949868444227469) started by @emersonbusson*