### PR TITLE
feat(kernel): add guard clauses and compat for devm_ioremap_wc

### DIFF
--- a/drivers/block/ramshared/compat.h
+++ b/drivers/block/ramshared/compat.h
@@ -13,6 +13,46 @@
 #include <linux/version.h>
 #include <linux/blkdev.h>
 #include <linux/blk-mq.h>
+#include <linux/io.h>
+#include <linux/overflow.h>
+#include <linux/err.h>
+
+/**
+ * ramshared_compat_ioremap_wc - Version-compatible write-combining I/O remap
+ * @dev: Device to allocate memory for
+ * @offset: Physical address of the resource
+ * @size: Size of the region
+ *
+ * Applies guard clauses, physical limits (4096 alignment, overflow check),
+ * and semantic errors via IOMEM_ERR_PTR.
+ */
+static inline void __iomem *ramshared_compat_ioremap_wc(struct device *dev,
+							resource_size_t offset,
+							resource_size_t size)
+{
+	resource_size_t end;
+	void __iomem *ptr;
+
+	if (!dev)
+		return IOMEM_ERR_PTR(-EINVAL);
+	if (size == 0)
+		return IOMEM_ERR_PTR(-EINVAL);
+	if (!IS_ALIGNED(offset, 4096))
+		return IOMEM_ERR_PTR(-EINVAL);
+	if (check_add_overflow(offset, size, &end))
+		return IOMEM_ERR_PTR(-ERANGE);
+
+#if defined(devm_ioremap_wc) || LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
+	ptr = devm_ioremap_wc(dev, offset, size);
+#else
+	ptr = devm_ioremap(dev, offset, size);
+#endif
+
+	if (!ptr)
+		return IOMEM_ERR_PTR(-ENOMEM);
+
+	return ptr;
+}
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
 /* Linux 6.11+ Paradigm: Features embedded in struct queue_limits */

--- a/drivers/block/ramshared/dma.c
+++ b/drivers/block/ramshared/dma.c
@@ -11,6 +11,7 @@
 #include <linux/dma-mapping.h>
 #include <linux/io.h>
 #include "ramshared.h"
+#include "compat.h"
 
 int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
 {
@@ -32,12 +33,14 @@ int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
 	rs_dev->dma.size = min_t(size_t, bar_len, rs_dev->capacity_bytes);
 
 	/* Map PCIe VRAM BAR using Write-Combining for peak throughput */
-	rs_dev->dma.cpu_addr = devm_ioremap_wc(&pdev->dev, rs_dev->dma.pci_addr,
-					       rs_dev->dma.size);
-	if (!rs_dev->dma.cpu_addr) {
-		dev_err(&pdev->dev, "failed to ioremap_wc VRAM BAR0 (%zu bytes)\n",
-			rs_dev->dma.size);
-		return -ENOMEM;
+	rs_dev->dma.cpu_addr = ramshared_compat_ioremap_wc(&pdev->dev, rs_dev->dma.pci_addr,
+							   rs_dev->dma.size);
+	if (IS_ERR(rs_dev->dma.cpu_addr)) {
+		int err = PTR_ERR(rs_dev->dma.cpu_addr);
+		rs_dev->dma.cpu_addr = NULL;
+		dev_err(&pdev->dev, "failed to ioremap_wc VRAM BAR0 (%zu bytes), err: %d\n",
+			rs_dev->dma.size, err);
+		return err;
 	}
 
 	dev_info(&pdev->dev, "DMA engine mapped %zu MB VRAM at %pa\n",


### PR DESCRIPTION
feat(kernel): add guard clauses and compat for devm_ioremap_wc

## Resumo
Introduced a compatibility layer for `devm_ioremap_wc` to support older kernels gracefully. Implemented guard clauses and physical limit sanity checks to prevent out-of-bounds mapping and unaligned accesses, returning specific semantic errors instead of raw NULL checking.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(kernel): add guard clauses and compat for devm_ioremap_wc | Added `ramshared_compat_ioremap_wc` in `compat.h` and used it in `dma.c` | To enforce defensive programming via guard clauses and ensure module compatibility across kernels. | Physical limits checked, early returns utilized. |

## Issue
N/A

## Responsavel
Jules

## Labels
type:kernel, type:refactor

## Validacao
`make -C /lib/modules/6.8.0-138-generic/build M=$(pwd)/drivers/block/ramshared modules`

## Rollback trigger
Compilation error or kernel panic during VRAM mapping at module load time.

---
*PR created automatically by Jules for task [5292674602615799518](https://jules.google.com/task/5292674602615799518) started by @emersonbusson*