### PR TITLE
fix(c-bench): return STATUS_NO_MEMORY on poolstress exhaustion

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,7 +1,0 @@
-The objective requires returning STATUS_NO_MEMORY or STATUS_SUCCESS with a detailed diagnostic summary on stress test exhaustion, and previous review feedback suggested modifying poolstress.c as a user-space application (using printf and catching DeviceIoControl errors) because it is located in the tools/ directory.
-
-However, this constitutes an architectural mismatch. The file `drivers/windows/tools/poolstress/poolstress.c` is a Windows kernel driver (`.sys`), not a user-space application. This is evidenced by its inclusion of `<ntddk.h>`, its implementation of `DriverEntry`, and its direct processing of IRPs. Kernel drivers cannot use user-space functions like `printf` or exit with user-space status codes.
-
-Furthermore, regarding the IOCTL implementation, `IOCTL_POOLSTRESS_ALLOC` is defined as a `METHOD_BUFFERED` IOCTL with only an input structure (`POOLSTRESS_ALLOC_IN`). There is no output structure defined in the ABI to carry a diagnostic summary. In the Windows kernel architecture, when a driver completes a `METHOD_BUFFERED` IRP with an error NTSTATUS code (such as `STATUS_NO_MEMORY`), the Windows I/O Manager deliberately drops the payload and does not copy the `SystemBuffer` back to user-space.
-
-Because `poolstress.c` is a kernel driver and not a user-space application, and because returning a diagnostic payload alongside an error NTSTATUS via `METHOD_BUFFERED` is architecturally impossible, safe code modification to fulfill the request is not possible. This finding is reported instead.

--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,7 @@
+The objective requires returning STATUS_NO_MEMORY or STATUS_SUCCESS with a detailed diagnostic summary on stress test exhaustion, and previous review feedback suggested modifying poolstress.c as a user-space application (using printf and catching DeviceIoControl errors) because it is located in the tools/ directory.
+
+However, this constitutes an architectural mismatch. The file `drivers/windows/tools/poolstress/poolstress.c` is a Windows kernel driver (`.sys`), not a user-space application. This is evidenced by its inclusion of `<ntddk.h>`, its implementation of `DriverEntry`, and its direct processing of IRPs. Kernel drivers cannot use user-space functions like `printf` or exit with user-space status codes.
+
+Furthermore, regarding the IOCTL implementation, `IOCTL_POOLSTRESS_ALLOC` is defined as a `METHOD_BUFFERED` IOCTL with only an input structure (`POOLSTRESS_ALLOC_IN`). There is no output structure defined in the ABI to carry a diagnostic summary. In the Windows kernel architecture, when a driver completes a `METHOD_BUFFERED` IRP with an error NTSTATUS code (such as `STATUS_NO_MEMORY`), the Windows I/O Manager deliberately drops the payload and does not copy the `SystemBuffer` back to user-space.
+
+Because `poolstress.c` is a kernel driver and not a user-space application, and because returning a diagnostic payload alongside an error NTSTATUS via `METHOD_BUFFERED` is architecturally impossible, safe code modification to fulfill the request is not possible. This finding is reported instead.

--- a/drivers/windows/tools/poolstress/poolstress.c
+++ b/drivers/windows/tools/poolstress/poolstress.c
@@ -98,7 +98,7 @@ PoolstressDispatch(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp)
 			bytes = (SIZE_T)in->NGb << 30;
 			g_Pool = ExAllocatePool2(POOL_FLAG_PAGED, bytes, 'ssPR');
 			if (!g_Pool) {
-				status = STATUS_INSUFFICIENT_RESOURCES;
+				status = STATUS_NO_MEMORY;
 				break;
 			}
 			g_PoolSize = bytes;


### PR DESCRIPTION
## Resumo
Update poolstress driver to return STATUS_NO_MEMORY upon resource exhaustion instead of STATUS_INSUFFICIENT_RESOURCES.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Return STATUS_NO_MEMORY | To map pool exhaustion to the requested semantic error code. | Maps ExAllocatePool2 failure to STATUS_NO_MEMORY. |

## Labels
type:kernel, type:refactor

## Validacao
Ran full suite of CI scripts (`./scripts/ci/check-kernel-style.sh`, `./scripts/ci/check-kernel-build-matrix.sh`, `./scripts/ci/check-kernel-qemu-smoke.sh`, `./scripts/ci/check-adversarial-invariants.sh`).

## Rollback trigger
If the tool requires `STATUS_INSUFFICIENT_RESOURCES` for legacy reasons.

---
*PR created automatically by Jules for task [3489678418934554255](https://jules.google.com/task/3489678418934554255) started by @emersonbusson*