### PR TITLE
feat(dma): enforce 4K alignment on PCIe BAR address

### DIFF
--- a/drivers/block/ramshared/dma.c
+++ b/drivers/block/ramshared/dma.c
@@ -28,6 +28,11 @@ int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
 		return -ENODEV;
 	}
 
+	if (bar_start & (PAGE_SIZE - 1)) {
+		dev_err(&pdev->dev, "PCIe BAR0 physical address is not page-aligned\n");
+		return -EINVAL;
+	}
+
 	rs_dev->dma.pci_addr = bar_start;
 	rs_dev->dma.size = min_t(size_t, bar_len, rs_dev->capacity_bytes);
 


### PR DESCRIPTION
## Resumo
Enforce 4096-byte (PAGE_SIZE) alignment check on PCIe BAR physical address in `ramshared_dma_init` before calling `ioremap_wc`, preventing potential invalid memory mappings.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(dma): enforce 4K alignment on PCIe BAR address | Added a guard clause to check if `bar_start` is aligned to `PAGE_SIZE` | To defensively verify physical hardware bounds and avoid invalid DMA mapping | Used bitwise AND with `PAGE_SIZE - 1` and returns `-EINVAL` if unaligned |

## Issue
None

## Responsavel
Jules

## Labels
type:kernel, type:security

## Validacao
Ran `./scripts/ci/check-kernel-style.sh`, `./scripts/ci/check-kernel-sparse.sh`, `./scripts/ci/check-kernel-build-matrix.sh`, `./scripts/ci/check-kernel-qemu-smoke.sh`, and `./scripts/ci/check-adversarial-invariants.sh` successfully.

## Rollback trigger
Revert if the driver fails to bind to valid hardware due to alignment mismatch errors.

---
*PR created automatically by Jules for task [16073079948187706066](https://jules.google.com/task/16073079948187706066) started by @emersonbusson*