### PR TITLE
feat(kernel-win): define protocol header struct with magic signature

### DIFF
--- a/crates/ramshared-winsvc/src/proto.rs
+++ b/crates/ramshared-winsvc/src/proto.rs
@@ -8,6 +8,7 @@ pub const ABI_VERSION: u32 = 1;
 pub const MAX_QD: u32 = 256;
 pub const MAX_IO: u32 = 1 << 20;
 pub const RING_MAGIC: u32 = 0x5253_5244; // 'RSRD'
+pub const PROTOCOL_MAGIC: u32 = 0x5241_4D53; // 'RAMS'
 
 pub const OP_READ: u32 = 0;
 pub const OP_WRITE: u32 = 1;
@@ -40,6 +41,14 @@ pub struct Cqe {
     pub tag: u64,
     pub status: i32,
     pub reserved: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct ProtocolHdr {
+    pub magic: u32,
+    pub version: u32,
+    pub reserved: [u32; 2],
 }
 
 #[repr(C)]
@@ -81,6 +90,7 @@ const _: () = {
     assert!(core::mem::size_of::<Sqe>() == 32);
     assert!(core::mem::align_of::<Sqe>() <= 8);
     assert!(core::mem::size_of::<Cqe>() == 16);
+    assert!(core::mem::size_of::<ProtocolHdr>() == 16);
     assert!(core::mem::size_of::<RingHdr>() == 16);
     assert!(core::mem::size_of::<Register>() == 72);
     assert!(core::mem::size_of::<DiskParams>() == 32);
@@ -131,5 +141,6 @@ mod tests {
         assert_eq!(MAX_QD, 256);
         assert_eq!(MAX_IO, 1 << 20);
         assert_eq!(RING_MAGIC, 0x5253_5244);
+        assert_eq!(PROTOCOL_MAGIC, 0x5241_4D53);
     }
 }

--- a/docs/governance/rust-slice-coverage.json
+++ b/docs/governance/rust-slice-coverage.json
@@ -156,7 +156,7 @@
         "-p",
         "ramshared-winsvc",
         "--files",
-        "crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs",
+        "crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs,crates/ramshared-winsvc/src/proto.rs",
         "--min",
         "80"
       ],
@@ -170,7 +170,8 @@
         "crates/ramshared-winsvc/src/broker_tenant.rs",
         "crates/ramshared-winsvc/src/runtime.rs",
         "crates/ramshared-winsvc/src/service.rs",
-        "crates/ramshared-winsvc/src/host_safety.rs"
+        "crates/ramshared-winsvc/src/host_safety.rs",
+        "crates/ramshared-winsvc/src/proto.rs"
       ],
       "min": 80
     },

--- a/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
+++ b/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
@@ -489,7 +489,7 @@ those shared sources as evidence without creating a second coverage owner.
 - [x] `cargo clippy -p ramshared-cuda -p ramshared-block -p ramshared-winsvc --all-targets -- -D warnings`
 - [x] `cargo test -p ramshared-cuda -p ramshared-block -p ramshared-winsvc`
 - [x] `cargo build -p ramshared-winsvc --target x86_64-pc-windows-msvc`
-- [x] `node tools/ci/check-rust-slice-coverage.mjs -p ramshared-winsvc --files crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs --min 80`
+- [x] `node tools/ci/check-rust-slice-coverage.mjs -p ramshared-winsvc --files crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs,crates/ramshared-winsvc/src/proto.rs --min 80`
   (also CUDA probe cover ≥80% when `crates/ramshared-cuda/src/probe.rs` is in the gate set)
 - [ ] If pure planning logic changes in `crates/ramshared-cuda/src/driver.rs`, include that file in a
   separate `ramshared-cuda` cover gate at >=80%; hardware-only lines remain live-E2E evidence.

--- a/drivers/windows/ramshared/protocol.h
+++ b/drivers/windows/ramshared/protocol.h
@@ -33,6 +33,7 @@ typedef uint8_t ramshared_u8;
 #define RAMSHARED_MAX_QD 256u	/* queue_depth max; power of two */
 #define RAMSHARED_MAX_IO (1u << 20) /* 1 MiB per bounce slot */
 #define RAMSHARED_RING_MAGIC 0x52535244u /* 'RSRD' */
+#define RAMSHARED_PROTOCOL_MAGIC 0x52414D53u /* 'RAMS' */
 
 enum ramshared_op {
 	RAMSHARED_OP_READ = 0,
@@ -61,6 +62,13 @@ typedef struct _RAMSHARED_CQE {
 	ramshared_i32 status;
 	ramshared_u32 reserved;
 } RAMSHARED_CQE, *PRAMSHARED_CQE;
+
+/* Handshake protocol header */
+typedef struct _RAMSHARED_PROTOCOL_HDR {
+	ramshared_u32 magic;
+	ramshared_u32 version;
+	ramshared_u32 reserved[2];
+} RAMSHARED_PROTOCOL_HDR, *PRAMSHARED_PROTOCOL_HDR;
 
 /* precedes entries[]; SPSC */
 typedef struct _RAMSHARED_RING_HDR {
@@ -111,6 +119,7 @@ typedef struct _RAMSHARED_DISK_PARAMS {
 #ifdef __cplusplus
 static_assert(sizeof(RAMSHARED_SQE) == 32, "RAMSHARED_SQE size");
 static_assert(sizeof(RAMSHARED_CQE) == 16, "RAMSHARED_CQE size");
+static_assert(sizeof(RAMSHARED_PROTOCOL_HDR) == 16, "RAMSHARED_PROTOCOL_HDR size");
 static_assert(sizeof(RAMSHARED_RING_HDR) == 16, "RAMSHARED_RING_HDR size");
 static_assert(sizeof(RAMSHARED_REGISTER) == 72, "RAMSHARED_REGISTER size");
 static_assert(sizeof(RAMSHARED_DISK_PARAMS) == 32, "RAMSHARED_DISK_PARAMS size");


### PR DESCRIPTION
## Resumo
Defined a new `_RAMSHARED_PROTOCOL_HDR` struct with `0x52414D53` ('RAMS') magic bytes and version fields in `drivers/windows/ramshared/protocol.h`, alongside its Rust mirror `ProtocolHdr` in `crates/ramshared-winsvc/src/proto.rs`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(kernel-win): define protocol header struct with magic signature | Defined new struct | To allow version handshake with RAMS magic | <details>Added `RAMSHARED_PROTOCOL_MAGIC` and `_RAMSHARED_PROTOCOL_HDR`.</details> |

## Issue
Closes #046

## Responsavel
@jules

## Labels
type:feat, area:kernel-win

## Validacao
Ran `cargo test` in `crates/ramshared-winsvc` to verify struct size and magic bytes.
Ran standard CI pipeline `check-adversarial-invariants.sh` successfully.

## Rollback trigger
Numerical stall/deadlock > 1ms, kernel panic (BSOD) during IO testing.

---
*PR created automatically by Jules for task [8190816778124140514](https://jules.google.com/task/8190816778124140514) started by @emersonbusson*