### PR TITLE
fix(ramshared): clamp queue_depth module parameter between 16 and 1024

### DIFF
--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -39,6 +39,8 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 		return -EINVAL;
 	}
 
+	queue_depth = clamp_t(unsigned int, queue_depth, 16, 1024);
+
 	rs_dev = devm_kzalloc(&pdev->dev, sizeof(*rs_dev), GFP_KERNEL);
 	if (!rs_dev)
 		return -ENOMEM;


### PR DESCRIPTION
## Resumo
Garante que o parametro queue_depth respeite os limites fisicos entre 16 e 1024.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| HEAD | Aplicou clamp_t no queue_depth | Prevenir bugs de hardware | O valor e validado no probe |

## Issue
kernel-linux

## Responsavel
Jules

## Labels
type:kernel

## Validacao
Inspecao estatica do codigo fonte e kernel build.

## Rollback trigger
Se o driver apresentar panics por filas muito pequenas.

---
*PR created automatically by Jules for task [2613496938329158431](https://jules.google.com/task/2613496938329158431) started by @emersonbusson*