### PR TITLE
refactor(c-bench): implement graceful SIGINT/SIGTERM cleanup

### DIFF
--- a/tools/benchmarks/kernel_vram_bench.c
+++ b/tools/benchmarks/kernel_vram_bench.c
@@ -12,9 +12,19 @@
 #include <string.h>
 #include <time.h>
 #include <dlfcn.h>
+#include <signal.h>
+#include <errno.h>
 
 #define DEFAULT_CHUNK_MIB 256
 #define MIB_TO_BYTES(mib) ((size_t)(mib) * 1024 * 1024)
+
+static volatile sig_atomic_t g_abort = 0;
+
+static void sig_handler(int signum) {
+	if (signum == SIGINT || signum == SIGTERM) {
+		g_abort = 1;
+	}
+}
 
 typedef int (*cuInit_t)(unsigned int);
 typedef int (*cuDeviceGet_t)(int*, int);
@@ -51,23 +61,41 @@ static void *load_cuda_driver(void) {
 }
 
 int main(int argc, char **argv) {
+	int ret = 0;
 	int chunk_mib = DEFAULT_CHUNK_MIB;
+	size_t chunk_bytes;
+	void *lib = NULL;
+	void *ctx = NULL;
+	void *host_pinned = NULL;
+	void *read_pinned = NULL;
+	uint64_t dev_ptr = 0;
+
 	if (argc > 1) {
 		int val = atoi(argv[1]);
-		if (val > 0 && val <= 4096) {
-			chunk_mib = val;
+		if (val <= 0 || val > 4096) {
+			fprintf(stderr, "[-] Error: Invalid chunk size.\n");
+			return -EINVAL;
 		}
+		chunk_mib = val;
 	}
-	size_t chunk_bytes = MIB_TO_BYTES(chunk_mib);
+	chunk_bytes = MIB_TO_BYTES(chunk_mib);
+
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = sig_handler;
+	if (sigaction(SIGINT, &sa, NULL) != 0 || sigaction(SIGTERM, &sa, NULL) != 0) {
+		fprintf(stderr, "[-] Error: Failed to register signal handlers.\n");
+		return -EINVAL;
+	}
 
 	printf("=================================================================\n");
 	printf("   RamShared Hardware DMA & PCIe Bandwidth Benchmark Tool         \n");
 	printf("=================================================================\n");
 
-	void *lib = load_cuda_driver();
+	lib = load_cuda_driver();
 	if (!lib) {
 		fprintf(stderr, "[-] Error: CUDA driver library (libcuda.so.1) not found.\n");
-		return 1;
+		return -ENODEV;
 	}
 
 	cuInit_t cuInit = (cuInit_t)dlsym(lib, "cuInit");
@@ -83,16 +111,16 @@ int main(int argc, char **argv) {
 	cuMemcpyHtoD_t cuMemcpyHtoD = (cuMemcpyHtoD_t)dlsym(lib, "cuMemcpyHtoD_v2");
 	cuMemcpyDtoH_t cuMemcpyDtoH = (cuMemcpyDtoH_t)dlsym(lib, "cuMemcpyDtoH_v2");
 
-	if (!cuInit || !cuCtxCreate || !cuMemcpyHtoD || !cuMemcpyDtoH) {
+	if (!cuInit || !cuCtxCreate || !cuMemcpyHtoD || !cuMemcpyDtoH || !cuMemAlloc || !cuMemFree || !cuMemHostAlloc || !cuMemFreeHost || !cuCtxDestroy) {
 		fprintf(stderr, "[-] Error: Required CUDA symbols missing in library.\n");
-		dlclose(lib);
-		return 1;
+		ret = -EINVAL;
+		goto err_lib;
 	}
 
 	if (cuInit(0) != 0) {
 		fprintf(stderr, "[-] Error: cuInit failed.\n");
-		dlclose(lib);
-		return 1;
+		ret = -ENODEV;
+		goto err_lib;
 	}
 
 	int dev = 0;
@@ -101,11 +129,10 @@ int main(int argc, char **argv) {
 	cuDeviceGetName(dev_name, sizeof(dev_name), dev);
 	printf("[+] Hardware: %s (PCIe Direct DMA Channel)\n", dev_name);
 
-	void *ctx = NULL;
 	if (cuCtxCreate(&ctx, 0, dev) != 0) {
 		fprintf(stderr, "[-] Error: cuCtxCreate failed.\n");
-		dlclose(lib);
-		return 1;
+		ret = -ENODEV;
+		goto err_lib;
 	}
 
 	size_t free_b = 0, total_b = 0;
@@ -113,27 +140,31 @@ int main(int argc, char **argv) {
 	printf("[+] GPU Memory: %zu MiB free / %zu MiB total\n",
 	       free_b / (1024 * 1024), total_b / (1024 * 1024));
 
-	// Allocate Pinned Host Memory
-	void *host_pinned = NULL;
 	if (cuMemHostAlloc(&host_pinned, chunk_bytes, 0) != 0) {
 		fprintf(stderr, "[-] Error: cuMemHostAlloc failed (%d MiB).\n", chunk_mib);
-		cuCtxDestroy(ctx);
-		dlclose(lib);
-		return 1;
+		ret = -ENOMEM;
+		goto err_ctx;
 	}
 	memset(host_pinned, 0xA5, chunk_bytes);
 
-	// Allocate Device VRAM Buffer
-	uint64_t dev_ptr = 0;
-	if (cuMemAlloc(&dev_ptr, chunk_bytes) != 0) {
-		fprintf(stderr, "[-] Error: cuMemAlloc failed (%d MiB).\n", chunk_mib);
-		cuMemFreeHost(host_pinned);
-		cuCtxDestroy(ctx);
-		dlclose(lib);
-		return 1;
+	if (g_abort) {
+		printf("\n[-] Interrupted by signal. Cleaning up...\n");
+		ret = -EINTR;
+		goto err_host_pinned;
 	}
 
-	// 1. Direct DMA Host -> VRAM (Push)
+	if (cuMemAlloc(&dev_ptr, chunk_bytes) != 0) {
+		fprintf(stderr, "[-] Error: cuMemAlloc failed (%d MiB).\n", chunk_mib);
+		ret = -ENOMEM;
+		goto err_host_pinned;
+	}
+
+	if (g_abort) {
+		printf("\n[-] Interrupted by signal. Cleaning up...\n");
+		ret = -EINTR;
+		goto err_dev_ptr;
+	}
+
 	printf("[+] Benchmarking Host -> VRAM DMA (%d MiB)...\n", chunk_mib);
 	double t0 = get_time_sec();
 	cuMemcpyHtoD(dev_ptr, host_pinned, chunk_bytes);
@@ -142,9 +173,24 @@ int main(int argc, char **argv) {
 	printf("[+] H2D PCIe DMA Write: %.2f MiB/s (%.2f GiB/s) in %.4f s\n",
 	       h2d_speed, h2d_speed / 1024.0, t1 - t0);
 
-	// 2. Direct DMA VRAM -> Host (Pull)
-	void *read_pinned = NULL;
-	cuMemHostAlloc(&read_pinned, chunk_bytes, 0);
+	if (g_abort) {
+		printf("\n[-] Interrupted by signal. Cleaning up...\n");
+		ret = -EINTR;
+		goto err_dev_ptr;
+	}
+
+	if (cuMemHostAlloc(&read_pinned, chunk_bytes, 0) != 0) {
+		fprintf(stderr, "[-] Error: cuMemHostAlloc (read_pinned) failed.\n");
+		ret = -ENOMEM;
+		goto err_dev_ptr;
+	}
+
+	if (g_abort) {
+		printf("\n[-] Interrupted by signal. Cleaning up...\n");
+		ret = -EINTR;
+		goto err_read_pinned;
+	}
+
 	printf("[+] Benchmarking VRAM -> Host DMA (%d MiB)...\n", chunk_mib);
 	t0 = get_time_sec();
 	cuMemcpyDtoH(read_pinned, dev_ptr, chunk_bytes);
@@ -153,18 +199,32 @@ int main(int argc, char **argv) {
 	printf("[+] D2H PCIe DMA Read : %.2f MiB/s (%.2f GiB/s) in %.4f s\n",
 	       d2h_speed, d2h_speed / 1024.0, t1 - t0);
 
-	// 3. Bit-by-bit Verification
+	if (g_abort) {
+		printf("\n[-] Interrupted by signal. Cleaning up...\n");
+		ret = -EINTR;
+		goto err_read_pinned;
+	}
+
 	int match = (memcmp(host_pinned, read_pinned, chunk_bytes) == 0);
 	printf("\n[+] Data Integrity Proof: %s\n",
 	       match ? "PASS (100% Bit-Exact Match, Zero Corruption)" : "FAIL");
 
-	// Cleanup
-	cuMemFree(dev_ptr);
-	cuMemFreeHost(host_pinned);
-	cuMemFreeHost(read_pinned);
-	cuCtxDestroy(ctx);
-	dlclose(lib);
+	if (!match) {
+		ret = -EFAULT;
+	}
 
 	printf("=================================================================\n");
-	return match ? 0 : 1;
+
+err_read_pinned:
+	if (read_pinned) cuMemFreeHost(read_pinned);
+err_dev_ptr:
+	if (dev_ptr) cuMemFree(dev_ptr);
+err_host_pinned:
+	if (host_pinned) cuMemFreeHost(host_pinned);
+err_ctx:
+	if (ctx) cuCtxDestroy(ctx);
+err_lib:
+	if (lib) dlclose(lib);
+
+	return ret;
 }


### PR DESCRIPTION
## Resumo
Added SIGINT and SIGTERM signal handlers to the kernel_vram_bench benchmark to ensure graceful release of CUDA memory upon interruption. Replaced nested logics with guard clauses and flat cleanup labels (Linux Kernel goto cleanup idiom) conforming to architectural rules, utilizing precise semantic errnos (-EINVAL, -ENODEV, -ENOMEM, -EFAULT, -EINTR).

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| refactor(c-bench): implement graceful SIGINT/SIGTERM cleanup | Added interrupt signal and goto cleanups | To guarantee DMA pointers and contexts are not orphaned on Ctrl+C | Used semantic errnos, guard clauses for check limits, global g_abort for handler, iterative labels |

## Issue
None

## Responsavel
Jules

## Labels
type:refactor

## Validacao
Compiled via gcc -Wall -Wextra -Werror tools/benchmarks/kernel_vram_bench.c -o test_bin -ldl

## Rollback trigger
Failure to capture SIGINT (memory leaks still present) or panic reported on CUDA context teardown.

---
*PR created automatically by Jules for task [18307293477541697010](https://jules.google.com/task/18307293477541697010) started by @emersonbusson*