### PR TITLE
docs: report architectural mismatch for WDF in WDM driver

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,9 @@
+Architectural Mismatch:
+The task requested to audit all WdfRequestComplete paths to ensure memory buffers are freed exactly once for IOCTL failure unwinding in drivers/windows/ramshared/control.c.
+
+Evidence of Mismatch:
+1. WDM vs WDF: The RamShared driver uses the Windows Driver Model (WDM), not the Kernel-Mode Driver Framework (KMDF). The target file relies on `IoCompleteRequest` and raw `PIRP` handling, rather than `WdfRequestComplete` and `WDFREQUEST`. Searching for `Wdf` in the codebase yields 0 results.
+2. Buffer Management: The IOCTLs in this driver are configured with `METHOD_BUFFERED`. Under this method, the Windows I/O Manager automatically allocates the `SystemBuffer` before passing the IRP to the driver, and automatically frees it when the IRP is completed. The driver is not responsible for allocating or freeing these buffers.
+
+Conclusion:
+Attempting to implement manual deallocations for the `SystemBuffer` in failure paths would inherently introduce double-free BSOD vulnerabilities, and injecting `WdfRequestComplete` into a WDM driver is invalid. Therefore, no code modification can safely satisfy the objective.


### PR DESCRIPTION
## Resumo
Report architectural mismatch regarding WdfRequestComplete and METHOD_BUFFERED double-frees in WDM control.c.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: report WDF/WDM mismatch | Created FINDING_ONLY.txt | The driver uses WDM and the I/O manager manages memory | METHOD_BUFFERED buffers must not be freed by the driver |

## Issue
N/A

## Responsavel
KernelC100

## Labels
type:docs, type:kernel

## Validacao
Executed ./scripts/docs-check.sh and kernel CI tests.

## Rollback trigger
N/A

1. RULES
- Target file uses WDM (IoCompleteRequest), not WDF (WdfRequestComplete).
- Produce FINDING_ONLY.txt with evidence in docs/jules/findings/.

2. MAIN_DIFF
N/A - Architectural mismatch.

3. FILES
- docs/jules/findings/FINDING_ONLY.txt

4. INVARIANTS
- METHOD_BUFFERED IOCTLs have their SystemBuffer allocated and freed by the Windows I/O Manager automatically.
- The driver is WDM-based and does not use KMDF (Wdf) functions.

5. COUNTERFACTUAL
- Attempting to call WdfRequestComplete would result in compilation errors because the driver does not link against KMDF.

6. RED_TEST
N/A

7. COVERAGE
N/A

8. REAL_PROOF
The file `drivers/windows/ramshared/control.c` contains 0 instances of `WdfRequestComplete` or `ExFreePool`.

9. ROLLBACK
N/A

10. PR_BOUNDARY
Target: jules/inbox (do not merge).

---
*PR created automatically by Jules for task [7506216011927413115](https://jules.google.com/task/7506216011927413115) started by @emersonbusson*