### PR TITLE
feat(kernel-win): add LBA to byte offset conversion helpers

### DIFF
--- a/drivers/windows/ramshared/virtdisk.h
+++ b/drivers/windows/ramshared/virtdisk.h
@@ -6,6 +6,28 @@
 #include "protocol.h"
 #include "queue.h"
 
+#define VD_SECTOR_SIZE_512  512u
+#define VD_SECTOR_SIZE_4096 4096u
+
+/*
+ * Type-safe helper for LBA to byte offset conversion with 64-bit overflow prevention.
+ * Returns STATUS_SUCCESS on success, or STATUS_INVALID_PARAMETER on overflow.
+ */
+static inline NTSTATUS VdLbaToByteOffset(UINT64 Lba, UINT32 BlockSize, UINT64 *ByteOffset)
+{
+	if (!ByteOffset)
+		return STATUS_INVALID_PARAMETER;
+
+	if (BlockSize == 0)
+		return STATUS_INVALID_PARAMETER;
+
+	if (Lba > (~0ULL) / BlockSize)
+		return STATUS_INVALID_PARAMETER;
+
+	*ByteOffset = Lba * BlockSize;
+	return STATUS_SUCCESS;
+}
+
 typedef enum _VD_STATE {
 	VdStateNone = 0,
 	VdStateCreated,


### PR DESCRIPTION
## Resumo
Added geometry descriptor constants and a type-safe helper macro/function for LBA to byte offset conversion with 64-bit overflow prevention in the Windows virtual disk driver header.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(kernel-win): add LBA to byte offset conversion helpers | Added `VD_SECTOR_SIZE_512`, `VD_SECTOR_SIZE_4096`, and `VdLbaToByteOffset` to `virtdisk.h` | To enforce physical sanity checks and prevent 64-bit arithmetic overflows when converting logical block addresses to byte offsets | Used `~0ULL` for safe bound checking. Returned `STATUS_INVALID_PARAMETER` upon validation failure. |

## Issue
None

## Responsavel
Jules

## Labels
type:kernel, type:security, type:refactor

## Validacao
Executed CI validation scripts: `./scripts/ci/check-kernel-style.sh`, `./scripts/ci/check-kernel-build-matrix.sh`, `./scripts/ci/check-kernel-qemu-smoke.sh`, and `./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
Revert if the inline function causes compilation errors in the Windows WDK build environment or if the check incorrectly blocks valid I/O sizes.

---
*PR created automatically by Jules for task [2577919702257284206](https://jules.google.com/task/2577919702257284206) started by @emersonbusson*