### PR TITLE
feat(c-bench): enforce CPU affinity mask within logical core bounds

### DIFF
--- a/tools/benchmarks/kernel_vram_bench.c
+++ b/tools/benchmarks/kernel_vram_bench.c
@@ -6,12 +6,18 @@
  * across the PCIe bus using page-locked pinned memory and CUDA driver FFI.
  */
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
 #include <time.h>
 #include <dlfcn.h>
+#include <unistd.h>
+#include <sched.h>
+#include <errno.h>
 
 #define DEFAULT_CHUNK_MIB 256
 #define MIB_TO_BYTES(mib) ((size_t)(mib) * 1024 * 1024)
@@ -58,6 +64,25 @@ int main(int argc, char **argv) {
 			chunk_mib = val;
 		}
 	}
+
+	if (argc > 2) {
+		int core_id = atoi(argv[2]);
+		long num_cores = sysconf(_SC_NPROCESSORS_ONLN);
+
+		if (core_id < 0 || core_id >= num_cores) {
+			fprintf(stderr, "[-] Error: Requested CPU core %d is out of range (0-%ld).\n", core_id, num_cores - 1);
+			return -ERANGE;
+		}
+
+		cpu_set_t cpuset;
+		CPU_ZERO(&cpuset);
+		CPU_SET(core_id, &cpuset);
+		if (sched_setaffinity(0, sizeof(cpu_set_t), &cpuset) != 0) {
+			fprintf(stderr, "[-] Error: Failed to set CPU affinity to core %d.\n", core_id);
+			return -EINVAL;
+		}
+	}
+
 	size_t chunk_bytes = MIB_TO_BYTES(chunk_mib);
 
 	printf("=================================================================\n");


### PR DESCRIPTION
## Resumo
Implementado controle rigoroso de afinidade de CPU para o benchmark kernel_vram_bench.c. Adicionado suporte ao segundo argumento da CLI, garantindo que o core requisitado esteja dentro dos limites físicos do sistema através de `sysconf(_SC_NPROCESSORS_ONLN)`, prevenindo execuções cegas.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(c-bench): enforce CPU affinity mask | Adicionada checagem com `sysconf` e `sched_setaffinity` | Prevenir alocação cega para CPUs inexistentes, reforçando resiliência. | Validação `core_id < 0 \|\| core_id >= num_cores` retornando `-ERANGE`. |

## Issue
c-bench/054

## Responsavel
Jules

## Labels
type:refactor, type:kernel

## Validacao
gcc -Wall -Wextra -Werror tools/benchmarks/kernel_vram_bench.c -o vram_bench
./scripts/ci/check-kernel-style.sh
./scripts/ci/check-kernel-build-matrix.sh
./scripts/ci/check-adversarial-invariants.sh

## Rollback trigger
Falhas severas de binding em distribuições onde `sched_setaffinity` não é suportado, resultando na indisponibilidade de testes e falha durante execução do benchmark.

---
*PR created automatically by Jules for task [8740035063880826818](https://jules.google.com/task/8740035063880826818) started by @emersonbusson*