### PR TITLE
🧹 refactor(winsvc): simplify validate_artifact_path with guard clauses

### DIFF
--- a/crates/ramshared-winsvc/src/package.rs
+++ b/crates/ramshared-winsvc/src/package.rs
@@ -165,20 +165,26 @@ fn validate_hash(hash: &str) -> Result<(), String> {
 }
 
 pub fn validate_artifact_path(value: &str) -> Result<(), String> {
+    if value.is_empty() || value.starts_with(['/', '\\']) || value.contains(':') {
+        return Err("artifact path must be a normalized relative child".into());
+    }
+
+    if value
+        .split(['/', '\\'])
+        .any(|component| component.is_empty() || matches!(component, "." | ".."))
+    {
+        return Err("artifact path must be a normalized relative child".into());
+    }
+
     let path = Path::new(value);
-    if value.is_empty()
-        || value.starts_with(['/', '\\'])
-        || value.contains(':')
-        || value
-            .split(['/', '\\'])
-            .any(|component| component.is_empty() || matches!(component, "." | ".."))
-        || path.is_absolute()
+    if path.is_absolute()
         || path
             .components()
             .any(|component| !matches!(component, Component::Normal(_)))
     {
         return Err("artifact path must be a normalized relative child".into());
     }
+
     Ok(())
 }
 


### PR DESCRIPTION
Simplified `validate_artifact_path` in `crates/ramshared-winsvc/src/package.rs` by replacing deep nesting and a multi-condition disjunction with clean guard clauses. All unit tests and clippy linter checks pass cleanly.

---
*PR created automatically by Jules for task [15311467891037365905](https://jules.google.com/task/15311467891037365905) started by @emersonbusson*