### PR TITLE
docs(findings): report architectural mismatch for CRC32 FFI in hash.rs

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,7 @@
+FINDING_ONLY: Architectural Mismatch
+
+The task requests to "audit C SIMD CRC32 acceleration FFI bindings and buffer alignment" in the target file `crates/ramshared-integrity/src/hash.rs`.
+
+However, upon inspecting `crates/ramshared-integrity/src/hash.rs`, no C SIMD CRC32 acceleration or FFI bindings are present. The file is written in pure safe Rust and implements a basic FNV-1a 64-bit hashing algorithm (using `FNV_OFFSET` and `FNV_PRIME`). It does not rely on hardware-accelerated CRC32 routines, SIMD instructions, or C FFI boundaries, making the request to enforce 16/32-byte alignment on memory buffers passed to hardware-accelerated CRC32 routines an architectural mismatch.
+
+Therefore, no C or FFI buffer alignment modifications can be applied.


### PR DESCRIPTION
## Resumo
Report architectural mismatch in `crates/ramshared-integrity/src/hash.rs` since it implements pure Rust FNV-1a hashing and contains no C SIMD CRC32 acceleration or FFI bindings.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs(findings): report architectural mismatch for CRC32 FFI in hash.rs | Added FINDING_ONLY.txt | Requested audit for C SIMD CRC32 FFI bindings targets a file using pure Rust FNV-1a. | Documented architectural mismatch instead of fabricating missing C FFI. |

## Issue
N/A

## Responsavel
KernelC100/2026-08-30/ffi-abi/085

## Labels
type:documentation, type:findings

## Validacao
Executed `./scripts/docs-check.sh` and CI scripts.

## Rollback trigger
Revert if the document conflicts with findings policy or CI fails.

---
*PR created automatically by Jules for task [10503886710995205867](https://jules.google.com/task/10503886710995205867) started by @emersonbusson*