### PR TITLE
refactor: semantic error for config parse and validate

### DIFF
--- a/crates/ramshared-config/src/error.rs
+++ b/crates/ramshared-config/src/error.rs
@@ -16,7 +16,11 @@ pub enum ConfigError {
 impl fmt::Display for ConfigError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Parse { message, line: Some(l), column: Some(c) } => {
+            Self::Parse {
+                message,
+                line: Some(l),
+                column: Some(c),
+            } => {
                 write!(f, "parse error at line {}, col {}: {}", l, c, message)
             }
             Self::Parse { message, .. } => {

--- a/crates/ramshared-config/src/error.rs
+++ b/crates/ramshared-config/src/error.rs
@@ -1,0 +1,32 @@
+use std::fmt;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ConfigError {
+    Parse {
+        message: String,
+        line: Option<usize>,
+        column: Option<usize>,
+    },
+    Invalid {
+        key_path: String,
+        reason: String,
+    },
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Parse { message, line: Some(l), column: Some(c) } => {
+                write!(f, "parse error at line {}, col {}: {}", l, c, message)
+            }
+            Self::Parse { message, .. } => {
+                write!(f, "parse error: {}", message)
+            }
+            Self::Invalid { key_path, reason } => {
+                write!(f, "invalid configuration at '{}': {}", key_path, reason)
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}

--- a/crates/ramshared-config/src/lib.rs
+++ b/crates/ramshared-config/src/lib.rs
@@ -4,6 +4,9 @@
 //! validation can be tested without sockets, root, or a GPU.
 #![forbid(unsafe_code)]
 
+pub mod error;
+pub use error::ConfigError;
+
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
@@ -77,23 +80,61 @@ impl Default for AgentConfig {
 }
 
 impl Config {
-    pub fn parse(text: &str) -> Result<Self, toml::de::Error> {
-        toml::from_str(text)
+    pub fn parse(text: &str) -> Result<Self, ConfigError> {
+        toml::from_str(text).map_err(|err| {
+            let message = err.message().to_string();
+            let mut line = None;
+            let mut column = None;
+            if let Some(span) = err.span() {
+                let mut l = 1;
+                let mut c = 1;
+                for (i, ch) in text.chars().enumerate() {
+                    if i == span.start {
+                        line = Some(l);
+                        column = Some(c);
+                        break;
+                    }
+                    if ch == '\n' {
+                        l += 1;
+                        c = 1;
+                    } else {
+                        c += 1;
+                    }
+                }
+            }
+            ConfigError::Parse {
+                message,
+                line,
+                column,
+            }
+        })
     }
 
-    pub fn validate(&self) -> Result<(), String> {
+    pub fn validate(&self) -> Result<(), ConfigError> {
         if self.broker.slices == 0 {
-            return Err("broker.slices must be > 0".into());
+            return Err(ConfigError::Invalid {
+                key_path: "broker.slices".into(),
+                reason: "must be > 0".into(),
+            });
         }
         if self.broker.slice_mib == 0 {
-            return Err("broker.slice_mib must be > 0".into());
+            return Err(ConfigError::Invalid {
+                key_path: "broker.slice_mib".into(),
+                reason: "must be > 0".into(),
+            });
         }
         if self.agent.watchdog_secs == 0 {
-            return Err("agent.watchdog_secs must be > 0".into());
+            return Err(ConfigError::Invalid {
+                key_path: "agent.watchdog_secs".into(),
+                reason: "must be > 0".into(),
+            });
         }
         match self.broker.backend.as_str() {
             "cuda" | "vulkan" => Ok(()),
-            other => Err(format!("unsupported backend: {other}")),
+            other => Err(ConfigError::Invalid {
+                key_path: "broker.backend".into(),
+                reason: format!("unsupported backend: {other}"),
+            }),
         }
     }
 }
@@ -124,6 +165,26 @@ mod tests {
         let mut cfg = Config::parse("").expect("parse");
         cfg.broker.listen = "0.0.0.0:7777".into();
         cfg.broker.backend = "unknown".into();
-        assert!(cfg.validate().is_err());
+        let err = cfg.validate().unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::Invalid {
+                ref key_path,
+                ref reason,
+            } if key_path == "broker.backend" && reason == "unsupported backend: unknown"
+        ));
+    }
+
+    #[test]
+    fn parses_error_captures_location() {
+        let err = Config::parse("[broker]\nslice_mib = 'hello'").unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::Parse {
+                line: Some(2),
+                column: Some(13),
+                ..
+            }
+        ));
     }
 }

--- a/crates/ramshared-config/src/lib.rs
+++ b/crates/ramshared-config/src/lib.rs
@@ -165,7 +165,7 @@ mod tests {
         let mut cfg = Config::parse("").expect("parse");
         cfg.broker.listen = "0.0.0.0:7777".into();
         cfg.broker.backend = "unknown".into();
-        let err = cfg.validate().unwrap_err();
+        let err = cfg.validate().expect_err("expected error");
         assert!(matches!(
             err,
             ConfigError::Invalid {
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn parses_error_captures_location() {
-        let err = Config::parse("[broker]\nslice_mib = 'hello'").unwrap_err();
+        let err = Config::parse("[broker]\nslice_mib = 'hello'").expect_err("expected error");
         assert!(matches!(
             err,
             ConfigError::Parse {
@@ -186,5 +186,28 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn display_errors() {
+        let p1 = ConfigError::Parse {
+            message: "msg".into(),
+            line: Some(1),
+            column: Some(2),
+        };
+        assert_eq!(p1.to_string(), "parse error at line 1, col 2: msg");
+
+        let p2 = ConfigError::Parse {
+            message: "msg".into(),
+            line: None,
+            column: None,
+        };
+        assert_eq!(p2.to_string(), "parse error: msg");
+
+        let i = ConfigError::Invalid {
+            key_path: "k".into(),
+            reason: "r".into(),
+        };
+        assert_eq!(i.to_string(), "invalid configuration at 'k': r");
     }
 }

--- a/docs/governance/rust-slice-coverage.json
+++ b/docs/governance/rust-slice-coverage.json
@@ -218,11 +218,25 @@
           "source": "crates/ramshared-cuda/src/lib.rs",
           "package": "ramshared-cuda",
           "test_module": "tests",
-          "cargo_test": ["cargo", "test", "-p", "ramshared-cuda", "--lib"],
+          "cargo_test": [
+            "cargo",
+            "test",
+            "-p",
+            "ramshared-cuda",
+            "--lib"
+          ],
           "ignored_gpu_tests": [
             {
               "name": "gpu_roundtrip_256mib",
-              "command": ["cargo", "test", "-p", "ramshared-cuda", "--", "--ignored", "--test-threads=1"],
+              "command": [
+                "cargo",
+                "test",
+                "-p",
+                "ramshared-cuda",
+                "--",
+                "--ignored",
+                "--test-threads=1"
+              ],
               "evidence": "validation.md"
             }
           ]
@@ -245,15 +259,21 @@
         "--report-json",
         "tmp/memory-broker-wsl2d-backend-cov.json"
       ],
-      "packages": ["ramshared-wsl2d"],
-      "files": ["crates/ramshared-wsl2d/src/backend.rs"],
+      "packages": [
+        "ramshared-wsl2d"
+      ],
+      "files": [
+        "crates/ramshared-wsl2d/src/backend.rs"
+      ],
       "min": 80
     },
     {
       "id": "memory-broker-wsl2d-backend-gpu-test-relocation",
       "kind": "rust-ignored-test-relocation",
       "spec": "docs/specs/no-milestone/memory-broker/SPEC.md",
-      "files": ["crates/ramshared-wsl2d/src/backend.rs"],
+      "files": [
+        "crates/ramshared-wsl2d/src/backend.rs"
+      ],
       "base_revision": "69f7469fa999b7d079341ee6bf8ebb006d517b51",
       "base_source_sha256": "b58d99366164b7e898baa42492fead82416a6169ec06ce16fb274b06b6d99663",
       "verification": {
@@ -277,14 +297,54 @@
         "ignored_gpu_tests": [
           {
             "name": "vram_backend_serves_nbd_write_then_read",
-            "command": ["cargo", "test", "-p", "ramshared-wsl2d", "--test", "backend_gpu", "vram_backend_serves_nbd_write_then_read", "--", "--ignored", "--test-threads=1"],
-            "historical_command": ["cargo", "test", "-p", "ramshared-wsl2d", "backend::tests::vram_backend_serves_nbd_write_then_read", "--", "--ignored", "--test-threads=1"],
+            "command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "--test",
+              "backend_gpu",
+              "vram_backend_serves_nbd_write_then_read",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
+            "historical_command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "backend::tests::vram_backend_serves_nbd_write_then_read",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
             "evidence": "validation.md"
           },
           {
             "name": "vram_gauge_outros_captures_real_graphics_usage",
-            "command": ["cargo", "test", "-p", "ramshared-wsl2d", "--test", "backend_gpu", "vram_gauge_outros_captures_real_graphics_usage", "--", "--ignored", "--test-threads=1"],
-            "historical_command": ["cargo", "test", "-p", "ramshared-wsl2d", "backend::tests::vram_gauge_outros_captures_real_graphics_usage", "--", "--ignored", "--test-threads=1"],
+            "command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "--test",
+              "backend_gpu",
+              "vram_gauge_outros_captures_real_graphics_usage",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
+            "historical_command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "backend::tests::vram_gauge_outros_captures_real_graphics_usage",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
             "evidence": "validation.md"
           }
         ]
@@ -705,6 +765,31 @@
       "files": [
         "crates/ramshared-wsl2d/src/autotier.rs",
         "crates/ramshared-dxg/src/lib.rs"
+      ],
+      "min": 80
+    },
+    {
+      "id": "ramshared-config-lib",
+      "kind": "rust-line-coverage",
+      "spec": "docs/specs/no-milestone/memory-broker/SPEC.md",
+      "command": [
+        "node",
+        "tools/ci/check-rust-slice-coverage.mjs",
+        "-p",
+        "ramshared-config",
+        "--files",
+        "crates/ramshared-config/src/lib.rs,crates/ramshared-config/src/error.rs",
+        "--min",
+        "80",
+        "--report-json",
+        "tmp/ramshared-config-lib-cov.json"
+      ],
+      "packages": [
+        "ramshared-config"
+      ],
+      "files": [
+        "crates/ramshared-config/src/lib.rs",
+        "crates/ramshared-config/src/error.rs"
       ],
       "min": 80
     }

--- a/docs/specs/no-milestone/memory-broker/SPEC.md
+++ b/docs/specs/no-milestone/memory-broker/SPEC.md
@@ -529,3 +529,11 @@ slice has an explicit `BINARY_MATCH/E2E` gap and is not a live-daemon DONE.
 4. **Agent Integration:** Refactor agent main loop, implement Windows target code and metrics.
 5. **Generic DCC/workload telemetry:** Implement app-agnostic local bridge and aggregate workload measurement.
 6. **E2E Validation:** Run isolated QEMU crash tests and E2E remote VM simulations.
+
+### ITEM-X — Crate `ramshared-config` coverage
+
+The `ramshared-config` crate requires coverage for its validation logic:
+
+```bash
+node tools/ci/check-rust-slice-coverage.mjs -p ramshared-config --files crates/ramshared-config/src/lib.rs,crates/ramshared-config/src/error.rs --min 80 --report-json tmp/ramshared-config-lib-cov.json
+```


### PR DESCRIPTION
## Resumo
Refactored `Config` parsing and validation to use a specific semantic error `ConfigError` instead of loose strings and `toml::de::Error`.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| HEAD | Added `ConfigError` enum in `error.rs` and replaced strings in `lib.rs` | Obey "Specific & Semantic Errors" principle | Added line/col parsing for TOML errors |

## Labels
type:refactor, type:test

## Validacao
`cargo test -p ramshared-config`
`cargo clippy -p ramshared-config -- -D warnings`

## Rollback trigger
Revert if downstream integrations relying on `ramshared-config` compilation fail or if parsing locations regress.

---
*PR created automatically by Jules for task [1254069171072560659](https://jules.google.com/task/1254069171072560659) started by @emersonbusson*