### PR TITLE
refactor: flatten dma checks and add pci_clear_master

### DIFF
--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -62,16 +62,17 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 	if (ret) {
 		dev_warn(&pdev->dev, "64-bit DMA failed, attempting 32-bit DMA\n");
 		ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
-		if (ret) {
-			dev_err(&pdev->dev, "no usable DMA configuration\n");
-			goto err_disable_pci;
-		}
+	}
+
+	if (ret) {
+		dev_err(&pdev->dev, "no usable DMA configuration\n");
+		goto err_clear_master;
 	}
 
 	ret = pci_request_mem_regions(pdev, RAMSHARED_DRIVER_NAME);
 	if (ret) {
 		dev_err(&pdev->dev, "failed to claim PCIe memory regions\n");
-		goto err_disable_pci;
+		goto err_clear_master;
 	}
 
 	ret = ramshared_dma_init(rs_dev, pdev);
@@ -99,6 +100,8 @@ err_dma_cleanup:
 	ramshared_dma_cleanup(rs_dev);
 err_release_regions:
 	pci_release_mem_regions(pdev);
+err_clear_master:
+	pci_clear_master(pdev);
 err_disable_pci:
 	pci_disable_device(pdev);
 	return ret;
@@ -114,6 +117,7 @@ static void ramshared_pci_remove(struct pci_dev *pdev)
 	ramshared_queue_cleanup(rs_dev);
 	ramshared_dma_cleanup(rs_dev);
 	pci_release_mem_regions(pdev);
+	pci_clear_master(pdev);
 	pci_disable_device(pdev);
 
 	dev_info(&pdev->dev, "RamShared device removed successfully\n");


### PR DESCRIPTION
## Resumo
Flattened dma_set_mask_and_coherent check and added missing pci_clear_master to cleanup paths.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| HEAD | Flatten dma check | Architecture rules | Added pci_clear_master |
## Issue
kernel-linux
## Responsavel
KernelC100
## Labels
type:refactor
## Validacao
Executed CI scripts.
## Rollback trigger
CI pipeline failures.

---
*PR created automatically by Jules for task [78893879337934722](https://jules.google.com/task/78893879337934722) started by @emersonbusson*