### PR TITLE
fix: validate fixed buffer registration bounds against kernel page size

### DIFF
--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -266,13 +266,14 @@ pub struct UblkCompletion {
     pub result: i32,
 }
 
-/// Validates that fixed buffer parameters are aligned to 4096 bytes and that the
+/// Validates that fixed buffer parameters are aligned to the system page size and that the
 /// total allocation (`queue_depth * buf_size`) does not exceed `RLIMIT_MEMLOCK`.
 pub fn validate_fixed_buffer_params(queue_depth: u16, buf_size: usize) -> io::Result<()> {
-    if buf_size == 0 || !buf_size.is_multiple_of(4096) {
+    let ps = page_size();
+    if buf_size == 0 || !buf_size.is_multiple_of(ps) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "buffer size must be > 0 and a multiple of 4096 bytes",
+            "buffer size must be > 0 and a multiple of the system page size",
         ));
     }
 
@@ -510,12 +511,14 @@ mod tests {
 
     #[test]
     fn test_validate_fixed_buffer_alignment_and_limits() {
+        let ps = page_size();
+
         // Test invalid alignment
-        let err = validate_fixed_buffer_params(2, 4095).expect_err("invalid alignment should fail");
+        let err = validate_fixed_buffer_params(2, ps - 1).expect_err("invalid alignment should fail");
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
 
         // Test valid alignment
-        assert!(validate_fixed_buffer_params(2, 4096).is_ok());
+        assert!(validate_fixed_buffer_params(2, ps).is_ok());
 
         // Test buffer size 0
         let err_zero = validate_fixed_buffer_params(2, 0).expect_err("zero size should fail");
@@ -531,7 +534,7 @@ mod tests {
         if res == 0 && rlim.rlim_cur != libc::RLIM_INFINITY {
             // we create a massive buffer
             // wait, if we pass u16::MAX for queue depth and rlim_cur for buf size...
-            let massive_buf_size = (((rlim.rlim_cur / 4096) + 2) * 4096) as usize;
+            let massive_buf_size = (((rlim.rlim_cur / (ps as u64)) + 2) * (ps as u64)) as usize;
             let huge_err = validate_fixed_buffer_params(2, massive_buf_size)
                 .expect_err("massive buffer should fail");
             assert_eq!(huge_err.raw_os_error(), Some(libc::ERANGE));
@@ -632,13 +635,14 @@ mod tests {
         assert!(ublk_start_dev(fd, 9, std::process::id()).is_err());
         assert!(ublk_stop_dev(fd, 9).is_err());
 
-        let mut server = UblkServer::new(fd, 1, 4096).expect("regular-file server fixture");
+        let ps = page_size();
+        let mut server = UblkServer::new(fd, 1, ps).expect("regular-file server fixture");
         assert_eq!(
             server.io_desc_snapshot(0).expect("zero descriptor"),
             [0u8; 24]
         );
         assert!(server.io_desc_snapshot(1).is_err());
-        assert_eq!(server.buffer_mut(0).expect("tag zero buffer").len(), 4096);
+        assert_eq!(server.buffer_mut(0).expect("tag zero buffer").len(), ps);
         assert!(server.buffer_mut(1).is_err());
         assert!(server.commit_and_fetch(1, 0).is_err());
         server
@@ -655,8 +659,9 @@ mod tests {
 
     #[test]
     fn regular_file_fetch_ring_drains_refusal_without_a_device() {
-        let (path, file) = regular_file_fixture("ublk-fetch-refusal", page_size());
-        let mut ring = UblkFetchRing::submit_fetch_all(file.as_raw_fd(), 2, 4096)
+        let ps = page_size();
+        let (path, file) = regular_file_fixture("ublk-fetch-refusal", ps);
+        let mut ring = UblkFetchRing::submit_fetch_all(file.as_raw_fd(), 2, ps)
             .expect("submit regular-file fetches");
         let deadline = Instant::now() + Duration::from_secs(2);
         let completions = loop {
@@ -676,10 +681,11 @@ mod tests {
 
     #[test]
     fn test_io_uring_worker_timeout_and_cancellation() {
-        let (path, file) = regular_file_fixture("ublk-timeout-cancel", page_size());
+        let ps = page_size();
+        let (path, file) = regular_file_fixture("ublk-timeout-cancel", ps);
         let fd = file.as_raw_fd();
 
-        let mut server = UblkServer::new(fd, 2, 4096).expect("server fixture");
+        let mut server = UblkServer::new(fd, 2, ps).expect("server fixture");
 
         // Simulate a Timeout directly in the server's ring
         let ts = types::Timespec::new().sec(0).nsec(1_000_000); // 1ms
@@ -743,8 +749,9 @@ mod tests {
     }
     #[test]
     fn ublk_server_push_guard_clause_rejects_full_ring() {
-        let (path, file) = regular_file_fixture("ublk-full-ring", page_size());
-        let mut server = UblkServer::new(file.as_raw_fd(), 2, 4096).expect("server fixture");
+        let ps = page_size();
+        let (path, file) = regular_file_fixture("ublk-full-ring", ps);
+        let mut server = UblkServer::new(file.as_raw_fd(), 2, ps).expect("server fixture");
 
         // Ring capacity is 2. Push 2 items, 3rd should fail.
         assert!(server.push(0, 0, 0, 0).is_ok());

--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -514,7 +514,8 @@ mod tests {
         let ps = page_size();
 
         // Test invalid alignment
-        let err = validate_fixed_buffer_params(2, ps - 1).expect_err("invalid alignment should fail");
+        let err =
+            validate_fixed_buffer_params(2, ps - 1).expect_err("invalid alignment should fail");
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
 
         // Test valid alignment


### PR DESCRIPTION
## Resumo
Update buffer size validation in `validate_fixed_buffer_params` and related tests to dynamically use `page_size()` instead of the hardcoded value 4096.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix: validate fixed buffer registration bounds against kernel page size | Updated `validate_fixed_buffer_params` to use `page_size()` | Prevent failures on non-x86 architectures where kernel page size is not 4096 | Adjusted tests that explicitly assumed buffer size 4096 |

## Issue
Fix fixed buffer registration alignment

## Responsavel
Jules

## Labels
type:kernel

## Validacao
- `./scripts/ci/check-kernel-style.sh`
- `./scripts/ci/check-kernel-build-matrix.sh`
- `./scripts/ci/check-kernel-qemu-smoke.sh`
- `./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
CI test failures regarding buffer compilation or validation

---
*PR created automatically by Jules for task [17347928250396431007](https://jules.google.com/task/17347928250396431007) started by @emersonbusson*