### PR TITLE
feat: enforce security descriptor ACL validation on admin IOCTLs

### DIFF
--- a/drivers/windows/ramshared/control.c
+++ b/drivers/windows/ramshared/control.c
@@ -116,6 +116,14 @@ CtlDispatchDeviceControl(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp)
 	inLen = irpSp->Parameters.DeviceIoControl.InputBufferLength;
 	buf = Irp->AssociatedIrp.SystemBuffer;
 
+	status = IoValidateDeviceIoControlAccess(Irp, FILE_READ_ACCESS | FILE_WRITE_ACCESS);
+	if (!NT_SUCCESS(status)) {
+		Irp->IoStatus.Status = status;
+		Irp->IoStatus.Information = 0;
+		IoCompleteRequest(Irp, IO_NO_INCREMENT);
+		return status;
+	}
+
 	switch (code) {
 	case IOCTL_RAMSHARED_REGISTER_QUEUE:
 		if (inLen != sizeof(RAMSHARED_REGISTER) || buf == NULL) {


### PR DESCRIPTION
## Resumo
Added IoValidateDeviceIoControlAccess check in CtlDispatchDeviceControl to enforce security descriptor ACL validation on administrative IOCTLs.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat: enforce security descriptor ACL validation on admin IOCTLs | Added IoValidateDeviceIoControlAccess check | To prevent unauthorized access to control device | Checked NTSTATUS and completed request on failure |

## Issue
N/A

## Responsavel
Jules

## Labels
type:security, type:kernel

## Validacao
cpp drivers/windows/ramshared/control.c > /dev/null
./scripts/ci/check-kernel-style.sh
./scripts/ci/check-kernel-build-matrix.sh
./scripts/ci/check-kernel-qemu-smoke.sh
./scripts/ci/check-adversarial-invariants.sh

## Rollback trigger
Revert IoValidateDeviceIoControlAccess addition if regressions or unexpected STATUS_ACCESS_DENIED occur for legitimate administrators.

---
*PR created automatically by Jules for task [1231438508181619982](https://jules.google.com/task/1231438508181619982) started by @emersonbusson*