### PR TITLE
kernel: validate zero-copy memcpy bounds in ramshared_queue_transfer

### DIFF
--- a/drivers/block/ramshared/queue.c
+++ b/drivers/block/ramshared/queue.c
@@ -20,11 +20,20 @@ static blk_status_t ramshared_process_bio(struct ramshared_device *rs_dev,
 	struct bio_vec bvec;
 	struct bvec_iter iter;
 	unsigned int op = bio_op(bio);
-	void __iomem *vram_ptr = rs_dev->dma.cpu_addr + pos;
+	void __iomem *vram_ptr;
 
 	bio_for_each_segment(bvec, bio, iter) {
-		void *src_or_dst = bvec_kmap_local(&bvec);
+		void *src_or_dst;
 		size_t len = bvec.bv_len;
+
+		if (unlikely(pos < 0 || len > rs_dev->dma.size || pos > rs_dev->dma.size - len))
+			return BLK_STS_IOERR;
+
+		if (unlikely(bvec.bv_offset > PAGE_SIZE || len > PAGE_SIZE - bvec.bv_offset))
+			return BLK_STS_IOERR;
+
+		vram_ptr = rs_dev->dma.cpu_addr + pos;
+		src_or_dst = bvec_kmap_local(&bvec);
 
 		if (op == REQ_OP_READ) {
 			dma_rmb();
@@ -37,7 +46,7 @@ static blk_status_t ramshared_process_bio(struct ramshared_device *rs_dev,
 			atomic64_add(len, &rs_dev->write_bytes);
 		}
 		kunmap_local(src_or_dst);
-		vram_ptr += len;
+		pos += len;
 	}
 
 	atomic64_inc(&rs_dev->dma_transfers_total);
@@ -57,10 +66,10 @@ static blk_status_t ramshared_queue_rq(struct blk_mq_hw_ctx *hctx,
 	if (unlikely(!rs_dev || !rs_dev->dma.cpu_addr))
 		return BLK_STS_IOERR;
 
-	if (unlikely(pos + len > rs_dev->capacity_bytes)) {
+	if (unlikely(pos < 0 || len > rs_dev->dma.size || pos > rs_dev->dma.size - len)) {
 		dev_err_ratelimited(rs_dev->dev,
-			"I/O bounds violation: pos=%lld, len=%zu, cap=%llu\n",
-			pos, len, rs_dev->capacity_bytes);
+			"I/O bounds violation: pos=%lld, len=%zu, cap=%zu\n",
+			pos, len, rs_dev->dma.size);
 		return BLK_STS_IOERR;
 	}
 
@@ -111,10 +120,10 @@ static int ramshared_bdev_rw_page(struct block_device *bdev, sector_t sector,
 	int is_write = op_is_write(op);
 
 	if (unlikely(!rs_dev || !rs_dev->dma.cpu_addr))
-		return -EIO;
+		return -ENODEV;
 
-	if (unlikely(pos + len > rs_dev->capacity_bytes))
-		return -EIO;
+	if (unlikely(pos < 0 || len > rs_dev->dma.size || pos > rs_dev->dma.size - len))
+		return -ERANGE;
 
 	vram_ptr = rs_dev->dma.cpu_addr + pos;
 	mem = kmap_local_page(page);


### PR DESCRIPTION
kernel: validate zero-copy memcpy bounds in ramshared_queue_transfer

## Resumo
Add strict physical capacity bounds checks to memory mapping operations. Replaces basic capacity_bytes validation with precise dma.size checks and bounded offset/len to ensure zero-copy ops don't exceed BAR mapping limits or trigger kernel panics.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|--------|-----------|-------------|----------|
| 1 | Add dma.size checks in block processing | Prevent OOB DMA read/writes | Replaces capacity_bytes checks with safer checked-arithmetic |

## Labels
type:kernel, type:security

## Validacao
cpp drivers/block/ramshared/queue.c > /dev/null
bash scripts/kernel/test-wsl-kernel-static.sh

## Rollback trigger
System freeze, bugcheck 0x7A, or kernel panic during VRAM swapping operations.

---
*PR created automatically by Jules for task [4324023739544457944](https://jules.google.com/task/4324023739544457944) started by @emersonbusson*