### PR TITLE
kernel: semantic SCSI status returns on virtual disk boundary violation

### DIFF
--- a/drivers/windows/ramshared/virtdisk.c
+++ b/drivers/windows/ramshared/virtdisk.c
@@ -188,6 +188,33 @@ VdSetSenseNotReady(_Inout_ PSCSI_REQUEST_BLOCK Srb)
 }
 
 /*
+ * Set CHECK CONDITION with ILLEGAL REQUEST (0x05) / LOGICAL BLOCK ADDRESS
+ * OUT OF RANGE (0x21).
+ */
+static VOID
+VdSetSenseIllegalRequest(_Inout_ PSCSI_REQUEST_BLOCK Srb)
+{
+	UCHAR *sense;
+	ULONG senseLen;
+
+	Srb->ScsiStatus = SCSISTAT_CHECK_CONDITION;
+	sense = (UCHAR *)Srb->SenseInfoBuffer;
+	senseLen = Srb->SenseInfoBufferLength;
+	if (sense != NULL && senseLen >= 18) {
+		RtlZeroMemory(sense, senseLen);
+		/* Fixed format sense data (response code 0x70). */
+		sense[0] = 0x70;
+		sense[2] = 0x05 /* ILLEGAL REQUEST */;
+		sense[7] = 10; /* additional sense length */
+		sense[12] = 0x21 /* LOGICAL BLOCK ADDRESS OUT OF RANGE */;
+		sense[13] = 0x00;
+		Srb->SrbStatus = (UCHAR)(SRB_STATUS_ERROR | SRB_STATUS_AUTOSENSE_VALID);
+	} else {
+		Srb->SrbStatus = SRB_STATUS_ERROR;
+	}
+}
+
+/*
  * Standard INQUIRY + VPD 0x00 / 0x80 (unit serial from 16-byte disk serial).
  * CDB[1] EVPD bit, CDB[2] page code (DT-5 / RF-4 / VPD_SERIAL_MATCH).
  */
@@ -506,8 +533,20 @@ VdTranslateSrb(
 					 ((UINT64)Srb->Cdb[4] << 8) |
 					 ((UINT64)Srb->Cdb[5]);
 			}
-			offset *= Disk->block_size;
+
 			len = Srb->DataTransferLength;
+
+			if (offset > (~0ULL) / Disk->block_size) {
+				VdSetSenseIllegalRequest(Srb);
+				break;
+			}
+			offset *= Disk->block_size;
+
+			if (offset + len < offset || offset + len > Disk->size_bytes) {
+				VdSetSenseIllegalRequest(Srb);
+				break;
+			}
+
 			if (op == SCSIOP_READ || op == SCSIOP_READ16) {
 				rop = RAMSHARED_OP_READ;
 			} else {


### PR DESCRIPTION
## Resumo
Adiciona verificacao de limites de hardware (bounds check) no disco virtual. Retorna ILLEGAL REQUEST quando LBA excede a capacidade do disco, evitando operacoes fora dos limites.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| kernel: Add defensive bounds check in virtdisk.c | Adicionou VdSetSenseIllegalRequest e checagem de offset | Evitar falha e overflow | Retorna ILLEGAL REQUEST para offset invalido |

## Labels
type:kernel, type:security

## Validacao
Executou a suite de scripts CI:
- ./scripts/ci/check-kernel-style.sh
- ./scripts/ci/check-kernel-build-matrix.sh
- ./scripts/ci/check-kernel-qemu-smoke.sh
- ./scripts/ci/check-adversarial-invariants.sh

## Rollback trigger
Falhas nos testes de kernel CI.

---
*PR created automatically by Jules for task [4940095127484332616](https://jules.google.com/task/4940095127484332616) started by @emersonbusson*