### PR TITLE
docs: document architectural mismatch for scsi pool allocations

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,10 @@
+The requested task asks to "prevent kernel pool memory leaks during unaligned SCSI read/write handling" in `drivers/windows/ramshared/virtdisk.c` and specifically mentions "Ensure intermediate bounce buffers are freed in finally blocks under all error conditions."
+
+However, a thorough analysis of the RamShared `virtdisk.c` and `queue.c` kernel implementation reveals a significant architectural mismatch:
+1. The driver does NOT allocate intermediate bounce buffers via kernel pool APIs (e.g., `ExAllocatePoolWithTag`, `kmalloc`) on a per-request basis during SCSI read/write handling.
+2. Instead, RamShared utilizes a statically allocated shared memory ring with bounded, pre-allocated slots (`RAMSHARED_MAX_IO`). The "bounce" buffer is accessed directly via offsets into the mapped `Q->Data` buffer (e.g., `Q->Data + (SIZE_T)tag * Q->MaxIoBytes` in `QSubmit` and `QCommitAndFetch`). No dynamic memory allocation or freeing occurs per IO request.
+3. C does not have `finally` blocks, and there are no dynamically allocated buffers in the SCSI read/write path that would require a Linux kernel `goto cleanup` idiom or `finally`-like construct to prevent memory leaks.
+4. The LBA bounds checks and parameter parsing are present, but there is no concept of a dynamically allocated "unaligned" intermediate bounce buffer in the fast path.
+5. `METHOD_BUFFERED` IOCTLs in this driver rely on the I/O Manager to allocate and free the `SystemBuffer`.
+
+Because the architecture uses a statically sized bounded queue without per-IO dynamic memory allocation, applying a fix to "free intermediate bounce buffers in finally blocks" is an impossible request that contradicts the codebase's existing zero-allocation fast-path design.


### PR DESCRIPTION
## Resumo
Document architectural mismatch regarding dynamically allocated bounce buffers in SCSI read/write path.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: document architectural mismatch for scsi pool allocations | Added FINDING_ONLY.txt | Requested changes clash with static ring buffer architecture | The driver does not allocate memory on a per-request basis. |

## Issue
kernel-harden-091

## Responsavel
Jules

## Labels
type:kernel, type:docs

## Validacao
Ran `./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
If the documentation CI check fails.

---
*PR created automatically by Jules for task [11346720223523434191](https://jules.google.com/task/11346720223523434191) started by @emersonbusson*