### PR TITLE
refactor(dma): validate 64-bit DMA mask with fallback in dma module

### DIFF
--- a/drivers/block/ramshared/dma.c
+++ b/drivers/block/ramshared/dma.c
@@ -16,6 +16,7 @@ int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
 {
 	int bar = 0;
 	resource_size_t bar_start, bar_len;
+	int ret;
 
 	if (!rs_dev || !pdev)
 		return -EINVAL;
@@ -25,6 +26,17 @@ int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
 
 	if (!bar_start || bar_len == 0) {
 		dev_err(&pdev->dev, "invalid PCIe BAR0 resource\n");
+		return -ENODEV;
+	}
+
+	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
+	if (ret) {
+		dev_warn(&pdev->dev, "64-bit DMA failed, attempting 32-bit DMA\n");
+		ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
+	}
+
+	if (ret) {
+		dev_err(&pdev->dev, "no usable DMA configuration\n");
 		return -ENODEV;
 	}
 

--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -58,16 +58,6 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 
 	pci_set_master(pdev);
 
-	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
-	if (ret) {
-		dev_warn(&pdev->dev, "64-bit DMA failed, attempting 32-bit DMA\n");
-		ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
-		if (ret) {
-			dev_err(&pdev->dev, "no usable DMA configuration\n");
-			goto err_disable_pci;
-		}
-	}
-
 	ret = pci_request_mem_regions(pdev, RAMSHARED_DRIVER_NAME);
 	if (ret) {
 		dev_err(&pdev->dev, "failed to claim PCIe memory regions\n");


### PR DESCRIPTION
## Resumo
Moved DMA mask negotiation from main.c into dma.c with flat guard clauses instead of nested logic, adhering to the project's architectural guidelines for clean C kernel code.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| HEAD | Refactored DMA mask setting | Flattened nested logic and centralized DMA setup in dma.c | Implemented early return guard clauses to prevent deep nesting |

## Issue
N/A

## Responsavel
KernelC100

## Labels
type:refactor, type:kernel

## Validacao
Ran checkpatch and git diffs to verify structural correctness of the flat C guard clauses.

## Rollback trigger
Revert if PCIe device fails to initialize DMA mask during boot.

---
*PR created automatically by Jules for task [4112688746917593975](https://jules.google.com/task/4112688746917593975) started by @emersonbusson*