### PR TITLE
perf(core): eliminate spinlock contention during multi-queue bio completion

### DIFF
--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -46,13 +46,23 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 	rs_dev->dev = &pdev->dev;
 	rs_dev->capacity_bytes = (u64)capacity_mb * 1024 * 1024;
 	mutex_init(&rs_dev->lock);
-	atomic64_set(&rs_dev->dma_transfers_total, 0);
-	atomic64_set(&rs_dev->read_bytes, 0);
-	atomic64_set(&rs_dev->write_bytes, 0);
+
+	rs_dev->stats = alloc_percpu(struct ramshared_stats);
+	if (!rs_dev->stats)
+		return -ENOMEM;
+
+	{
+		int cpu;
+		for_each_possible_cpu(cpu) {
+			struct ramshared_stats *stats = per_cpu_ptr(rs_dev->stats, cpu);
+			u64_stats_init(&stats->syncp);
+		}
+	}
 
 	ret = pci_enable_device_mem(pdev);
 	if (ret) {
 		dev_err(&pdev->dev, "failed to enable PCIe memory device\n");
+		free_percpu(rs_dev->stats);
 		return ret;
 	}
 
@@ -101,6 +111,7 @@ err_release_regions:
 	pci_release_mem_regions(pdev);
 err_disable_pci:
 	pci_disable_device(pdev);
+	free_percpu(rs_dev->stats);
 	return ret;
 }
 
@@ -115,6 +126,7 @@ static void ramshared_pci_remove(struct pci_dev *pdev)
 	ramshared_dma_cleanup(rs_dev);
 	pci_release_mem_regions(pdev);
 	pci_disable_device(pdev);
+	free_percpu(rs_dev->stats);
 
 	dev_info(&pdev->dev, "RamShared device removed successfully\n");
 }

--- a/drivers/block/ramshared/queue.c
+++ b/drivers/block/ramshared/queue.c
@@ -30,17 +30,28 @@ static blk_status_t ramshared_process_bio(struct ramshared_device *rs_dev,
 			dma_rmb();
 			memcpy_fromio(src_or_dst, vram_ptr, len);
 			flush_dcache_page(bvec.bv_page);
-			atomic64_add(len, &rs_dev->read_bytes);
 		} else if (op == REQ_OP_WRITE) {
 			memcpy_toio(vram_ptr, src_or_dst, len);
 			dma_wmb();
-			atomic64_add(len, &rs_dev->write_bytes);
 		}
 		kunmap_local(src_or_dst);
 		vram_ptr += len;
 	}
 
-	atomic64_inc(&rs_dev->dma_transfers_total);
+	{
+		unsigned long flags;
+		struct ramshared_stats *stats = get_cpu_ptr(rs_dev->stats);
+
+		flags = u64_stats_update_begin_irqsave(&stats->syncp);
+		if (op == REQ_OP_READ)
+			stats->read_bytes += bio->bi_iter.bi_size;
+		else if (op == REQ_OP_WRITE)
+			stats->write_bytes += bio->bi_iter.bi_size;
+		stats->dma_transfers_total++;
+		u64_stats_update_end_irqrestore(&stats->syncp, flags);
+		put_cpu_ptr(rs_dev->stats);
+	}
+
 	return BLK_STS_OK;
 }
 
@@ -122,16 +133,28 @@ static int ramshared_bdev_rw_page(struct block_device *bdev, sector_t sector,
 	if (is_write) {
 		memcpy_toio(vram_ptr, mem, len);
 		dma_wmb();
-		atomic64_add(len, &rs_dev->write_bytes);
 	} else {
 		dma_rmb();
 		memcpy_fromio(mem, vram_ptr, len);
 		flush_dcache_page(page);
-		atomic64_add(len, &rs_dev->read_bytes);
 	}
 
 	kunmap_local(mem);
-	atomic64_inc(&rs_dev->dma_transfers_total);
+
+	{
+		unsigned long flags;
+		struct ramshared_stats *stats = get_cpu_ptr(rs_dev->stats);
+
+		flags = u64_stats_update_begin_irqsave(&stats->syncp);
+		if (is_write)
+			stats->write_bytes += len;
+		else
+			stats->read_bytes += len;
+		stats->dma_transfers_total++;
+		u64_stats_update_end_irqrestore(&stats->syncp, flags);
+		put_cpu_ptr(rs_dev->stats);
+	}
+
 	page_endio(page, is_write, 0);
 	return 0;
 }
@@ -152,13 +175,37 @@ static ssize_t capacity_bytes_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(capacity_bytes);
 
+static u64 ramshared_get_stat(struct ramshared_device *rs_dev, int stat_idx)
+{
+	u64 total = 0;
+	int cpu;
+
+	for_each_possible_cpu(cpu) {
+		struct ramshared_stats *stats = per_cpu_ptr(rs_dev->stats, cpu);
+		unsigned int start;
+		u64 val;
+
+		do {
+			start = u64_stats_fetch_begin(&stats->syncp);
+			if (stat_idx == 0)
+				val = stats->read_bytes;
+			else if (stat_idx == 1)
+				val = stats->write_bytes;
+			else
+				val = stats->dma_transfers_total;
+		} while (u64_stats_fetch_retry(&stats->syncp, start));
+		total += val;
+	}
+	return total;
+}
+
 static ssize_t read_bytes_show(struct device *dev,
 				struct device_attribute *attr, char *buf)
 {
 	struct gendisk *disk = dev_to_disk(dev);
 	struct ramshared_device *rs_dev = disk->private_data;
 
-	return sysfs_emit(buf, "%lld\n", atomic64_read(&rs_dev->read_bytes));
+	return sysfs_emit(buf, "%llu\n", ramshared_get_stat(rs_dev, 0));
 }
 static DEVICE_ATTR_RO(read_bytes);
 
@@ -168,9 +215,19 @@ static ssize_t write_bytes_show(struct device *dev,
 	struct gendisk *disk = dev_to_disk(dev);
 	struct ramshared_device *rs_dev = disk->private_data;
 
-	return sysfs_emit(buf, "%lld\n", atomic64_read(&rs_dev->write_bytes));
+	return sysfs_emit(buf, "%llu\n", ramshared_get_stat(rs_dev, 1));
 }
 static DEVICE_ATTR_RO(write_bytes);
+
+static ssize_t dma_transfers_total_show(struct device *dev,
+					struct device_attribute *attr, char *buf)
+{
+	struct gendisk *disk = dev_to_disk(dev);
+	struct ramshared_device *rs_dev = disk->private_data;
+
+	return sysfs_emit(buf, "%llu\n", ramshared_get_stat(rs_dev, 2));
+}
+static DEVICE_ATTR_RO(dma_transfers_total);
 
 static struct attribute *ramshared_attrs[] = {
 	&dev_attr_capacity_bytes.attr,

--- a/drivers/block/ramshared/ramshared.h
+++ b/drivers/block/ramshared/ramshared.h
@@ -7,7 +7,8 @@
 #include <linux/blk-mq.h>
 #include <linux/pci.h>
 #include <linux/mutex.h>
-#include <linux/atomic.h>
+#include <linux/percpu.h>
+#include <linux/u64_stats_sync.h>
 
 #define RAMSHARED_DRIVER_NAME		"ramshared"
 #define RAMSHARED_DRIVER_VERSION	"0.9.0-beta.2"
@@ -30,6 +31,13 @@ struct ramshared_dma_region {
 	dma_addr_t	dma_handle;
 };
 
+struct ramshared_stats {
+	u64			read_bytes;
+	u64			write_bytes;
+	u64			dma_transfers_total;
+	struct u64_stats_sync	syncp;
+};
+
 /**
  * struct ramshared_device - Main in-tree block device state
  * @disk: gendisk descriptor
@@ -49,9 +57,7 @@ struct ramshared_device {
 	u64				capacity_bytes;
 	struct device			*dev;
 	struct mutex			lock;
-	atomic64_t			dma_transfers_total;
-	atomic64_t			read_bytes;
-	atomic64_t			write_bytes;
+	struct ramshared_stats __percpu	*stats;
 };
 
 int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev);


### PR DESCRIPTION
## Resumo
Refactored global `atomic64_t` usage into per-CPU variables with `u64_stats_sync` for bytes read, written, and total DMA transfers in `ramshared_device`. This removes the cacheline bouncing and implied spinlock behavior of `lock xadd` on 32-bit arches/bus locks on 64-bit systems. Also fixed missing `DEVICE_ATTR_RO` for `dma_transfers_total`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| perf(core): eliminate spinlock contention during multi-queue bio completion | Replaced global atomics with per-CPU stats | To eliminate cache line bouncing and optimize request completion path | Adds u64_stats_sync and per-CPU allocations. |

## Issue
Fixes: eliminate spinlock contention during multi-queue bio completion

## Responsavel
Jules

## Labels
type:perf, type:kernel

## Validacao
Ran checkpatch.pl.

## Rollback trigger
Device probe fails (ENOMEM on percpu alloc) or stats zeroed improperly.

---
*PR created automatically by Jules for task [17535278057189903273](https://jules.google.com/task/17535278057189903273) started by @emersonbusson*