### PR TITLE
🧪 [testing] add unit tests for windows driver ioctl wrappers

### DIFF
--- a/crates/ramshared-winsvc/src/windows_driver.rs
+++ b/crates/ramshared-winsvc/src/windows_driver.rs
@@ -574,12 +574,15 @@ mod tests {
             pending: false,
         };
         let params = DiskParams {
-            capacity_bytes: 1024 * 1024,
+            size_bytes: 1024 * 1024,
             block_size: 512,
             reserved: 1,
+            serial: [0u8; 16],
         };
         let res = link.create_disk(&params);
-        assert!(matches!(res, Err(IoctlError::Invalid(msg)) if msg.contains("disk reserved non-zero")));
+        assert!(
+            matches!(res, Err(IoctlError::Invalid(msg)) if msg.contains("disk reserved non-zero"))
+        );
     }
 
     #[test]
@@ -605,7 +608,9 @@ mod tests {
             cq_event_handle: 0,
         };
         let res1 = link.register_queue(&reg);
-        assert!(matches!(res1, Err(IoctlError::Invalid(msg)) if msg.contains("register reserved non-zero")));
+        assert!(
+            matches!(res1, Err(IoctlError::Invalid(msg)) if msg.contains("register reserved non-zero"))
+        );
 
         reg.reserved = 0;
         reg.disk_id = 1;
@@ -621,7 +626,9 @@ mod tests {
             pending: true,
         };
         let res = link.commit_and_fetch(Duration::from_millis(100));
-        assert!(matches!(res, Err(IoctlError::Invalid(msg)) if msg.contains("commit already pending")));
+        assert!(
+            matches!(res, Err(IoctlError::Invalid(msg)) if msg.contains("commit already pending"))
+        );
     }
 
     #[test]
@@ -639,6 +646,8 @@ mod tests {
             pending: true,
         };
         let res = link_pending.cancel_fetch();
-        assert!(matches!(res, Err(IoctlError::Invalid(msg)) if msg.contains("pending fetch cannot be cancelled")));
+        assert!(
+            matches!(res, Err(IoctlError::Invalid(msg)) if msg.contains("pending fetch cannot be cancelled"))
+        );
     }
 }

--- a/crates/ramshared-winsvc/src/windows_driver.rs
+++ b/crates/ramshared-winsvc/src/windows_driver.rs
@@ -561,3 +561,84 @@ fn struct_bytes<T>(v: &T) -> Vec<u8> {
     }
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_disk_rejects_non_zero_reserved() {
+        let mut link = WindowsDriverLink {
+            handle: ptr::null_mut(),
+            event: ptr::null_mut(),
+            pending: false,
+        };
+        let params = DiskParams {
+            capacity_bytes: 1024 * 1024,
+            block_size: 512,
+            reserved: 1,
+        };
+        let res = link.create_disk(&params);
+        assert!(matches!(res, Err(IoctlError::Invalid(msg)) if msg.contains("disk reserved non-zero")));
+    }
+
+    #[test]
+    fn register_queue_rejects_invalid_params() {
+        let mut link = WindowsDriverLink {
+            handle: ptr::null_mut(),
+            event: ptr::null_mut(),
+            pending: false,
+        };
+
+        let mut reg = Register {
+            abi_version: ABI_VERSION,
+            disk_id: 0,
+            queue_depth: 32,
+            block_size: 512,
+            max_io_bytes: 65536,
+            reserved: 1,
+            sq_ring_va: 0,
+            cq_ring_va: 0,
+            data_area_va: 0,
+            data_area_len: 0,
+            sq_event_handle: 0,
+            cq_event_handle: 0,
+        };
+        let res1 = link.register_queue(&reg);
+        assert!(matches!(res1, Err(IoctlError::Invalid(msg)) if msg.contains("register reserved non-zero")));
+
+        reg.reserved = 0;
+        reg.disk_id = 1;
+        let res2 = link.register_queue(&reg);
+        assert!(matches!(res2, Err(IoctlError::Invalid(msg)) if msg.contains("disk_id must be 0")));
+    }
+
+    #[test]
+    fn commit_and_fetch_rejects_already_pending() {
+        let mut link = WindowsDriverLink {
+            handle: ptr::null_mut(),
+            event: ptr::null_mut(),
+            pending: true,
+        };
+        let res = link.commit_and_fetch(Duration::from_millis(100));
+        assert!(matches!(res, Err(IoctlError::Invalid(msg)) if msg.contains("commit already pending")));
+    }
+
+    #[test]
+    fn cancel_fetch_state_transitions() {
+        let mut link_idle = WindowsDriverLink {
+            handle: ptr::null_mut(),
+            event: ptr::null_mut(),
+            pending: false,
+        };
+        assert!(link_idle.cancel_fetch().is_ok());
+
+        let mut link_pending = WindowsDriverLink {
+            handle: ptr::null_mut(),
+            event: ptr::null_mut(),
+            pending: true,
+        };
+        let res = link_pending.cancel_fetch();
+        assert!(matches!(res, Err(IoctlError::Invalid(msg)) if msg.contains("pending fetch cannot be cancelled")));
+    }
+}

--- a/docs/governance/rust-slice-coverage.json
+++ b/docs/governance/rust-slice-coverage.json
@@ -156,7 +156,7 @@
         "-p",
         "ramshared-winsvc",
         "--files",
-        "crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs",
+        "crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs,crates/ramshared-winsvc/src/windows_driver.rs",
         "--min",
         "80"
       ],
@@ -170,7 +170,8 @@
         "crates/ramshared-winsvc/src/broker_tenant.rs",
         "crates/ramshared-winsvc/src/runtime.rs",
         "crates/ramshared-winsvc/src/service.rs",
-        "crates/ramshared-winsvc/src/host_safety.rs"
+        "crates/ramshared-winsvc/src/host_safety.rs",
+        "crates/ramshared-winsvc/src/windows_driver.rs"
       ],
       "min": 80
     },

--- a/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
+++ b/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
@@ -489,7 +489,7 @@ those shared sources as evidence without creating a second coverage owner.
 - [x] `cargo clippy -p ramshared-cuda -p ramshared-block -p ramshared-winsvc --all-targets -- -D warnings`
 - [x] `cargo test -p ramshared-cuda -p ramshared-block -p ramshared-winsvc`
 - [x] `cargo build -p ramshared-winsvc --target x86_64-pc-windows-msvc`
-- [x] `node tools/ci/check-rust-slice-coverage.mjs -p ramshared-winsvc --files crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs --min 80`
+- [x] `node tools/ci/check-rust-slice-coverage.mjs -p ramshared-winsvc --files crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs,crates/ramshared-winsvc/src/windows_driver.rs --min 80`
   (also CUDA probe cover ≥80% when `crates/ramshared-cuda/src/probe.rs` is in the gate set)
 - [ ] If pure planning logic changes in `crates/ramshared-cuda/src/driver.rs`, include that file in a
   separate `ramshared-cuda` cover gate at >=80%; hardware-only lines remain live-E2E evidence.


### PR DESCRIPTION
Adds unit tests for `WindowsDriverLink` IOCTL wrapper parameter validations and state checks in `crates/ramshared-winsvc/src/windows_driver.rs`.

---
*PR created automatically by Jules for task [3895012826955583626](https://jules.google.com/task/3895012826955583626) started by @emersonbusson*