### PR TITLE
feat: guard clauses for Windows named pipe handle validity

### DIFF
--- a/crates/ramshared-winbroker/src/pipe.rs
+++ b/crates/ramshared-winbroker/src/pipe.rs
@@ -246,15 +246,16 @@ impl Drop for PipeServer {
 }
 
 fn run_connect(handle: HANDLE, stop: &AtomicBool, deadline: Instant) -> Result<(), PipeAuthError> {
+    if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+        return Err(io::Error::from_raw_os_error(22).into());
+    }
     let event = unsafe { CreateEventW(std::ptr::null(), 1, 0, std::ptr::null()) };
     if event.is_null() {
         return Err(io::Error::last_os_error().into());
     }
     let event = Handle(event);
-    let mut overlapped = OVERLAPPED {
-        hEvent: event.0,
-        ..Default::default()
-    };
+    let mut overlapped = unsafe { std::mem::zeroed::<OVERLAPPED>() };
+    overlapped.hEvent = event.0;
     if unsafe { ConnectNamedPipe(handle, &mut overlapped) } == 0 {
         let error = unsafe { GetLastError() };
         if error != ERROR_IO_PENDING {
@@ -439,16 +440,17 @@ fn overlapped_io(
     write: bool,
     stop: Option<&AtomicBool>,
 ) -> io::Result<usize> {
+    if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+        return Err(io::Error::from_raw_os_error(22));
+    }
     let length = u32::try_from(len).unwrap_or(u32::MAX);
     let event = unsafe { CreateEventW(std::ptr::null(), 1, 0, std::ptr::null()) };
     if event.is_null() {
         return Err(io::Error::last_os_error());
     }
     let event = Handle(event);
-    let mut overlapped = OVERLAPPED {
-        hEvent: event.0,
-        ..Default::default()
-    };
+    let mut overlapped = unsafe { std::mem::zeroed::<OVERLAPPED>() };
+    overlapped.hEvent = event.0;
     let started = unsafe {
         if write {
             WriteFile(


### PR DESCRIPTION
## Resumo
Added guard clauses in `run_connect` and `overlapped_io` to validate handle non-nullness and validity.
Replaced `OVERLAPPED { ..Default::default() }` with `unsafe { std::mem::zeroed::<OVERLAPPED>() }` to properly zero-initialize the struct, avoiding potential uninitialized padding issues during FFI boundary crossing.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: validate handle and zero OVERLAPPED | Add handle validation; use `zeroed` for OVERLAPPED | Prevent kernel faults from invalid handles and uninitialized struct padding | Check `is_null()` and `INVALID_HANDLE_VALUE`, return EINVAL |

## Issue
- None

## Responsavel
- Jules

## Labels
- type:refactor
- type:kernel

## Validacao
- `cargo test -p ramshared-winbroker && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
- Revert if callers break due to `EINVAL` (22) or if `std::mem::zeroed` causes unforeseen initialization issues with `OVERLAPPED`.

---
*PR created automatically by Jules for task [5726779009687643632](https://jules.google.com/task/5726779009687643632) started by @emersonbusson*