### PR TITLE
⚡ perf(cli): avoid string clone in cascade snapshot pairs

### DIFF
--- a/crates/ramshared-cli/src/cascade/lifecycle.rs
+++ b/crates/ramshared-cli/src/cascade/lifecycle.rs
@@ -347,7 +347,7 @@ pub fn derive_lifecycle(s: &CascadeSnapshot) -> LifecycleView {
 
 /// Build tier samples + order_ok from swap lines (filename lowercase match).
 pub fn tiers_from_swap_names(
-    entries: &[(String, u64, u64, i32)],
+    entries: &[(&str, u64, u64, i32)],
 ) -> (TierSample, TierSample, TierSample, bool) {
     let mut zram = TierSample::default();
     let mut vram = TierSample::default();
@@ -854,17 +854,17 @@ mod tests {
     #[test]
     fn tiers_from_swap_names_order() {
         let entries = vec![
-            ("/dev/zram0".into(), 100u64, 10u64, 200i32),
-            ("/dev/nbd0".into(), 200, 5, 100),
-            ("/dev/sdc".into(), 300, 0, -2),
+            ("/dev/zram0", 100u64, 10u64, 200i32),
+            ("/dev/nbd0", 200, 5, 100),
+            ("/dev/sdc", 300, 0, -2),
         ];
         let (z, v, d, ok) = tiers_from_swap_names(&entries);
         assert!(z.present && v.present && d.present);
         assert!(ok);
         assert_eq!(z.prio, Some(200));
         let bad = vec![
-            ("/dev/zram0".into(), 100u64, 0u64, 50i32),
-            ("/dev/nbd0".into(), 200, 0, 100),
+            ("/dev/zram0", 100u64, 0u64, 50i32),
+            ("/dev/nbd0", 200, 0, 100),
         ];
         let (_, _, _, ok2) = tiers_from_swap_names(&bad);
         assert!(!ok2);

--- a/crates/ramshared-cli/src/cascade/mod.rs
+++ b/crates/ramshared-cli/src/cascade/mod.rs
@@ -1330,10 +1330,10 @@ use lifecycle::{
 
 /// Build lifecycle snapshot from live swaps + daemon (read-only).
 pub fn build_cascade_snapshot(entries: &[SwapEntry]) -> CascadeSnapshot {
-    let pairs: Vec<(String, u64, u64, i32)> = entries
+    let pairs: Vec<(&str, u64, u64, i32)> = entries
         .iter()
         .filter(|e| !e.is_ghost())
-        .map(|e| (e.filename.clone(), e.size_kb, e.used_kb, e.priority))
+        .map(|e| (e.filename.as_str(), e.size_kb, e.used_kb, e.priority))
         .collect();
     let (zram, vram, disk, order_ok) = lifecycle::tiers_from_swap_names(&pairs);
     let ghosts = ghost_vram_swaps(entries);


### PR DESCRIPTION
## Resumo
Elimina alocações desnecessárias de String em build_cascade_snapshot alterando tiers_from_swap_names para aceitar fatias de &str em vez de String.

## Commits
- perf(cli): avoid string clone in cascade snapshot pairs

## Issue
- Unnecessary string cloning in map at crates/ramshared-cli/src/cascade/mod.rs:1336

## Responsavel
- Jules

## Labels
- performance
- refactor

## Validacao
- Executado `cargo test -p ramshared-cli cascade::` com sucesso.
- Executado `cargo clippy -p ramshared-cli -- -D warnings` sem avisos.

## Rollback trigger
- Falha na verificação de regressão em testes do cascade ou erros de compilação em ramshared-cli.

---
*PR created automatically by Jules for task [13465504454586479029](https://jules.google.com/task/13465504454586479029) started by @emersonbusson*