### PR TITLE
perf: use CLOCK_MONOTONIC_RAW for accurate dma benchmark latency

### DIFF
--- a/tools/benchmarks/kernel_vram_bench.c
+++ b/tools/benchmarks/kernel_vram_bench.c
@@ -31,7 +31,7 @@ typedef int (*cuMemcpyDtoH_t)(void*, uint64_t, size_t);
 
 static double get_time_sec(void) {
 	struct timespec ts;
-	clock_gettime(CLOCK_MONOTONIC, &ts);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
 	return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
 }
 


### PR DESCRIPTION
## Resumo
Replaced CLOCK_MONOTONIC with CLOCK_MONOTONIC_RAW to ensure that DMA benchmark timing does not suffer from NTP skew adjustments, maintaining measurement accuracy.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| perf: use CLOCK_MONOTONIC_RAW for accurate dma benchmark latency | Switched CLOCK_MONOTONIC to CLOCK_MONOTONIC_RAW in get_time_sec | To prevent NTP skew from affecting latency measurements | Ensures accurate monotonic measurement without external adjustments |

## Issue
accurate monotonic clock timing with clock_gettime(CLOCK_MONOTONIC_RAW)

## Responsavel
Jules

## Labels
type:perf, type:kernel

## Validacao
gcc -Wall -Wextra -Werror tools/benchmarks/kernel_vram_bench.c -o tools/benchmarks/kernel_vram_bench -ldl && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh

## Rollback trigger
If older environments or containers running the benchmark do not support CLOCK_MONOTONIC_RAW and fail with ENOTSUP.

---
*PR created automatically by Jules for task [18282992437027092697](https://jules.google.com/task/18282992437027092697) started by @emersonbusson*