### PR TITLE
kernel: add semantic errnos and pci_clear_master to pci handlers

### DIFF
--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -53,7 +53,7 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 	ret = pci_enable_device_mem(pdev);
 	if (ret) {
 		dev_err(&pdev->dev, "failed to enable PCIe memory device\n");
-		return ret;
+		return -ENODEV;
 	}
 
 	pci_set_master(pdev);
@@ -71,6 +71,7 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 	ret = pci_request_mem_regions(pdev, RAMSHARED_DRIVER_NAME);
 	if (ret) {
 		dev_err(&pdev->dev, "failed to claim PCIe memory regions\n");
+		ret = -EBUSY;
 		goto err_disable_pci;
 	}
 
@@ -100,6 +101,7 @@ err_dma_cleanup:
 err_release_regions:
 	pci_release_mem_regions(pdev);
 err_disable_pci:
+	pci_clear_master(pdev);
 	pci_disable_device(pdev);
 	return ret;
 }
@@ -114,6 +116,7 @@ static void ramshared_pci_remove(struct pci_dev *pdev)
 	ramshared_queue_cleanup(rs_dev);
 	ramshared_dma_cleanup(rs_dev);
 	pci_release_mem_regions(pdev);
+	pci_clear_master(pdev);
 	pci_disable_device(pdev);
 
 	dev_info(&pdev->dev, "RamShared device removed successfully\n");


### PR DESCRIPTION
## Resumo
Return specific semantic errnos (-ENODEV, -EBUSY) during PCI probing memory errors, and ensure pci_clear_master is called during error and removal paths to prevent resource leakage.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| main.c updates | Add semantic error handling and explicit pci_clear_master | Conform to C kernel best practices | Changed pci_enable_device_mem to return -ENODEV and pci_request_mem_regions to return -EBUSY. Added pci_clear_master to err_disable_pci label and pci removal. |

## Issue
None

## Responsavel
jules

## Labels
type:kernel, type:refactor

## Validacao
Ran ./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh

## Rollback trigger
Any kernel panics or regressions during pci probing or device removal.

---
*PR created automatically by Jules for task [17424110631399650249](https://jules.google.com/task/17424110631399650249) started by @emersonbusson*