### PR TITLE
docs: document impossibility of manual memory allocation fix in IOCTL

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,6 @@
+EVIDENCE FOR FINDING_ONLY:
+The task requested to "prevent integer overflow in IOCTL memory allocation size calculation" by using `RtlULongLongAdd` before allocating kernel pool memory in `drivers/windows/ramshared/control.c`.
+
+However, the file `drivers/windows/ramshared/control.c` utilizes `METHOD_BUFFERED` IOCTLs exclusively. In `METHOD_BUFFERED` IOCTLs, the Windows I/O Manager automatically handles the allocation of the `SystemBuffer` based on `InputBufferLength` and `OutputBufferLength`. The driver itself does not manually allocate kernel pool memory using `ExAllocatePool` or similar APIs within the IOCTL dispatch routine (`CtlDispatchDeviceControl`).
+
+Furthermore, there are no manual buffer allocations in `control.c` that could suffer from integer overflows related to IOCTL memory size calculations. Therefore, the requested modification is not possible because the architectural pattern described in the task (manual allocation inside the IOCTL handler) does not exist in this StorPort virtual miniport control device. The I/O manager is responsible for these allocations.


### PR DESCRIPTION
## Resumo
Added a FINDING_ONLY report explaining that the requested change (preventing overflow in IOCTL memory allocation) is impossible because the driver utilizes METHOD_BUFFERED exclusively. SystemBuffer allocation is handled automatically by the I/O Manager, and there are no manual allocations (e.g. ExAllocatePool) in control.c.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: document impossibility of manual memory allocation fix in IOCTL | Added FINDING_ONLY report | Code modification is not applicable. | METHOD_BUFFERED manages SystemBuffer automatically. |

## Issue
TASK: prevent integer overflow in IOCTL memory allocation size calculation

## Responsavel
Jules

## Labels
type:docs, type:security, type:kernel-win

## Validacao
scripts/docs-check.sh

## Rollback trigger
If there is a failure in the documentation validation CI.

---
*PR created automatically by Jules for task [13787292116113324591](https://jules.google.com/task/13787292116113324591) started by @emersonbusson*