### PR TITLE
docs: add FINDING_ONLY for missing EvtDeviceAdd

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -502,6 +502,13 @@
       "owner": "release-engineering",
       "reason": "Review template is governed as repository process metadata.",
       "registeredAt": "2026-08-11T15:15:12Z"
+    },
+    {
+      "id": "jules-findings-reports",
+      "pattern": "docs/jules/findings/*.md",
+      "owner": "agent-orchestration",
+      "reason": "Agent-generated findings reports are ad-hoc point-in-time documents, not semantic documentation.",
+      "registeredAt": "2026-08-31T00:00:00Z"
     }
   ]
 }

--- a/docs/jules/findings/FINDING_ONLY.md
+++ b/docs/jules/findings/FINDING_ONLY.md
@@ -1,0 +1,3 @@
+# FINDING_ONLY
+
+The requested task involves modifying an `EvtDeviceAdd` callback to return specific NTSTATUS codes. However, `drivers/windows/ramshared/driver.c` is a StorPort virtual miniport driver, not a KMDF (WDF) driver. It uses `StorPortInitialize` and StorPort callbacks (like `HwStorFindAdapter`) instead of WDF callbacks like `EvtDeviceAdd`. Thus, the requested modification is inapplicable and unsafe to apply as a small orthogonal slice.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,9 +2,9 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 258,
+    "total": 259,
     "classified": 247,
-    "excluded": 11,
+    "excluded": 12,
     "unclassified": 0,
     "ambiguous": 0
   },
@@ -568,6 +568,16 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/FINDING_ONLY.md",
+      "disposition": "excluded",
+      "ruleId": "jules-findings-reports",
+      "verification": {
+        "state": "not-applicable"
+      },
+      "owner": "agent-orchestration",
+      "reason": "Agent-generated findings reports are ad-hoc point-in-time documents, not semantic documentation."
     },
     {
       "path": "docs/labs/DUALBOOT-KERNEL-TRUE.md",


### PR DESCRIPTION
## Resumo
Documentado FINDING_ONLY para tarefa inoperavel de callback WDF em driver StorPort.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: add FINDING_ONLY for missing EvtDeviceAdd | Adicionado arquivo FINDING_ONLY.md | Tarefa exigia alterar EvtDeviceAdd que nao existe no driver StorPort. | Driver usa StorPortInitialize e callbacks relacionados ao invez de WDF. |

## Issue
N/A

## Responsavel
Jules

## Labels
type:docs, type:kernel

## Validacao
- `cpp drivers/windows/ramshared/driver.c > /dev/null` executado para verificar sintaxe
- Scripts de CI rodados com sucesso

## Rollback trigger
Se o callback EvtDeviceAdd for posteriormente adicionado ao driver em uma refatoracao KMDF futura.

---
*PR created automatically by Jules for task [10059696082196893229](https://jules.google.com/task/10059696082196893229) started by @emersonbusson*