### PR TITLE
kernel-win: audit packed alignment and typedefs in driver.h

### DIFF
--- a/drivers/windows/ramshared/driver.h
+++ b/drivers/windows/ramshared/driver.h
@@ -18,6 +18,8 @@
  */
 #define RAMSHARED_MATRIX_MAX_IO (256u * 1024u)
 
+#pragma pack(push, 8)
+
 /* Device extension for the StorPort adapter (virtual). */
 typedef struct _RAMSHARED_ADAPTER_EXT {
 	PVOID StorPortExt; /* reserved for StorPort-owned memory */
@@ -25,9 +27,11 @@ typedef struct _RAMSHARED_ADAPTER_EXT {
 	struct _RAMSHARED_QUEUE *Queue;
 	PDEVICE_OBJECT ControlDevice;
 	UNICODE_STRING ControlLink;
-	BOOLEAN QueueRegistered;
-	BOOLEAN AdapterStopped;
+	UINT8 QueueRegistered;
+	UINT8 AdapterStopped;
 } RAMSHARED_ADAPTER_EXT, *PRAMSHARED_ADAPTER_EXT;
+
+#pragma pack(pop)
 
 DRIVER_INITIALIZE DriverEntry;
 


### PR DESCRIPTION
## Resumo
Added `#pragma pack(push, 8)` around `RAMSHARED_ADAPTER_EXT` in `drivers/windows/ramshared/driver.h` and converted `BOOLEAN` types to fixed-width `UINT8` to enforce rigid structure layout and guarantee deterministic ABI sizes across environments.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `kernel-win: audit packed alignment and typedefs in driver.h` | Applied `#pragma pack` and changed `BOOLEAN` to `UINT8` | To prevent non-deterministic sizes of `BOOLEAN` across SDKs and avoid implicit ABI alignment breakage | Enforced explicit 8-byte alignment padding for shared Windows driver structures |

## Issue
N/A

## Responsavel
Jules

## Labels
type:kernel-win, type:refactor

## Validacao
Executed `./scripts/ci/check-kernel-style.sh`, `./scripts/ci/check-kernel-build-matrix.sh`, `./scripts/ci/check-kernel-qemu-smoke.sh`, and `./scripts/ci/check-adversarial-invariants.sh` successfully.

## Rollback trigger
Revert if virtual disk creation in Windows hosts encounters BSOD or STORPORT failures during MSBuild or CI operations.

---
*PR created automatically by Jules for task [3393706265953102758](https://jules.google.com/task/3393706265953102758) started by @emersonbusson*