### PR TITLE
chore(c-bench): report finding on architectural mismatch for ioctl benchmark

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,10 @@
+Task Objective: "Validate character device handle and query device capability before starting timing loop." in tools/benchmarks/kernel_vram_bench.c
+
+Finding: Architectural Mismatch - Cannot Safely Implement
+
+Evidence:
+1. The benchmark `tools/benchmarks/kernel_vram_bench.c` does not interface with a character device or issue ioctls. Instead, it dynamically loads `libcuda.so.1` and uses CUDA driver API FFI (cuInit, cuCtxCreate, cuMemAlloc, cuMemcpyHtoD, etc.) to perform direct DMA benchmarking.
+2. A search across the repository (`grep -rn "ioctl" /usr/include/linux/` and project files) shows no `ioctl` mappings or definitions within the RamShared C kernel headers (`drivers/block/ramshared/ramshared.h` and `compat.h`) that would correspond to character device capability queries (`RAMSHARED_IOC_QUERY_CAP`).
+3. The in-tree Linux kernel driver (`drivers/block/ramshared/main.c`) registers a block device (`add_disk(rs_dev->disk)`) with block multi-queue support, not a character device. The `udev` rules (`packaging/systemd/65-ramshared-observability.rules`) also confirm it acts as a block driver (`/dev/ramshared*`).
+
+Conclusion: Injecting an `open("/dev/...")` call and an ioctl capability check into the benchmark is invalid because it contradicts the fundamental CUDA FFI architecture of the benchmark and targets non-existent character device ioctl capabilities.


### PR DESCRIPTION
## Resumo
Created a FINDING_ONLY report detailing an architectural mismatch preventing the safe implementation of ioctl capability checks in the VRAM benchmark harness.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Create FINDING_ONLY report | Architectural mismatch prevents safe code implementation | Documented evidence that the benchmark uses CUDA FFI and the RamShared kernel module provides a block device, not an ioctl character device. |

## Issue
Adherence to kernel linear cleanup styles and defensive guard clauses in the benchmark suite, resulting in a FINDING_ONLY due to mismatched architecture.

## Responsavel
Jules

## Labels
type:doc, type:c-bench

## Validacao
```bash
./scripts/docs-check.sh
```

## Rollback trigger
If the documentation CI fails or the report is formatted incorrectly.

---
*PR created automatically by Jules for task [5110071051560887161](https://jules.google.com/task/5110071051560887161) started by @emersonbusson*