### PR TITLE
feat(kernel-win): validate RegistryPath parameter in DriverEntry

### DIFF
--- a/drivers/windows/ramshared/driver.c
+++ b/drivers/windows/ramshared/driver.c
@@ -255,6 +255,9 @@ DriverEntry(_In_ PDRIVER_OBJECT DriverObject, _In_ PUNICODE_STRING RegistryPath)
 	HW_INITIALIZATION_DATA hw;
 	NTSTATUS status;
 
+	if (!RegistryPath || !RegistryPath->Buffer || RegistryPath->Length == 0)
+		return STATUS_INVALID_PARAMETER;
+
 	RtlZeroMemory(&hw, sizeof(hw));
 	hw.HwInitializationDataSize = sizeof(HW_INITIALIZATION_DATA);
 	hw.AdapterInterfaceType = Internal;


### PR DESCRIPTION
## Resumo
Added defensively validation to PUNICODE_STRING RegistryPath before driver initialization to prevent BSOD.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(kernel-win): validate RegistryPath parameter in DriverEntry | Added guard clauses to validate RegistryPath in DriverEntry | To prevent BSOD and ensure physical integrity in kernel | Checks for null and length. Returns STATUS_INVALID_PARAMETER |

## Issue
N/A

## Responsavel
jules

## Labels
type:security, type:kernel

## Validacao
Executed scripts:
- ./scripts/ci/check-kernel-style.sh
- ./scripts/ci/check-kernel-build-matrix.sh
- ./scripts/ci/check-kernel-qemu-smoke.sh
- ./scripts/ci/check-adversarial-invariants.sh

## Rollback trigger
Revert if the driver fails to load properly on Windows with a valid RegistryPath.

---
*PR created automatically by Jules for task [307196309009866807](https://jules.google.com/task/307196309009866807) started by @emersonbusson*