### PR TITLE
fix(kernel): enforce strict bounds check on PCIe BAR offset and length

### DIFF
--- a/drivers/block/ramshared/dma.c
+++ b/drivers/block/ramshared/dma.c
@@ -31,6 +31,12 @@ int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
 	rs_dev->dma.pci_addr = bar_start;
 	rs_dev->dma.size = min_t(size_t, bar_len, rs_dev->capacity_bytes);
 
+	if (rs_dev->capacity_bytes > rs_dev->dma.size) {
+		dev_info(&pdev->dev, "clamping capacity to PCIe BAR size: %zu bytes\n",
+			 rs_dev->dma.size);
+		rs_dev->capacity_bytes = rs_dev->dma.size;
+	}
+
 	/* Map PCIe VRAM BAR using Write-Combining for peak throughput */
 	rs_dev->dma.cpu_addr = devm_ioremap_wc(&pdev->dev, rs_dev->dma.pci_addr,
 					       rs_dev->dma.size);

--- a/drivers/block/ramshared/queue.c
+++ b/drivers/block/ramshared/queue.c
@@ -57,7 +57,8 @@ static blk_status_t ramshared_queue_rq(struct blk_mq_hw_ctx *hctx,
 	if (unlikely(!rs_dev || !rs_dev->dma.cpu_addr))
 		return BLK_STS_IOERR;
 
-	if (unlikely(pos + len > rs_dev->capacity_bytes)) {
+	if (unlikely(pos < 0 || len > rs_dev->capacity_bytes ||
+		     pos > rs_dev->capacity_bytes - len)) {
 		dev_err_ratelimited(rs_dev->dev,
 			"I/O bounds violation: pos=%lld, len=%zu, cap=%llu\n",
 			pos, len, rs_dev->capacity_bytes);
@@ -113,8 +114,9 @@ static int ramshared_bdev_rw_page(struct block_device *bdev, sector_t sector,
 	if (unlikely(!rs_dev || !rs_dev->dma.cpu_addr))
 		return -EIO;
 
-	if (unlikely(pos + len > rs_dev->capacity_bytes))
-		return -EIO;
+	if (unlikely(pos < 0 || len > rs_dev->capacity_bytes ||
+		     pos > rs_dev->capacity_bytes - len))
+		return -ERANGE;
 
 	vram_ptr = rs_dev->dma.cpu_addr + pos;
 	mem = kmap_local_page(page);


### PR DESCRIPTION
## Resumo
Enforce strict bounds check on PCIe BAR offset and transfer length to prevent integer overflow and out of bounds DMA transfers.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix(kernel): enforce strict bounds check on PCIe BAR offset and length | Used subtraction for bounds check | Prevent integer overflow on `pos + len` | Changed `pos + len > cap` to `pos > cap - len` and updated error to -ERANGE |

## Issue
kernel-harden-096

## Responsavel
KernelC100/2026-08-30

## Labels
type:kernel, type:security

## Validacao
Ran check-kernel-style.sh, check-kernel-build-matrix.sh, check-kernel-qemu-smoke.sh, check-adversarial-invariants.sh

## Rollback trigger
Revert if valid I/O requests are spuriously rejected.

---
*PR created automatically by Jules for task [11099937553047411656](https://jules.google.com/task/11099937553047411656) started by @emersonbusson*