### PR TITLE
refactor(core): implement guard clauses for queue parameters

### DIFF
--- a/drivers/block/ramshared/queue.c
+++ b/drivers/block/ramshared/queue.c
@@ -193,18 +193,18 @@ static const struct attribute_group *ramshared_attr_groups[] = {
 int ramshared_queue_init(struct ramshared_device *rs_dev,
 			 struct device *parent_dev, unsigned int q_depth)
 {
-	unsigned int valid_depth;
 	int ret;
 
-	if (!rs_dev)
+	if (!rs_dev || !parent_dev)
 		return -EINVAL;
 
-	valid_depth = clamp_t(unsigned int, q_depth, 16U, 2048U);
+	if (q_depth < 16U || q_depth > 1024U)
+		return -ERANGE;
 
 	memset(&rs_dev->tag_set, 0, sizeof(rs_dev->tag_set));
 	rs_dev->tag_set.ops = &ramshared_mq_ops;
 	rs_dev->tag_set.nr_hw_queues = num_online_cpus();
-	rs_dev->tag_set.queue_depth = valid_depth;
+	rs_dev->tag_set.queue_depth = q_depth;
 	rs_dev->tag_set.numa_node = NUMA_NO_NODE;
 	rs_dev->tag_set.flags = BLK_MQ_F_SHOULD_MERGE;
 


### PR DESCRIPTION
## Resumo
Added guard clauses in ramshared_queue_init() to validate queue initialization parameters:
1. Returns -EINVAL if rs_dev or parent_dev are null, instead of proceeding.
2. Replaces clamp_t with a strict guard clause that rejects q_depth less than 16 or greater than 1024 (returning -ERANGE).

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(core): implement guard clauses for queue parameters | Validated null pointers and q_depth boundaries. | Prevent downstream problems instead of hiding them with clamp. | Queue initialization parameter guards. |

## Issue
N/A

## Responsavel
Jules

## Labels
type:refactor, type:kernel

## Validacao
Inspected the local file and ran git diff to confirm correct application of guard clauses.

## Rollback trigger
If this commit causes driver initialization faults that prevent proper loading, revert the commit.

---
*PR created automatically by Jules for task [10966352930925447542](https://jules.google.com/task/10966352930925447542) started by @emersonbusson*