### PR TITLE
feat(dxg): map dxgkrnl errno return -EFAULT to typed Rust enum

### DIFF
--- a/crates/ramshared-dxg/src/lib.rs
+++ b/crates/ramshared-dxg/src/lib.rs
@@ -85,6 +85,7 @@ pub enum DxgError {
     UnsupportedHardware,
     BufferOverflow,
     PermissionDenied,
+    InvalidPointer,
     NoAdapters,
     AmbiguousAdapters(usize),
     AdapterNotFound(AdapterLuid),
@@ -101,6 +102,7 @@ impl fmt::Display for DxgError {
             Self::UnsupportedHardware => write!(f, "dxg unsupported hardware"),
             Self::BufferOverflow => write!(f, "dxg buffer overflow"),
             Self::PermissionDenied => write!(f, "dxg permission denied"),
+            Self::InvalidPointer => write!(f, "dxg invalid pointer"),
             Self::NoAdapters => write!(f, "dxg returned no adapters"),
             Self::AmbiguousAdapters(count) => {
                 write!(f, "dxg returned {count} adapters; explicit LUID required")
@@ -117,6 +119,7 @@ impl std::error::Error for DxgError {}
 impl DxgError {
     pub fn from_sys_error(error: std::io::Error) -> Self {
         match error.raw_os_error() {
+            Some(libc::EFAULT) => Self::InvalidPointer,
             Some(libc::ENODEV) => Self::DeviceNotFound,
             Some(libc::ENOTTY) => Self::UnsupportedHardware,
             Some(libc::EOVERFLOW) => Self::BufferOverflow,
@@ -389,6 +392,10 @@ mod tests {
             super::DxgError::from_sys_error(std::io::Error::from_raw_os_error(1)),
             super::DxgError::PermissionDenied
         );
+        assert_eq!(
+            super::DxgError::from_sys_error(std::io::Error::from_raw_os_error(14)),
+            super::DxgError::InvalidPointer
+        );
         let unknown = super::DxgError::from_sys_error(std::io::Error::from_raw_os_error(9999));
         assert!(matches!(unknown, super::DxgError::Io(_)));
     }
@@ -412,6 +419,7 @@ mod tests {
             super::DxgError::UnsupportedHardware,
             super::DxgError::BufferOverflow,
             super::DxgError::PermissionDenied,
+            super::DxgError::InvalidPointer,
         ];
         for error in cases {
             assert!(!error.to_string().is_empty());


### PR DESCRIPTION
## Resumo
Adds a missing semantic mapping for the `-EFAULT` kernel error code, returning it as a typed `DxgError::InvalidPointer` variant instead of a generic IO error string.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(dxg): map dxgkrnl errno return -EFAULT to typed Rust enum | Added EFAULT to ioctl error mapping. | To ensure safe semantic returns from Rust ffi for invalid user space pointers. | Added DxgError::InvalidPointer, tested, and implemented Display. |

## Issue
N/A

## Responsavel
KernelC-100

## Labels
type:refactor

## Validacao
./scripts/ci/check-kernel-style.sh
./scripts/ci/check-kernel-build-matrix.sh
./scripts/ci/check-kernel-qemu-smoke.sh
./scripts/ci/check-adversarial-invariants.sh

## Rollback trigger
Compilation error or test failures related to DxgError in ramshared-dxg crate.

---
*PR created automatically by Jules for task [8668369958324496817](https://jules.google.com/task/8668369958324496817) started by @emersonbusson*