### PR TITLE
test(ffi-abi): audit io_uring_sqe layout

### DIFF
--- a/crates/ramshared-uring/Cargo.toml
+++ b/crates/ramshared-uring/Cargo.toml
@@ -18,3 +18,6 @@ libc = "0.2"
 [lints.clippy]
 unwrap_used = "deny"
 expect_used = "deny"
+
+[dev-dependencies]
+libc = "0.2"

--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -13,6 +13,13 @@ use std::ptr;
 
 use io_uring::{IoUring, opcode, squeue, types};
 
+/// A compile-time check enforcing the exact `#[repr(C)]` memory layout of the
+/// submission queue entry, verifying that the structure is strictly 64 bytes.
+/// This ensures ABI compatibility and that `user_data` aligns with the C kernel.
+const _: () = {
+    assert!(std::mem::size_of::<squeue::Entry>() == 64, "io_uring_sqe struct layout mismatch");
+};
+
 /// Returns the system page size (`sysconf(_SC_PAGESIZE)`), falling back to 4096.
 pub fn page_size() -> usize {
     // SAFETY: Calling `sysconf` with `_SC_PAGESIZE` has no side effects and is always
@@ -758,5 +765,16 @@ mod tests {
         drop(server);
         drop(file);
         fs::remove_file(path).expect("remove fixture");
+    }
+
+    #[test]
+    fn test_io_uring_sqe_user_data_offset() {
+        let e = io_uring::opcode::Nop::new().build().user_data(0xDEADBEEFCAFEBABEu64);
+        let e_ptr = &e as *const _ as *const u8;
+        // SAFETY: The Entry is guaranteed to be 64 bytes by the compile-time assertion.
+        let slice = unsafe { std::slice::from_raw_parts(e_ptr, 64) };
+        let expected = 0xDEADBEEFCAFEBABEu64.to_ne_bytes();
+        let actual = &slice[32..40];
+        assert_eq!(actual, expected, "user_data must be exactly at offset 32 to match io_uring_sqe");
     }
 }

--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -17,7 +17,10 @@ use io_uring::{IoUring, opcode, squeue, types};
 /// submission queue entry, verifying that the structure is strictly 64 bytes.
 /// This ensures ABI compatibility and that `user_data` aligns with the C kernel.
 const _: () = {
-    assert!(std::mem::size_of::<squeue::Entry>() == 64, "io_uring_sqe struct layout mismatch");
+    assert!(
+        std::mem::size_of::<squeue::Entry>() == 64,
+        "io_uring_sqe struct layout mismatch"
+    );
 };
 
 /// Returns the system page size (`sysconf(_SC_PAGESIZE)`), falling back to 4096.
@@ -769,12 +772,17 @@ mod tests {
 
     #[test]
     fn test_io_uring_sqe_user_data_offset() {
-        let e = io_uring::opcode::Nop::new().build().user_data(0xDEADBEEFCAFEBABEu64);
+        let e = io_uring::opcode::Nop::new()
+            .build()
+            .user_data(0xDEADBEEFCAFEBABEu64);
         let e_ptr = &e as *const _ as *const u8;
         // SAFETY: The Entry is guaranteed to be 64 bytes by the compile-time assertion.
         let slice = unsafe { std::slice::from_raw_parts(e_ptr, 64) };
         let expected = 0xDEADBEEFCAFEBABEu64.to_ne_bytes();
         let actual = &slice[32..40];
-        assert_eq!(actual, expected, "user_data must be exactly at offset 32 to match io_uring_sqe");
+        assert_eq!(
+            actual, expected,
+            "user_data must be exactly at offset 32 to match io_uring_sqe"
+        );
     }
 }


### PR DESCRIPTION
## Resumo
Audit `io_uring_sqe` struct layout and 64-bit `user_data` tagging in `crates/ramshared-uring/src/lib.rs`. This ensures ABI compatibility with the C kernel, confirming that the structure is strictly 64 bytes and `user_data` aligns accurately at offset 32.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| test(ffi-abi): audit io_uring_sqe layout | Added `const _` layout check and test `test_io_uring_sqe_user_data_offset`. | Ensure compatibility with `#[repr(C)]` 64-byte layout and 32-byte offset for user_data. | Strict validation against the C kernel's `struct io_uring_sqe`. |

## Issue
Issue: ffi-abi

## Responsavel
Jules

## Labels
type:ffi-abi

## Validacao
Compiled and ran tests through CI scripts: `check-kernel-style.sh`, `check-kernel-build-matrix.sh`, `check-kernel-qemu-smoke.sh`, `check-adversarial-invariants.sh` as well as `cargo test -p ramshared-uring`.

## Rollback trigger
Any build failure or kernel test regression when interacting with the io_uring submission queues due to ABI layout mismatches.

---
*PR created automatically by Jules for task [7284399542582430436](https://jules.google.com/task/7284399542582430436) started by @emersonbusson*