### PR TITLE
docs(kernel): report finding on dma guard clauses

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -472,7 +472,19 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-08-11T15:15:12Z"
-    }
+    },
+    {
+        "id": "jules-findings",
+        "pattern": "docs/jules/findings/*.md",
+        "owner": "wsl2-reliability",
+        "canonicalSource": "docs/jules/findings/TASK_006_FINDINGS.md",
+        "lifecycle": "historical",
+        "freshnessDays": null,
+        "verification": {
+              "state": "unverified"
+        },
+        "registeredAt": "2026-08-31T02:08:59.435Z"
+  }
   ],
   "exclusions": [
     {

--- a/docs/jules/findings/TASK_006_FINDINGS.md
+++ b/docs/jules/findings/TASK_006_FINDINGS.md
@@ -1,0 +1,24 @@
+# TASK-006 FINDING_ONLY Report
+
+## Objective
+Check `rs_dev` and `pdev` non-nullness at the top of `ramshared_dma_init` with immediate `-EINVAL` return in `drivers/block/ramshared/dma.c`.
+
+## Finding
+The requested modification is **already implemented** in the target file.
+
+## Evidence
+File: `drivers/block/ramshared/dma.c`
+
+Lines 15-22 already contain the precise guard clause requested:
+
+```c
+int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
+{
+	int bar = 0;
+	resource_size_t bar_start, bar_len;
+
+	if (!rs_dev || !pdev)
+		return -EINVAL;
+```
+
+No further code modifications are possible without introducing redundancy. The C/Kernel Clean Architecture principles for guard clauses and semantic error returns are already fully satisfied.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 258,
-    "classified": 247,
+    "total": 259,
+    "classified": 248,
     "excluded": 11,
     "unclassified": 0,
     "ambiguous": 0
@@ -568,6 +568,18 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/TASK_006_FINDINGS.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "wsl2-reliability",
+      "canonicalSource": "docs/jules/findings/TASK_006_FINDINGS.md",
+      "lifecycle": "historical",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/DUALBOOT-KERNEL-TRUE.md",


### PR DESCRIPTION
## Resumo
Foi verificado que a função `ramshared_dma_init` em `drivers/block/ramshared/dma.c` já possui a cláusula de guarda (`guard clause`) solicitada para validar ponteiros nulos (`rs_dev` e `pdev`) retornando `-EINVAL`. Nenhuma modificação no código-fonte é necessária. O relatório de descoberta (FINDING_ONLY) foi adicionado em `docs/jules/findings/`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs(kernel): report finding on dma guard clauses | Adicionou relatório FINDING_ONLY | O código fonte alvo já implementava o requisito solicitado | Documento adicionado confirmando as linhas exatas do código com o guard clause existente. |

## Issue
N/A

## Responsavel
jules

## Labels
type:kernel

## Validacao
- git diff --check executado sem problemas.
- ./scripts/docs-check.sh executado com sucesso.
- Verificação visual do arquivo `drivers/block/ramshared/dma.c`.

## Rollback trigger
Remover o documento adicionado caso seja provado que a verificação de código estava incorreta ou incompleta.

---
*PR created automatically by Jules for task [7437864166715853862](https://jules.google.com/task/7437864166715853862) started by @emersonbusson*