### PR TITLE
refactor(c-bench): flatten CLI parser with guard clauses

### DIFF
--- a/tools/benchmarks/kernel_vram_bench.c
+++ b/tools/benchmarks/kernel_vram_bench.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <time.h>
 #include <dlfcn.h>
+#include <errno.h>
 
 #define DEFAULT_CHUNK_MIB 256
 #define MIB_TO_BYTES(mib) ((size_t)(mib) * 1024 * 1024)
@@ -52,12 +53,20 @@ static void *load_cuda_driver(void) {
 
 int main(int argc, char **argv) {
 	int chunk_mib = DEFAULT_CHUNK_MIB;
-	if (argc > 1) {
-		int val = atoi(argv[1]);
-		if (val > 0 && val <= 4096) {
-			chunk_mib = val;
-		}
+
+	if (argc > 1)
+		chunk_mib = atoi(argv[1]);
+
+	if (chunk_mib <= 0) {
+		fprintf(stderr, "[-] Error: Invalid chunk size.\n");
+		return -EINVAL;
 	}
+
+	if (chunk_mib > 4096) {
+		fprintf(stderr, "[-] Error: Chunk size exceeds physical bounds (4096 MiB).\n");
+		return -ERANGE;
+	}
+
 	size_t chunk_bytes = MIB_TO_BYTES(chunk_mib);
 
 	printf("=================================================================\n");


### PR DESCRIPTION
## Resumo
Refatorado o parser de argumentos CLI no benchmark para utilizar guard clauses em vez de blocos aninhados if/else, validando os limites físicos imediatamente e retornando erros semânticos (-EINVAL, -ERANGE).

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(c-bench): flatten CLI parser com guard clauses | Removeu if/else aninhado em kernel_vram_bench.c | Para aderir aos princípios arquiteturais de Clean Architecture e limites físicos | Retorna -EINVAL e -ERANGE para entradas inválidas |

## Issue
c-bench/051

## Responsavel
jules

## Labels
type:refactor

## Validacao
gcc -Wall -Wextra -Werror tools/benchmarks/kernel_vram_bench.c -o tools/benchmarks/kernel_vram_bench -ldl
./scripts/ci/check-kernel-style.sh
./scripts/ci/check-kernel-build-matrix.sh
./scripts/ci/check-kernel-qemu-smoke.sh
./scripts/ci/check-adversarial-invariants.sh

## Rollback trigger
Se falhar compilação ou se a execução do benchmark rejeitar valores válidos (1 a 4096).

---
*PR created automatically by Jules for task [7468725876433634727](https://jules.google.com/task/7468725876433634727) started by @emersonbusson*