### PR TITLE
⚡ [eliminate unnecessary cloning in restore_restart_record iter map]

### DIFF
--- a/crates/ramshared-tier/src/n3_state.rs
+++ b/crates/ramshared-tier/src/n3_state.rs
@@ -267,6 +267,11 @@ impl RestartRecord {
         &self.checkpoints
     }
 
+    /// Consumes the record and returns its inner checkpoints without cloning.
+    pub fn into_checkpoints(self) -> Vec<GenerationCheckpoint> {
+        self.checkpoints
+    }
+
     fn validate(&self) -> Result<(), FailureReason> {
         if self.schema_version != N3_SCHEMA_VERSION {
             return Err(FailureReason::UnknownSchema);
@@ -1214,13 +1219,14 @@ impl LeaseMachine {
             return Err(self.fail_restart_restore(FailureReason::InvalidTransition));
         }
 
+        let host_epoch = record.host_epoch();
         let generation_history = record
-            .checkpoints()
-            .iter()
-            .map(|checkpoint| (checkpoint.lease_id.clone(), checkpoint.generation))
+            .into_checkpoints()
+            .into_iter()
+            .map(|checkpoint| (checkpoint.lease_id, checkpoint.generation))
             .collect();
         self.generation_history = generation_history;
-        self.restored_restart_epoch = Some(record.host_epoch());
+        self.restored_restart_epoch = Some(host_epoch);
         Ok(())
     }
 


### PR DESCRIPTION
⚡ [eliminate unnecessary cloning in restore_restart_record iter map]

💡 **What:** Added `into_checkpoints(self)` method on `RestartRecord` to transfer ownership of inner checkpoints without cloning `LeaseId`.
🎯 **Why:** Previously, `restore_restart_record` iterated over checkpoint references via `record.checkpoints().iter()`, forcing a `.clone()` on each `LeaseId` (`Vec<u8>`). By consuming `record`, `LeaseId` elements are moved directly without allocation.
📊 **Measured Improvement:** Eliminates heap allocations for `LeaseId` (`Vec<u8>`) on each checkpoint restoration cycle. All unit tests and clippy checks pass cleanly.

---
*PR created automatically by Jules for task [8106843844965151080](https://jules.google.com/task/8106843844965151080) started by @emersonbusson*