### PR TITLE
feat(ffi): map CUDA error codes to semantic enum

### DIFF
--- a/crates/ramshared-cuda/src/driver.rs
+++ b/crates/ramshared-cuda/src/driver.rs
@@ -12,7 +12,10 @@
 use core::ffi::{CStr, c_char, c_void};
 use core::fmt;
 
-use crate::ffi::{CUDA_SUCCESS, CuContext, CuDevice, CuDevicePtr, CuResult, Syms};
+use crate::ffi::{
+    CUDA_ERROR_INVALID_VALUE, CUDA_ERROR_OUT_OF_MEMORY, CUDA_SUCCESS, CuContext, CuDevice,
+    CuDevicePtr, CuResult, Syms,
+};
 
 /// CUDA layer error representation. No `panic`/`unwrap` in production paths (coding.md rules).
 #[derive(Debug)]
@@ -29,6 +32,10 @@ pub enum CudaError {
     },
     /// VRAM memory region access out of bounds (offset + len > size).
     OutOfRange { off: usize, len: usize, size: usize },
+    /// Out of memory error.
+    OutOfMemory { op: &'static str },
+    /// Invalid value (e.g. invalid alignment).
+    InvalidValue { op: &'static str },
 }
 
 impl fmt::Display for CudaError {
@@ -41,6 +48,12 @@ impl fmt::Display for CudaError {
             }
             CudaError::OutOfRange { off, len, size } => {
                 write!(f, "out of bounds access: off={off} len={len} > size={size}")
+            }
+            CudaError::OutOfMemory { op } => {
+                write!(f, "{op} failed: out of memory")
+            }
+            CudaError::InvalidValue { op } => {
+                write!(f, "{op} failed: invalid value")
             }
         }
     }
@@ -329,14 +342,15 @@ fn load_sym_opt<T: Copy>(handle: *mut c_void, name: &CStr) -> Option<T> {
 }
 
 fn check(syms: &Syms, r: CuResult, op: &'static str) -> Result<(), CudaError> {
-    if r == CUDA_SUCCESS {
-        Ok(())
-    } else {
-        Err(CudaError::Driver {
+    match r {
+        CUDA_SUCCESS => Ok(()),
+        CUDA_ERROR_OUT_OF_MEMORY => Err(CudaError::OutOfMemory { op }),
+        CUDA_ERROR_INVALID_VALUE => Err(CudaError::InvalidValue { op }),
+        _ => Err(CudaError::Driver {
             op,
             code: r,
             msg: err_string(syms, r),
-        })
+        }),
     }
 }
 

--- a/crates/ramshared-cuda/src/ffi.rs
+++ b/crates/ramshared-cuda/src/ffi.rs
@@ -14,6 +14,8 @@ use core::ffi::{c_char, c_int, c_uint, c_void};
 
 pub type CuResult = c_int;
 pub const CUDA_SUCCESS: CuResult = 0;
+pub const CUDA_ERROR_INVALID_VALUE: CuResult = 1;
+pub const CUDA_ERROR_OUT_OF_MEMORY: CuResult = 2;
 
 pub type CuDevice = c_int;
 pub type CuContext = *mut c_void;

--- a/crates/ramshared-cuda/src/lib.rs
+++ b/crates/ramshared-cuda/src/lib.rs
@@ -61,12 +61,12 @@ mod tests {
     fn driver_error_carries_op_and_code() {
         let e = CudaError::Driver {
             op: "cuMemAlloc",
-            code: 2,
+            code: 999,
             msg: "out of memory".to_string(),
         };
         let s = e.to_string();
         assert!(s.contains("cuMemAlloc"));
-        assert!(s.contains("CUresult=2"));
+        assert!(s.contains("CUresult=999"));
     }
 
     /// Real Host→VRAM→Host roundtrip. Requires a working CUDA GPU (WSL2/GPU-PV).

--- a/crates/ramshared-cuda/src/vram_impl.rs
+++ b/crates/ramshared-cuda/src/vram_impl.rs
@@ -14,6 +14,8 @@ impl From<CudaError> for VramError {
                 len: len as u64,
                 size: size as u64,
             },
+            CudaError::OutOfMemory { .. } => VramError::OutOfMemory,
+            CudaError::InvalidValue { .. } => VramError::InvalidAlignment,
             other => VramError::Provider(other.to_string()),
         }
     }

--- a/crates/ramshared-cuda/src/vram_impl.rs
+++ b/crates/ramshared-cuda/src/vram_impl.rs
@@ -89,7 +89,7 @@ mod tests {
     fn test_vram_error_conversion_provider() {
         let cuda_err = CudaError::Driver {
             op: "cuMemAlloc",
-            code: 2,
+            code: 999,
             msg: "out of memory".to_string(),
         };
         let vram_err: VramError = cuda_err.into();
@@ -97,7 +97,7 @@ mod tests {
         match vram_err {
             VramError::Provider(msg) => {
                 assert!(msg.contains("cuMemAlloc"));
-                assert!(msg.contains("CUresult=2"));
+                assert!(msg.contains("CUresult=999"));
             }
             _ => panic!("Expected VramError::Provider"),
         }

--- a/docs/governance/rust-slice-coverage.json
+++ b/docs/governance/rust-slice-coverage.json
@@ -306,6 +306,32 @@
       "min": 80
     },
     {
+      "id": "cuda-driver-ffi-abi",
+      "kind": "rust-line-coverage",
+      "spec": "docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md",
+      "command": [
+        "node",
+        "tools/ci/check-rust-slice-coverage.mjs",
+        "-p",
+        "ramshared-cuda",
+        "--files",
+        "crates/ramshared-cuda/src/ffi.rs,crates/ramshared-cuda/src/driver.rs,crates/ramshared-cuda/src/vram_impl.rs",
+        "--min",
+        "80",
+        "--report-json",
+        "tmp/cuda-driver-ffi-abi-cov.json"
+      ],
+      "packages": [
+        "ramshared-cuda"
+      ],
+      "files": [
+        "crates/ramshared-cuda/src/ffi.rs",
+        "crates/ramshared-cuda/src/driver.rs",
+        "crates/ramshared-cuda/src/vram_impl.rs"
+      ],
+      "min": 80
+    },
+    {
       "id": "cuda-probe-planning-coverage",
       "kind": "rust-line-coverage",
       "spec": "docs/specs/no-milestone/comment-language-integrity/SPEC.md",

--- a/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
+++ b/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
@@ -532,3 +532,7 @@ those shared sources as evidence without creating a second coverage owner.
   StartIo and manufactured pagefile refuse are claimed. **Separate non-claims:** daily-host physical
   Online (policy), WSL2 freeze-elimination (env-bound isolated lab only). **SDV closed as N/A
   (DT-30), not pending.**
+
+```bash
+node tools/ci/check-rust-slice-coverage.mjs -p ramshared-cuda --files crates/ramshared-cuda/src/ffi.rs,crates/ramshared-cuda/src/driver.rs,crates/ramshared-cuda/src/vram_impl.rs --min 80 --report-json tmp/cuda-driver-ffi-abi-cov.json
+```


### PR DESCRIPTION
## Resumo
Mapped `CUDA_ERROR_OUT_OF_MEMORY` and `CUDA_ERROR_INVALID_VALUE` to explicit Rust variants (`CudaError::OutOfMemory` and `CudaError::InvalidValue`) instead of generic driver errors, and safely converted them into `VramError` mappings to preserve precise semantic error returns.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(ffi): map CUDA error codes to semantic enum | Added CUDA constants, modified `CudaError`, and updated VRAM error trait conversion | To enforce specific semantic kernel error returns and avoid masking out-of-memory or invalid alignment conditions | Added `CUDA_ERROR_INVALID_VALUE` (1) and `CUDA_ERROR_OUT_OF_MEMORY` (2) to ffi, replaced `if` with `match` in `driver::check`, and updated `vram_impl` conversion |

## Issue
N/A

## Responsavel
KernelC100

## Labels
type:feat, type:ffi

## Validacao
Executed CI tests and confirmed semantic mapping integration.

## Rollback trigger
If CUDA driver begins returning alternate error codes for memory allocation failures and our `InvalidValue` mapping masks legitimate API variations in `vram_impl`.

---
*PR created automatically by Jules for task [3682089915902058025](https://jules.google.com/task/3682089915902058025) started by @emersonbusson*