### PR TITLE
fix: prevent handle leak on vram bench initialization failure

### DIFF
--- a/tools/benchmarks/kernel_vram_bench.c
+++ b/tools/benchmarks/kernel_vram_bench.c
@@ -83,16 +83,16 @@ int main(int argc, char **argv) {
 	cuMemcpyHtoD_t cuMemcpyHtoD = (cuMemcpyHtoD_t)dlsym(lib, "cuMemcpyHtoD_v2");
 	cuMemcpyDtoH_t cuMemcpyDtoH = (cuMemcpyDtoH_t)dlsym(lib, "cuMemcpyDtoH_v2");
 
-	if (!cuInit || !cuCtxCreate || !cuMemcpyHtoD || !cuMemcpyDtoH) {
+	if (!cuInit || !cuDeviceGet || !cuDeviceGetName || !cuCtxCreate ||
+	    !cuCtxDestroy || !cuMemGetInfo || !cuMemAlloc || !cuMemFree ||
+	    !cuMemHostAlloc || !cuMemFreeHost || !cuMemcpyHtoD || !cuMemcpyDtoH) {
 		fprintf(stderr, "[-] Error: Required CUDA symbols missing in library.\n");
-		dlclose(lib);
-		return 1;
+		goto err_lib;
 	}
 
 	if (cuInit(0) != 0) {
 		fprintf(stderr, "[-] Error: cuInit failed.\n");
-		dlclose(lib);
-		return 1;
+		goto err_lib;
 	}
 
 	int dev = 0;
@@ -104,8 +104,7 @@ int main(int argc, char **argv) {
 	void *ctx = NULL;
 	if (cuCtxCreate(&ctx, 0, dev) != 0) {
 		fprintf(stderr, "[-] Error: cuCtxCreate failed.\n");
-		dlclose(lib);
-		return 1;
+		goto err_lib;
 	}
 
 	size_t free_b = 0, total_b = 0;
@@ -117,9 +116,7 @@ int main(int argc, char **argv) {
 	void *host_pinned = NULL;
 	if (cuMemHostAlloc(&host_pinned, chunk_bytes, 0) != 0) {
 		fprintf(stderr, "[-] Error: cuMemHostAlloc failed (%d MiB).\n", chunk_mib);
-		cuCtxDestroy(ctx);
-		dlclose(lib);
-		return 1;
+		goto err_ctx;
 	}
 	memset(host_pinned, 0xA5, chunk_bytes);
 
@@ -127,10 +124,7 @@ int main(int argc, char **argv) {
 	uint64_t dev_ptr = 0;
 	if (cuMemAlloc(&dev_ptr, chunk_bytes) != 0) {
 		fprintf(stderr, "[-] Error: cuMemAlloc failed (%d MiB).\n", chunk_mib);
-		cuMemFreeHost(host_pinned);
-		cuCtxDestroy(ctx);
-		dlclose(lib);
-		return 1;
+		goto err_free_host;
 	}
 
 	// 1. Direct DMA Host -> VRAM (Push)
@@ -144,7 +138,10 @@ int main(int argc, char **argv) {
 
 	// 2. Direct DMA VRAM -> Host (Pull)
 	void *read_pinned = NULL;
-	cuMemHostAlloc(&read_pinned, chunk_bytes, 0);
+	if (cuMemHostAlloc(&read_pinned, chunk_bytes, 0) != 0) {
+		fprintf(stderr, "[-] Error: cuMemHostAlloc (read) failed (%d MiB).\n", chunk_mib);
+		goto err_free_dev;
+	}
 	printf("[+] Benchmarking VRAM -> Host DMA (%d MiB)...\n", chunk_mib);
 	t0 = get_time_sec();
 	cuMemcpyDtoH(read_pinned, dev_ptr, chunk_bytes);
@@ -159,12 +156,22 @@ int main(int argc, char **argv) {
 	       match ? "PASS (100% Bit-Exact Match, Zero Corruption)" : "FAIL");
 
 	// Cleanup
+	cuMemFreeHost(read_pinned);
 	cuMemFree(dev_ptr);
 	cuMemFreeHost(host_pinned);
-	cuMemFreeHost(read_pinned);
 	cuCtxDestroy(ctx);
 	dlclose(lib);
 
 	printf("=================================================================\n");
 	return match ? 0 : 1;
+
+err_free_dev:
+	cuMemFree(dev_ptr);
+err_free_host:
+	cuMemFreeHost(host_pinned);
+err_ctx:
+	cuCtxDestroy(ctx);
+err_lib:
+	dlclose(lib);
+	return 1;
 }


### PR DESCRIPTION
## Resumo
Refactored the C initialization path for the kernel vram benchmark tool to properly close device handles and use the idiomatic Linux kernel `goto` cleanup label pattern, preventing resource leaks on early error exits.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix: implement goto cleanup and verify all cuda symbols | Replaced nested cleanup code with goto labels and expanded pointer checks | To prevent resource leaks (like lib/device handles) on early failure | Ensured that all dynamically loaded functions are verified to not be NULL before usage |

## Issue
None

## Responsavel
Jules

## Labels
type:fix, type:kernel

## Validacao
Compiled with GCC (`gcc -Wall -Wextra -Werror`) and ran `./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`.

## Rollback trigger
If the benchmark tool crashes on startup or produces unexpected regression behavior in production tests.

1. RULES
- Guard Clauses: Checked all CUDA symbols from `dlsym`, added `goto` labels to clean up resources cleanly without nesting or inline cleanup copies.
- Physical Sanity Checks: Checked return of the 2nd `cuMemHostAlloc`.
- Semantic Error Returns: Kept return 1 on error, as it's the main function of a userspace benchmark.

2. MAIN_DIFF
```diff
<<<<<<< SEARCH
	if (!cuInit || !cuCtxCreate || !cuMemcpyHtoD || !cuMemcpyDtoH) {
		fprintf(stderr, "[-] Error: Required CUDA symbols missing in library.\n");
		dlclose(lib);
		return 1;
	}

	if (cuInit(0) != 0) {
		fprintf(stderr, "[-] Error: cuInit failed.\n");
		dlclose(lib);
		return 1;
	}

	int dev = 0;
	cuDeviceGet(&dev, 0);
	char dev_name[256] = {0};
	cuDeviceGetName(dev_name, sizeof(dev_name), dev);
	printf("[+] Hardware: %s (PCIe Direct DMA Channel)\n", dev_name);

	void *ctx = NULL;
	if (cuCtxCreate(&ctx, 0, dev) != 0) {
		fprintf(stderr, "[-] Error: cuCtxCreate failed.\n");
		dlclose(lib);
		return 1;
	}

	size_t free_b = 0, total_b = 0;
	cuMemGetInfo(&free_b, &total_b);
	printf("[+] GPU Memory: %zu MiB free / %zu MiB total\n",
	       free_b / (1024 * 1024), total_b / (1024 * 1024));

	// Allocate Pinned Host Memory
	void *host_pinned = NULL;
	if (cuMemHostAlloc(&host_pinned, chunk_bytes, 0) != 0) {
		fprintf(stderr, "[-] Error: cuMemHostAlloc failed (%d MiB).\n", chunk_mib);
		cuCtxDestroy(ctx);
		dlclose(lib);
		return 1;
	}
	memset(host_pinned, 0xA5, chunk_bytes);

	// Allocate Device VRAM Buffer
	uint64_t dev_ptr = 0;
	if (cuMemAlloc(&dev_ptr, chunk_bytes) != 0) {
		fprintf(stderr, "[-] Error: cuMemAlloc failed (%d MiB).\n", chunk_mib);
		cuMemFreeHost(host_pinned);
		cuCtxDestroy(ctx);
		dlclose(lib);
		return 1;
	}

	// 1. Direct DMA Host -> VRAM (Push)
	printf("[+] Benchmarking Host -> VRAM DMA (%d MiB)...\n", chunk_mib);
	double t0 = get_time_sec();
	cuMemcpyHtoD(dev_ptr, host_pinned, chunk_bytes);
	double t1 = get_time_sec();
	double h2d_speed = (double)chunk_mib / (t1 - t0);
	printf("[+] H2D PCIe DMA Write: %.2f MiB/s (%.2f GiB/s) in %.4f s\n",
	       h2d_speed, h2d_speed / 1024.0, t1 - t0);

	// 2. Direct DMA VRAM -> Host (Pull)
	void *read_pinned = NULL;
	cuMemHostAlloc(&read_pinned, chunk_bytes, 0);
	printf("[+] Benchmarking VRAM -> Host DMA (%d MiB)...\n", chunk_mib);
	t0 = get_time_sec();
	cuMemcpyDtoH(read_pinned, dev_ptr, chunk_bytes);
	t1 = get_time_sec();
	double d2h_speed = (double)chunk_mib / (t1 - t0);
	printf("[+] D2H PCIe DMA Read : %.2f MiB/s (%.2f GiB/s) in %.4f s\n",
	       d2h_speed, d2h_speed / 1024.0, t1 - t0);

	// 3. Bit-by-bit Verification
	int match = (memcmp(host_pinned, read_pinned, chunk_bytes) == 0);
	printf("\n[+] Data Integrity Proof: %s\n",
	       match ? "PASS (100% Bit-Exact Match, Zero Corruption)" : "FAIL");

	// Cleanup
	cuMemFree(dev_ptr);
	cuMemFreeHost(host_pinned);
	cuMemFreeHost(read_pinned);
	cuCtxDestroy(ctx);
	dlclose(lib);

	printf("=================================================================\n");
	return match ? 0 : 1;
}
=======
	if (!cuInit || !cuDeviceGet || !cuDeviceGetName || !cuCtxCreate ||
	    !cuCtxDestroy || !cuMemGetInfo || !cuMemAlloc || !cuMemFree ||
	    !cuMemHostAlloc || !cuMemFreeHost || !cuMemcpyHtoD || !cuMemcpyDtoH) {
		fprintf(stderr, "[-] Error: Required CUDA symbols missing in library.\n");
		goto err_lib;
	}

	if (cuInit(0) != 0) {
		fprintf(stderr, "[-] Error: cuInit failed.\n");
		goto err_lib;
	}

	int dev = 0;
	cuDeviceGet(&dev, 0);
	char dev_name[256] = {0};
	cuDeviceGetName(dev_name, sizeof(dev_name), dev);
	printf("[+] Hardware: %s (PCIe Direct DMA Channel)\n", dev_name);

	void *ctx = NULL;
	if (cuCtxCreate(&ctx, 0, dev) != 0) {
		fprintf(stderr, "[-] Error: cuCtxCreate failed.\n");
		goto err_lib;
	}

	size_t free_b = 0, total_b = 0;
	cuMemGetInfo(&free_b, &total_b);
	printf("[+] GPU Memory: %zu MiB free / %zu MiB total\n",
	       free_b / (1024 * 1024), total_b / (1024 * 1024));

	// Allocate Pinned Host Memory
	void *host_pinned = NULL;
	if (cuMemHostAlloc(&host_pinned, chunk_bytes, 0) != 0) {
		fprintf(stderr, "[-] Error: cuMemHostAlloc failed (%d MiB).\n", chunk_mib);
		goto err_ctx;
	}
	memset(host_pinned, 0xA5, chunk_bytes);

	// Allocate Device VRAM Buffer
	uint64_t dev_ptr = 0;
	if (cuMemAlloc(&dev_ptr, chunk_bytes) != 0) {
		fprintf(stderr, "[-] Error: cuMemAlloc failed (%d MiB).\n", chunk_mib);
		goto err_free_host;
	}

	// 1. Direct DMA Host -> VRAM (Push)
	printf("[+] Benchmarking Host -> VRAM DMA (%d MiB)...\n", chunk_mib);
	double t0 = get_time_sec();
	cuMemcpyHtoD(dev_ptr, host_pinned, chunk_bytes);
	double t1 = get_time_sec();
	double h2d_speed = (double)chunk_mib / (t1 - t0);
	printf("[+] H2D PCIe DMA Write: %.2f MiB/s (%.2f GiB/s) in %.4f s\n",
	       h2d_speed, h2d_speed / 1024.0, t1 - t0);

	// 2. Direct DMA VRAM -> Host (Pull)
	void *read_pinned = NULL;
	if (cuMemHostAlloc(&read_pinned, chunk_bytes, 0) != 0) {
		fprintf(stderr, "[-] Error: cuMemHostAlloc (read) failed (%d MiB).\n", chunk_mib);
		goto err_free_dev;
	}
	printf("[+] Benchmarking VRAM -> Host DMA (%d MiB)...\n", chunk_mib);
	t0 = get_time_sec();
	cuMemcpyDtoH(read_pinned, dev_ptr, chunk_bytes);
	t1 = get_time_sec();
	double d2h_speed = (double)chunk_mib / (t1 - t0);
	printf("[+] D2H PCIe DMA Read : %.2f MiB/s (%.2f GiB/s) in %.4f s\n",
	       d2h_speed, d2h_speed / 1024.0, t1 - t0);

	// 3. Bit-by-bit Verification
	int match = (memcmp(host_pinned, read_pinned, chunk_bytes) == 0);
	printf("\n[+] Data Integrity Proof: %s\n",
	       match ? "PASS (100% Bit-Exact Match, Zero Corruption)" : "FAIL");

	// Cleanup
	cuMemFreeHost(read_pinned);
	cuMemFree(dev_ptr);
	cuMemFreeHost(host_pinned);
	cuCtxDestroy(ctx);
	dlclose(lib);

	printf("=================================================================\n");
	return match ? 0 : 1;

err_free_dev:
	cuMemFree(dev_ptr);
err_free_host:
	cuMemFreeHost(host_pinned);
err_ctx:
	cuCtxDestroy(ctx);
err_lib:
	dlclose(lib);
	return 1;
}
>>>>>>> REPLACE
```

3. FILES
- tools/benchmarks/kernel_vram_bench.c

4. INVARIANTS
- No wild pointers, no double frees. Handled all resource releases in exact reverse order of allocation using linear forward `goto`.
- Replaced nested duplication of cleanup code with the idiomatic Linux kernel `goto` cleanup pattern.

5. COUNTERFACTUAL
- If we didn't add all CUDA symbols to the initial `NULL` check, any NULL symbol invoked later would cause a crash. If we continued using inline `dlclose` and `cuCtxDestroy`, the code would be brittle and susceptible to resource leaks during maintenance.

6. RED_TEST
- Compile the modified code using `gcc -Wall -Wextra -Werror tools/benchmarks/kernel_vram_bench.c -ldl -o tools/benchmarks/kernel_vram_bench`. It should compile without errors or warnings.

7. COVERAGE
- CI suite (kernel style scripts) will ensure the C code is clean.

8. REAL_PROOF
- Tested via GCC compilation.

9. ROLLBACK
- Revert the `goto` refactoring in `tools/benchmarks/kernel_vram_bench.c` if unexpected regressions occur in benchmark behavior.

10. PR_BOUNDARY
- do not merge

---
*PR created automatically by Jules for task [5757670465193629362](https://jules.google.com/task/5757670465193629362) started by @emersonbusson*