### PR TITLE
chore: report architectural mismatch on CUDA context FFI validation

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,5 @@
+The request to verify the active CUDA context handle is non-null before invoking device memory API functions in `crates/ramshared-cuda/src/ffi.rs` presents an architectural mismatch:
+
+1. No API Invocations: `crates/ramshared-cuda/src/ffi.rs` exclusively defines raw type aliases and FFI signatures (e.g., `FnMemAlloc`). It contains no function implementations or API invocations where a runtime guard clause could be placed.
+2. Implicit Thread-Local Context: In the CUDA Driver API, device memory functions such as `cuMemAlloc` do not take a `CuContext` handle as a parameter because the active context is implicit and thread-local.
+3. Safe Rust Function Pointers: If the request implies verifying that the FFI function pointers themselves (e.g., `unsafe extern "C" fn`) are non-null, this is an architectural mismatch. Rust guarantees these function pointers are non-null. Forcing C-style raw null pointer checks by degrading these signatures to `Option<fn>` is explicitly forbidden.


### PR DESCRIPTION
1. RULES: The request asks to apply C-style guard clauses to verify the active CUDA context handle before FFI invocations in `crates/ramshared-cuda/src/ffi.rs`. However, `ffi.rs` only contains type definitions and FFI signatures, and CUDA memory APIs don't take a context handle. Furthermore, modifying the `unsafe extern "C" fn` signatures to `Option<fn>` to allow null checks is an architectural mismatch.
2. MAIN_DIFF: No source code changes are applicable due to the architectural mismatch. A `FINDING_ONLY.txt` will be created instead.
3. FILES: `docs/jules/findings/FINDING_ONLY.txt`
4. INVARIANTS: Rust's `unsafe extern "C" fn` types inherently guarantee non-nullness, preventing the need for C-style null pointer checks.
5. COUNTERFACTUAL: If I changed `FnMemAlloc` to `Option<unsafe extern "C" fn>` or added a `CuContext` parameter, it would degrade the safe Rust API and break the CUDA Driver ABI (`_v2`).
6. RED_TEST: N/A, architectural mismatch.
7. COVERAGE: N/A, architectural mismatch.
8. REAL_PROOF: `FINDING_ONLY.txt` documents the impossibility of adding runtime FFI null checks without violating type safety rules and ABI.
9. ROLLBACK: N/A, architectural mismatch.
10. PR_BOUNDARY: do not merge

## Resumo
The request to validate if the CUDA context handle is non-null before invoking memory APIs in `crates/ramshared-cuda/src/ffi.rs` presents an architectural mismatch. The file only contains FFI signatures, the CUDA memory functions do not accept explicit context handles (it is implicit/thread-local), and forcing null checks on `unsafe extern "C" fn` function pointers would degrade Rust's safe typing to `Option<fn>`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| chore: report architectural mismatch on CUDA context FFI validation | Created FINDING_ONLY.txt | Architectural mismatch in FFI validation. | Rust function pointers (`unsafe extern "C" fn`) are non-nullable and CUDA memory API does not take an explicit handle. |

## Issue
kernel-harden

## Responsavel
KernelC100

## Labels
type:kernel

## Validacao
The following verification commands were executed:
- `./scripts/docs-check.sh`
- `./scripts/ci/check-kernel-style.sh`
- `./scripts/ci/check-kernel-build-matrix.sh`
- `./scripts/ci/check-kernel-qemu-smoke.sh`
- `./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
If the FINDING_ONLY.txt report is not correctly parsed by the architecture review tools.

---
*PR created automatically by Jules for task [12163969008564461675](https://jules.google.com/task/12163969008564461675) started by @emersonbusson*