### PR TITLE
fix(kernel): prevent double-free on failed disk addition in probe error path

### DIFF
--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -85,7 +85,7 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 	ret = add_disk(rs_dev->disk);
 	if (ret) {
 		dev_err(&pdev->dev, "failed to add block disk (err=%d)\n", ret);
-		goto err_queue_cleanup;
+		goto err_add_disk;
 	}
 
 	pci_set_drvdata(pdev, rs_dev);
@@ -93,6 +93,9 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 		 rs_dev->disk->disk_name);
 	return 0;
 
+err_add_disk:
+	put_disk(rs_dev->disk);
+	rs_dev->disk = NULL;
 err_queue_cleanup:
 	ramshared_queue_cleanup(rs_dev);
 err_dma_cleanup:


### PR DESCRIPTION
## Resumo
Fix double-free vulnerability in the probe error path when `add_disk` fails. If `add_disk` fails, `put_disk` should be called, and the reference in `rs_dev->disk` must be cleared before calling `ramshared_queue_cleanup` which unconditionally calls `del_gendisk` and `put_disk` if `rs_dev->disk` is not NULL.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix(kernel): prevent double-free | Added `err_add_disk` cleanup path | Fix probe error handling when add_disk fails | Calls put_disk and clears rs_dev->disk before queue cleanup |

## Issue
Fix double-free vulnerability in probe cleanup path.

## Responsavel
Jules

## Labels
type:kernel, type:bug

## Validacao
Successfully ran pre-processor `cpp drivers/block/ramshared/main.c > /dev/null` and module compilation check.

## Rollback trigger
Revert if kernel module fails to load or panics during standard operations.

---
*PR created automatically by Jules for task [18433480645148039443](https://jules.google.com/task/18433480645148039443) started by @emersonbusson*