### PR TITLE
docs(findings): report WDF architectural mismatch in StorPort driver

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,14 @@
+FINDING_ONLY: Architectural Mismatch - WDF Object Hierarchy in StorPort Driver
+
+The task requests an audit of the WDF (Windows Driver Framework) object hierarchy and parent-child cleanup relationships in `drivers/windows/ramshared/driver.c`.
+
+However, upon auditing `driver.c` and the associated headers, it is evident that the RamShared Windows driver is a StorPort virtual miniport driver, not a KMDF (WDF) driver.
+
+Evidence:
+1. The driver initializes via `StorPortInitialize` in `DriverEntry`, not `WdfDriverCreate`.
+2. It uses WDM/StorPort callbacks (e.g., `HwStorFindAdapter`, `HwStorInitialize`, `HwStorStartIo`), not WDF callbacks (e.g., `EvtDeviceAdd`).
+3. The codebase includes `<ntddk.h>` and `<storport.h>`, and there are no inclusions of `<wdf.h>` or usages of `WDFOBJECT`, `WDFDEVICE`, or other WDF constructs.
+4. An independent WDM control device is created manually via `IoCreateDeviceSecure` (`CtlCreateControlDevice` in `control.c`), which is typical for StorPort miniports exposing a sideband control interface.
+
+Conclusion:
+Safe code modification is not possible due to this architectural mismatch. There are no WDF objects to allocate or hierarchy to audit. The driver's memory management and cleanup must follow WDM and StorPort paradigms (e.g., `HwStorFreeAdapterResources` and manual `IoDeleteDevice` for the control device). No WDF-related code changes can be applied.


### PR DESCRIPTION
## Resumo
O driver do Windows em ramshared é um virtual miniport do StorPort, não um driver KMDF. Portanto, não possui objetos WDF para auditar ou gerenciar hierarquia. Um relatório FINDING_ONLY foi adicionado.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs(findings): report WDF architectural mismatch | Adicionou FINDING_ONLY.txt | Requisição inválida devido à arquitetura | Detalhou a arquitetura StorPort |

## Issue
N/A

## Responsavel
jules

## Labels
type:docs, type:kernel-win

## Validacao
Executado ./scripts/docs-check.sh com sucesso.

## Rollback trigger
Falha no CI de documentação.

---
*PR created automatically by Jules for task [6383208856878421890](https://jules.google.com/task/6383208856878421890) started by @emersonbusson*