### PR TITLE
kernel-win: add guard clauses in EvtDriverUnload context cleanup

### DIFF
--- a/drivers/windows/ramshared/driver.c
+++ b/drivers/windows/ramshared/driver.c
@@ -249,6 +249,20 @@ HwStorFreeAdapterResources(_In_ PVOID DeviceExtension)
 	}
 }
 
+static PDRIVER_UNLOAD g_OrigUnload = NULL;
+
+VOID
+EvtDriverUnload(_In_ PDRIVER_OBJECT DriverObject)
+{
+	if (DriverObject == NULL)
+		return;
+
+	CtlDeleteControlDevice();
+
+	if (g_OrigUnload != NULL)
+		g_OrigUnload(DriverObject);
+}
+
 NTSTATUS
 DriverEntry(_In_ PDRIVER_OBJECT DriverObject, _In_ PUNICODE_STRING RegistryPath)
 {
@@ -305,5 +319,10 @@ DriverEntry(_In_ PDRIVER_OBJECT DriverObject, _In_ PUNICODE_STRING RegistryPath)
 
 	status = CtlCreateControlDevice(DriverObject, RamsharedSddl,
 					&GUID_DEVINTERFACE_RAMSHARED_CTL);
+	if (NT_SUCCESS(status)) {
+		g_OrigUnload = DriverObject->DriverUnload;
+		DriverObject->DriverUnload = EvtDriverUnload;
+	}
+
 	return status;
 }

--- a/drivers/windows/ramshared/driver.h
+++ b/drivers/windows/ramshared/driver.h
@@ -30,6 +30,7 @@ typedef struct _RAMSHARED_ADAPTER_EXT {
 } RAMSHARED_ADAPTER_EXT, *PRAMSHARED_ADAPTER_EXT;
 
 DRIVER_INITIALIZE DriverEntry;
+DRIVER_UNLOAD EvtDriverUnload;
 
 /* Virtual miniport FindAdapter has LowerDevice (PVIRTUAL_HW_FIND_ADAPTER). */
 ULONG


### PR DESCRIPTION
## Resumo
Adicionado EvtDriverUnload com guard clauses em driver.c para assegurar a liberação do ControlDevice.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | Hook EvtDriverUnload e check driver context | Evitar memory leak do control device na descarga | Guard clauses foram usados |

## Issue
N/A

## Responsavel
Jules

## Labels
type:kernel

## Validacao
./scripts/ci/check-kernel-build-matrix.sh executado com sucesso.

## Rollback trigger
Falha de carregamento do driver ou BSOD no momento do unload.

---
*PR created automatically by Jules for task [15691108986590765530](https://jules.google.com/task/15691108986590765530) started by @emersonbusson*