### PR TITLE
refactor(kernel): linearize queue cleanup and tagset freeing

### DIFF
--- a/drivers/block/ramshared/queue.c
+++ b/drivers/block/ramshared/queue.c
@@ -240,14 +240,15 @@ int ramshared_queue_init(struct ramshared_device *rs_dev,
 
 void ramshared_queue_cleanup(struct ramshared_device *rs_dev)
 {
-	if (!rs_dev)
+	if (unlikely(!rs_dev))
 		return;
 
-	if (rs_dev->disk) {
+	if (likely(rs_dev->disk)) {
 		del_gendisk(rs_dev->disk);
-		put_disk(rs_dev->disk);
+		blk_cleanup_disk(rs_dev->disk);
 		rs_dev->disk = NULL;
 	}
 
-	blk_mq_free_tag_set(&rs_dev->tag_set);
+	if (likely(rs_dev->tag_set.tags))
+		blk_mq_free_tag_set(&rs_dev->tag_set);
 }


### PR DESCRIPTION
## Resumo
Linearized queue cleanup in ramshared_queue_cleanup with guard checks and safely ordered blk_cleanup_disk and blk_mq_free_tag_set.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| HEAD | Refactored queue cleanup | Eliminate nested logic and ensure safe tagset freeing | Utilized likely/unlikely guard clauses, replaced put_disk with blk_cleanup_disk, and guarded tagset freeing. |

## Issue
None

## Responsavel
Jules

## Labels
type:refactor, type:kernel

## Validacao
Executed ./scripts/ci/check-kernel-style.sh, ./scripts/ci/check-kernel-build-matrix.sh, ./scripts/ci/check-kernel-qemu-smoke.sh, and ./scripts/ci/check-adversarial-invariants.sh.

## Rollback trigger
Kernel panic or compilation failure.

---
*PR created automatically by Jules for task [11291236447847687398](https://jules.google.com/task/11291236447847687398) started by @emersonbusson*