### PR TITLE
refactor(kernel): report missing spinlocks and initialized mutex

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,9 @@
+Task Analysis:
+- Target File: drivers/block/ramshared/main.c
+- Objective: Ensure all synchronization primitives are fully initialized before registering device nodes.
+- Issue: Prevent null pointer dereference on uninitialized mutex and spinlock contexts.
+
+Findings:
+1. Architectural Mismatch (Spinlocks): There are no spinlocks declared, initialized, or utilized in `drivers/block/ramshared/main.c` or anywhere within the RamShared block driver (`drivers/block/ramshared/`). Attempting to initialize or validate a non-existent spinlock would require fabricating unauthorized code, violating the Groundedness Rule.
+2. Proper Initialization (Mutex): The only synchronization primitive present in `main.c` is `rs_dev->lock` (a `struct mutex`). Upon review, this mutex is perfectly initialized via `mutex_init(&rs_dev->lock);` at line 48, immediately after verifying the allocation of `rs_dev` (preventing null pointer dereference) and strictly prior to device node registration via `add_disk(rs_dev->disk);` at line 85.
+3. Conclusion: As there are no uninitialized mutexes and no spinlock contexts within the target file, safe code modification aligning with the task title is not possible without fabricating artifacts.


### PR DESCRIPTION
## Resumo
The task requested preventing null pointer dereferences on uninitialized mutex and spinlock contexts. However, an analysis revealed an architectural mismatch: the `main.c` file does not contain spinlocks, and the only mutex is already correctly initialized prior to disk registration. A `FINDING_ONLY.txt` report was generated to document the absence of vulnerability.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(kernel): report missing spinlocks and initialized mutex | Added `FINDING_ONLY.txt` report describing the architectural mismatch. | There are no spinlocks, and the mutex is properly initialized, making the requested modification impossible. | File generated at `docs/jules/findings/FINDING_ONLY.txt`. |

## Issue
N/A

## Responsavel
Emerson Busson

## Labels
type:kernel, type:refactor

## Validacao
Executed `./scripts/docs-check.sh`, `./scripts/ci/check-kernel-style.sh`, `./scripts/ci/check-kernel-build-matrix.sh`, `./scripts/ci/check-kernel-qemu-smoke.sh` and `./scripts/ci/check-adversarial-invariants.sh`, all passed successfully.

## Rollback trigger
Clear failure in documentation or kernel CI tests.

---
*PR created automatically by Jules for task [13938798312607531113](https://jules.google.com/task/13938798312607531113) started by @emersonbusson*