### PR TITLE
🧹 standardize run_systemctl_bounded error handling

### DIFF
--- a/crates/ramshared-cli/src/supervisor.rs
+++ b/crates/ramshared-cli/src/supervisor.rs
@@ -763,7 +763,7 @@ fn run_systemctl_bounded_for(
         bounded_process::DEFAULT_OUTPUT_LIMIT,
         |_| {},
     )
-    .map_err(|error| format!("bounded systemctl action failed: {error}"))?;
+    .map_err(|error| format!("systemctl action failed: {error}"))?;
     if output.status.success() {
         Ok(())
     } else {


### PR DESCRIPTION
Standardized error output formatting for systemctl action failures in supervisor.rs.

---
*PR created automatically by Jules for task [13990776372976090291](https://jules.google.com/task/13990776372976090291) started by @emersonbusson*