### PR TITLE
🧹 [code health improvement] verify error handling in read_frozen_target

### DIFF
--- a/crates/ramshared-cli/src/supervisor.rs
+++ b/crates/ramshared-cli/src/supervisor.rs
@@ -605,6 +605,7 @@ fn validate_record_victim(unit: String, invocation_id: String) -> Result<VictimI
     })
 }
 
+/// Reads the frozen scope target record from runtime storage if present.
 fn read_frozen_target(runtime: &Path) -> Result<Option<(FrozenPhase, VictimIdentity)>, String> {
     let Some(record) = read_runtime_record_at::<FrozenTargetRecord>(runtime, "frozen-scope.json")?
     else {


### PR DESCRIPTION
🧹 Code Health Improvement: Verified that `read_frozen_target` in `crates/ramshared-cli/src/supervisor.rs` already uses proper `Result` error handling and `?` propagation without any `unwrap()` calls. Ran unit tests and clippy lint checks to validate code health.

---
*PR created automatically by Jules for task [10615838065293275318](https://jules.google.com/task/10615838065293275318) started by @emersonbusson*