### PR TITLE
🧪 test(wsl2d): test io error propagation in serve_request

### DIFF
--- a/crates/ramshared-wsl2d/tests/ublk_server.rs
+++ b/crates/ramshared-wsl2d/tests/ublk_server.rs
@@ -1,4 +1,4 @@
-use ramshared_block::{Command, Request};
+use ramshared_block::{BlockBackend, Command, IoError, Request};
 use ramshared_wsl2d::{RamBackend, ublk_server};
 
 fn req(cmd: Command, offset: u64, len: u32) -> Request {
@@ -8,6 +8,46 @@ fn req(cmd: Command, offset: u64, len: u32) -> Request {
         handle: 0,
         offset,
         len,
+    }
+}
+
+struct FailingBackend {
+    fail_read: bool,
+    fail_write: bool,
+    fail_flush: bool,
+}
+
+impl BlockBackend for FailingBackend {
+    fn size_bytes(&self) -> u64 {
+        4096
+    }
+
+    fn block_size(&self) -> u32 {
+        512
+    }
+
+    fn read_at(&mut self, _off: u64, _buf: &mut [u8]) -> Result<(), IoError> {
+        if self.fail_read {
+            Err(IoError("simulated read failure".into()))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn write_at(&mut self, _off: u64, _data: &[u8]) -> Result<(), IoError> {
+        if self.fail_write {
+            Err(IoError("simulated write failure".into()))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn flush(&mut self) -> Result<(), IoError> {
+        if self.fail_flush {
+            Err(IoError("simulated flush failure".into()))
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -51,6 +91,44 @@ fn serve_request_handles_flush_and_rejects_oversized_or_oob() {
     // READ outside the backend => -EIO.
     assert_eq!(
         ublk_server::serve_request(&req(Command::Read, 51200, 512), &mut backend, &mut buf),
+        -5
+    );
+}
+
+#[test]
+fn serve_request_propagates_backend_errors() {
+    let mut buf = vec![0u8; 512];
+
+    // Read error propagation -> -EIO (-5)
+    let mut read_failing = FailingBackend {
+        fail_read: true,
+        fail_write: false,
+        fail_flush: false,
+    };
+    assert_eq!(
+        ublk_server::serve_request(&req(Command::Read, 0, 512), &mut read_failing, &mut buf),
+        -5
+    );
+
+    // Write error propagation -> -EIO (-5)
+    let mut write_failing = FailingBackend {
+        fail_read: false,
+        fail_write: true,
+        fail_flush: false,
+    };
+    assert_eq!(
+        ublk_server::serve_request(&req(Command::Write, 0, 512), &mut write_failing, &mut buf),
+        -5
+    );
+
+    // Flush error propagation -> -EIO (-5)
+    let mut flush_failing = FailingBackend {
+        fail_read: false,
+        fail_write: false,
+        fail_flush: true,
+    };
+    assert_eq!(
+        ublk_server::serve_request(&req(Command::Flush, 0, 0), &mut flush_failing, &mut buf),
         -5
     );
 }


### PR DESCRIPTION
🧪 [testing improvement] Add test for io::Result error propagation in ublk_server::serve_request

🎯 **What:** Untested error propagation paths in `serve_request` when `BlockBackend` operations (`read_at`, `write_at`, `flush`) fail with an `IoError`.

📊 **Coverage:** Added test double `FailingBackend` in `crates/ramshared-wsl2d/tests/ublk_server.rs` testing `serve_request` error propagation for `Read`, `Write`, and `Flush` commands.

✨ **Result:** Confirmed that `serve_request` returns `-EIO` (`-5`) when backend operations return errors. All tests pass cleanly.

---
*PR created automatically by Jules for task [6540979825710063523](https://jules.google.com/task/6540979825710063523) started by @emersonbusson*