### PR TITLE
docs: report architectural mismatch on pool allocation guard clauses

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,22 @@
+FINDING_ONLY REPORT
+Task: guard clauses on pool allocation handles in poolstress harness
+Objective: Check ExAllocatePoolWithTag return pointers with guard clauses before writing test patterns.
+
+Evidence:
+1. The target file `drivers/windows/tools/poolstress/poolstress.c` does not use `ExAllocatePoolWithTag` for pool allocations. It has been modernized to use `ExAllocatePool2(POOL_FLAG_PAGED, bytes, 'ssPR')` instead.
+2. The requested guard clause is already present. Immediately following the `ExAllocatePool2` call, the codebase explicitly validates the return pointer `g_Pool` before proceeding to write test patterns:
+   ```c
+   g_Pool = ExAllocatePool2(POOL_FLAG_PAGED, bytes, 'ssPR');
+   if (!g_Pool) {
+       status = STATUS_INSUFFICIENT_RESOURCES;
+       break;
+   }
+   ```
+3. Furthermore, the `PoolstressFill` function, which performs the actual writing of test patterns, also begins with a strict guard clause:
+   ```c
+   if (pool == NULL || bytes == 0)
+       return;
+   ```
+
+Conclusion:
+Safe code modification is not necessary or possible due to an architectural mismatch. The driver uses the modern `ExAllocatePool2` API, and all necessary guard clauses enforcing defensive kernel programming principles are already correctly implemented.


### PR DESCRIPTION
## Resumo
Identified an architectural mismatch with the task objective. The target file `drivers/windows/tools/poolstress/poolstress.c` already uses the modern `ExAllocatePool2` API and the required guard clauses for pool allocations are already implemented correctly. Generated a FINDING_ONLY report to document this finding.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: report architectural mismatch on pool allocation guard clauses | Created FINDING_ONLY.txt | The task requested guard clauses for ExAllocatePoolWithTag, but the codebase already uses ExAllocatePool2 with proper verification. | Prevents unnecessary modifications and accurately reports the architectural mismatch. |

## Issue
N/A

## Responsavel
Jules

## Labels
type:docs, type:kernel

## Validacao
Verified file creation using cat and executed `./scripts/docs-check.sh`.

## Rollback trigger
If the created report breaks any documentation CI checks.

---
*PR created automatically by Jules for task [600580602112513366](https://jules.google.com/task/600580602112513366) started by @emersonbusson*