### PR TITLE
refactor(kernel): enforce checked 64-bit multiplication for capacity_bytes

### DIFF
--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -9,6 +9,7 @@
 #include <linux/kernel.h>
 #include <linux/init.h>
 #include <linux/pci.h>
+#include <linux/overflow.h>
 #include "ramshared.h"
 
 MODULE_AUTHOR("Emerson Busson");
@@ -44,7 +45,12 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 		return -ENOMEM;
 
 	rs_dev->dev = &pdev->dev;
-	rs_dev->capacity_bytes = (u64)capacity_mb * 1024 * 1024;
+
+	if (check_mul_overflow((u64)capacity_mb, 1048576ULL, &rs_dev->capacity_bytes)) {
+		dev_err(&pdev->dev, "capacity calculation overflowed\n");
+		return -ERANGE;
+	}
+
 	mutex_init(&rs_dev->lock);
 	atomic64_set(&rs_dev->dma_transfers_total, 0);
 	atomic64_set(&rs_dev->read_bytes, 0);


### PR DESCRIPTION
## Resumo
Enforced checked 64-bit arithmetic using `check_mul_overflow` in `ramshared_pci_probe` when calculating `capacity_bytes` to prevent integer overflows. Returns `-ERANGE` dynamically if overflow detected.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(kernel): enforce checked 64-bit multiplication for capacity_bytes | Added check_mul_overflow to capacity_bytes calculation | Prevent integer overflows and enforce defensive hardware programming limits | Used linux/overflow.h and early return with -ERANGE |

## Responsavel
Jules

## Labels
type:refactor, type:kernel, type:security

## Validacao
Executed cpp syntax check via cpp drivers/block/ramshared/main.c > /dev/null.

## Rollback trigger
Compilation failures or kernel panics related to overflow checking logic during module probe.

---
*PR created automatically by Jules for task [12264274457830389098](https://jules.google.com/task/12264274457830389098) started by @emersonbusson*