### PR TITLE
feat(kernel): enforce 4096-byte alignment check on PCIe BAR

### DIFF
--- a/drivers/block/ramshared/dma.c
+++ b/drivers/block/ramshared/dma.c
@@ -28,6 +28,12 @@ int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
 		return -ENODEV;
 	}
 
+	if (bar_start & (PAGE_SIZE - 1)) {
+		dev_err(&pdev->dev, "PCIe BAR0 physical address %pa is not page-aligned\n",
+			&bar_start);
+		return -EINVAL;
+	}
+
 	rs_dev->dma.pci_addr = bar_start;
 	rs_dev->dma.size = min_t(size_t, bar_len, rs_dev->capacity_bytes);
 


### PR DESCRIPTION
## Resumo
Adiciona validação de alinhamento de 4096 bytes (PAGE_SIZE) para o endereço físico do PCIe BAR antes do mapeamento de memória.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(kernel): enforce 4096-byte alignment check on PCIe BAR | Adicionou guard clause | Prevenir mapeamento desalinhado | Retorna -EINVAL |

## Labels
type:kernel, type:security

## Validacao
Revisão manual de código e cpp check.

## Rollback trigger
Falhas de inicialização em dispositivos validamente não alinhados à página.

---
*PR created automatically by Jules for task [13030073431752554898](https://jules.google.com/task/13030073431752554898) started by @emersonbusson*