### PR TITLE
fix(kernel): prevent race condition in I/O request cancellation

### DIFF
--- a/drivers/windows/ramshared/queue.c
+++ b/drivers/windows/ramshared/queue.c
@@ -382,13 +382,15 @@ QSubmit(
 		PIRP irp = Q->PendedFetch;
 		PDRIVER_CANCEL oldc;
 
-		Q->PendedFetch = NULL;
-		KeReleaseSpinLock(&Q->Lock, old);
 		oldc = IoSetCancelRoutine(irp, NULL);
 		if (oldc != NULL) {
+			Q->PendedFetch = NULL;
+			KeReleaseSpinLock(&Q->Lock, old);
 			irp->IoStatus.Status = STATUS_SUCCESS;
 			irp->IoStatus.Information = 0;
 			IoCompleteRequest(irp, IO_NO_INCREMENT);
+		} else {
+			KeReleaseSpinLock(&Q->Lock, old);
 		}
 		ExReleaseRundownProtection(&Q->IoRundown);
 		return STATUS_PENDING;
@@ -633,7 +635,13 @@ QTeardownOnCrash(_Inout_ PRAMSHARED_QUEUE Q)
 
 	KeAcquireSpinLock(&Q->Lock, &old);
 	pending = Q->PendedFetch;
-	Q->PendedFetch = NULL;
+	if (pending) {
+		if (IoSetCancelRoutine(pending, NULL) != NULL) {
+			Q->PendedFetch = NULL;
+		} else {
+			pending = NULL;
+		}
+	}
 	Q->Registered = FALSE;
 	InterlockedExchange(&Q->QState, (LONG)RamQClosing);
 
@@ -657,11 +665,9 @@ QTeardownOnCrash(_Inout_ PRAMSHARED_QUEUE Q)
 	}
 
 	if (pending) {
-		if (IoSetCancelRoutine(pending, NULL) != NULL) {
-			pending->IoStatus.Status = STATUS_DEVICE_NOT_CONNECTED;
-			pending->IoStatus.Information = 0;
-			IoCompleteRequest(pending, IO_NO_INCREMENT);
-		}
+		pending->IoStatus.Status = STATUS_DEVICE_NOT_CONNECTED;
+		pending->IoStatus.Information = 0;
+		IoCompleteRequest(pending, IO_NO_INCREMENT);
 	}
 
 	/* RUNDOWN_UNMAP_AFTER_COPY: wait for in-flight copies before unmap. */


### PR DESCRIPTION
1. RULES: The rule is to prevent race conditions between I/O request completion and cancellation using the correct WDM equivalents (IoSetCancelRoutine).
2. MAIN_DIFF: 
```c
<<<<<<< SEARCH
	/* Wake primary: complete pended COMMIT_AND_FETCH IRP if any. */
	if (Q->PendedFetch) {
		PIRP irp = Q->PendedFetch;
		PDRIVER_CANCEL oldc;

		Q->PendedFetch = NULL;
		KeReleaseSpinLock(&Q->Lock, old);
		oldc = IoSetCancelRoutine(irp, NULL);
		if (oldc != NULL) {
			irp->IoStatus.Status = STATUS_SUCCESS;
			irp->IoStatus.Information = 0;
			IoCompleteRequest(irp, IO_NO_INCREMENT);
		}
		ExReleaseRundownProtection(&Q->IoRundown);
		return STATUS_PENDING;
	}
=======
	/* Wake primary: complete pended COMMIT_AND_FETCH IRP if any. */
	if (Q->PendedFetch) {
		PIRP irp = Q->PendedFetch;
		PDRIVER_CANCEL oldc;

		oldc = IoSetCancelRoutine(irp, NULL);
		if (oldc != NULL) {
			Q->PendedFetch = NULL;
			KeReleaseSpinLock(&Q->Lock, old);
			irp->IoStatus.Status = STATUS_SUCCESS;
			irp->IoStatus.Information = 0;
			IoCompleteRequest(irp, IO_NO_INCREMENT);
		} else {
			KeReleaseSpinLock(&Q->Lock, old);
		}
		ExReleaseRundownProtection(&Q->IoRundown);
		return STATUS_PENDING;
	}
>>>>>>> REPLACE
<<<<<<< SEARCH
	KeAcquireSpinLock(&Q->Lock, &old);
	pending = Q->PendedFetch;
	Q->PendedFetch = NULL;
	Q->Registered = FALSE;
	InterlockedExchange(&Q->QState, (LONG)RamQClosing);

	for (i = 0; i < RAMSHARED_MAX_QD; i++) {
		if (Q->Inflight[i].State != RamSlotFree && Q->Inflight[i].Srb) {
			failed[nfail++] = Q->Inflight[i].Srb;
			Q->Inflight[i].State = RamSlotFree;
			Q->Inflight[i].Srb = NULL;
		}
	}
	KeReleaseSpinLock(&Q->Lock, old);

	for (i = 0; i < nfail; i++) {
		if (failed[i] == NULL) {
			continue;
		}
		failed[i]->SrbStatus = SRB_STATUS_ERROR;
		if (adext != NULL) {
			StorPortNotification(RequestComplete, adext, failed[i]);
		}
	}

	if (pending) {
		if (IoSetCancelRoutine(pending, NULL) != NULL) {
			pending->IoStatus.Status = STATUS_DEVICE_NOT_CONNECTED;
			pending->IoStatus.Information = 0;
			IoCompleteRequest(pending, IO_NO_INCREMENT);
		}
	}
=======
	KeAcquireSpinLock(&Q->Lock, &old);
	pending = Q->PendedFetch;
	if (pending) {
		if (IoSetCancelRoutine(pending, NULL) != NULL) {
			Q->PendedFetch = NULL;
		} else {
			pending = NULL;
		}
	}
	Q->Registered = FALSE;
	InterlockedExchange(&Q->QState, (LONG)RamQClosing);

	for (i = 0; i < RAMSHARED_MAX_QD; i++) {
		if (Q->Inflight[i].State != RamSlotFree && Q->Inflight[i].Srb) {
			failed[nfail++] = Q->Inflight[i].Srb;
			Q->Inflight[i].State = RamSlotFree;
			Q->Inflight[i].Srb = NULL;
		}
	}
	KeReleaseSpinLock(&Q->Lock, old);

	for (i = 0; i < nfail; i++) {
		if (failed[i] == NULL) {
			continue;
		}
		failed[i]->SrbStatus = SRB_STATUS_ERROR;
		if (adext != NULL) {
			StorPortNotification(RequestComplete, adext, failed[i]);
		}
	}

	if (pending) {
		pending->IoStatus.Status = STATUS_DEVICE_NOT_CONNECTED;
		pending->IoStatus.Information = 0;
		IoCompleteRequest(pending, IO_NO_INCREMENT);
	}
>>>>>>> REPLACE
```
3. FILES: drivers/windows/ramshared/queue.c
4. INVARIANTS: I/O completion and cancellation are synchronized, preventing double completion or missed completion.
5. COUNTERFACTUAL: If IoSetCancelRoutine is called outside the spinlock after PendedFetch is cleared, the cancel routine might observe PendedFetch == NULL and exit without completing the IRP, leading to a lost IRP.
6. RED_TEST: A compilation and load test under I/O cancellation pressure would reveal IRP hangs without this fix.
7. COVERAGE: The changes apply to both `QSubmit` and `QTeardownOnCrash` where IRPs are popped for completion.
8. REAL_PROOF: `IoSetCancelRoutine(irp, NULL)` is properly evaluated under `Q->Lock` before modifying `Q->PendedFetch`.
9. ROLLBACK: Revert the `queue.c` patch.
10. PR_BOUNDARY: do not merge.

## Resumo
Synchronized IRP cancellation by calling `IoSetCancelRoutine` under the lock before modifying `Q->PendedFetch`, fixing a race condition.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix(kernel): prevent race condition in I/O request cancellation | Moved `IoSetCancelRoutine` checks under `Q->Lock` before clearing `Q->PendedFetch` | Prevents a race where an IRP could be lost if completion and cancellation race | Aligned WDM cancellation with safe synchronization practices. |

## Issue
prevent race conditions between I/O request completion and cancellation

## Responsavel
Jules

## Labels
type:kernel, type:bug

## Validacao
CI docs-check.sh and kernel suite tests passed.

## Rollback trigger
Driver crash or hangs during I/O cancellation.

---
*PR created automatically by Jules for task [3836470999073024686](https://jules.google.com/task/3836470999073024686) started by @emersonbusson*