### PR TITLE
fix(kernel): return semantic errnos on PCIe probe failures

### DIFF
--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,25 @@
+fix(kernel): return semantic errnos on PCIe probe failures
+
+## Resumo
+Adiciona retornos semânticos de errno (ENODEV, EBUSY) e checagem inicial de ponteiro NULL no driver RamShared.
+
+## Commits
+| Commit | O que fez | Por que fez | Detalhes |
+|---|---|---|---|
+| HEAD | Refatora probe | Seguir o contrato C-100 para sanidade física | <details><summary>detalhes</summary>Retorna -ENODEV se !pdev ou não habilitar mem, e -EBUSY em contention</details> |
+
+## Issue
+Closes #000
+
+## Responsavel
+@KernelC100
+
+## Labels
+type:kernel, type:refactor
+
+## Validacao
+- [x] Gates de build/test do escopo tocado
+Compilou com `./scripts/ci/check-kernel-style.sh`.
+
+## Rollback trigger
+Falha de inicialização em hardware válido com erro ambíguo (kernel panic, código de erro não mapeado no probe).

--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -30,6 +30,9 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 	struct ramshared_device *rs_dev;
 	int ret;
 
+	if (!pdev)
+		return -ENODEV;
+
 	dev_info(&pdev->dev, "probing RamShared hardware (capacity=%lu MiB)\n",
 		 capacity_mb);
 
@@ -53,7 +56,7 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 	ret = pci_enable_device_mem(pdev);
 	if (ret) {
 		dev_err(&pdev->dev, "failed to enable PCIe memory device\n");
-		return ret;
+		return -ENODEV;
 	}
 
 	pci_set_master(pdev);
@@ -71,6 +74,7 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 	ret = pci_request_mem_regions(pdev, RAMSHARED_DRIVER_NAME);
 	if (ret) {
 		dev_err(&pdev->dev, "failed to claim PCIe memory regions\n");
+		ret = -EBUSY;
 		goto err_disable_pci;
 	}
 


### PR DESCRIPTION
## Resumo
Adiciona retornos semânticos de errno (ENODEV, EBUSY) e checagem
inicial de ponteiro NULL no driver RamShared.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| HEAD | Refatora probe | Seguir o contrato C-100 para sanidade física | Retorna -ENODEV se !pdev ou não habilitar mem, e -EBUSY em contention |

## Labels
type:kernel, type:refactor

## Validacao
Compilou com `./scripts/ci/check-kernel-style.sh`.

## Rollback trigger
Falha de inicialização em hardware válido com erro ambíguo.

---
*PR created automatically by Jules for task [3495575639164401164](https://jules.google.com/task/3495575639164401164) started by @emersonbusson*