### PR TITLE
feat: add exponential backoff to wsl2d ipc acceptors

### DIFF
--- a/crates/ramshared-wsl2d/src/conn.rs
+++ b/crates/ramshared-wsl2d/src/conn.rs
@@ -231,11 +231,31 @@ pub fn spawn_acceptor(
     jobs: SyncSender<WMsg>,
 ) -> JoinHandle<()> {
     std::thread::spawn(move || {
+        let mut backoff_ms = 10;
         loop {
             let stream = match listener.accept() {
-                Ok((s, _)) => s,
+                Ok((s, _)) => {
+                    backoff_ms = 10;
+                    s
+                }
                 Err(e) => {
                     eprintln!("[ramsharedd] accept failed: {e}");
+                    let kind = e.kind();
+                    if kind == std::io::ErrorKind::ConnectionAborted
+                        || kind == std::io::ErrorKind::ConnectionReset
+                        || kind == std::io::ErrorKind::Interrupted
+                        || kind == std::io::ErrorKind::WouldBlock
+                    {
+                        let jitter =
+                            (std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .subsec_nanos()
+                                % 10) as u64;
+                        std::thread::sleep(std::time::Duration::from_millis(backoff_ms + jitter));
+                        backoff_ms = std::cmp::min(backoff_ms * 2, 1000);
+                        continue;
+                    }
                     break;
                 }
             };
@@ -266,11 +286,31 @@ pub fn spawn_acceptor_tcp(
     jobs: SyncSender<WMsg>,
 ) -> JoinHandle<()> {
     std::thread::spawn(move || {
+        let mut backoff_ms = 10;
         loop {
             let stream = match listener.accept() {
-                Ok((s, _)) => s,
+                Ok((s, _)) => {
+                    backoff_ms = 10;
+                    s
+                }
                 Err(e) => {
                     eprintln!("[ramsharedd] TCP accept failed: {e}");
+                    let kind = e.kind();
+                    if kind == std::io::ErrorKind::ConnectionAborted
+                        || kind == std::io::ErrorKind::ConnectionReset
+                        || kind == std::io::ErrorKind::Interrupted
+                        || kind == std::io::ErrorKind::WouldBlock
+                    {
+                        let jitter =
+                            (std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .subsec_nanos()
+                                % 10) as u64;
+                        std::thread::sleep(std::time::Duration::from_millis(backoff_ms + jitter));
+                        backoff_ms = std::cmp::min(backoff_ms * 2, 1000);
+                        continue;
+                    }
                     break;
                 }
             };
@@ -733,6 +773,34 @@ mod tests {
             &ramshared_block::protocol::NBDMAGIC.to_be_bytes()
         );
         assert_only_closed(&jobs_rx);
+    }
+
+    #[test]
+    fn unix_acceptor_backs_off_on_transient_errors() {
+        let unix_path = socket_path("acceptor_backoff");
+        let _ = std::fs::remove_file(&unix_path);
+        let unix_listener = TestUnixListener::bind(&unix_path).unwrap();
+        unix_listener.set_nonblocking(true).unwrap();
+
+        let (jobs_tx, _jobs_rx) = sync_channel(2);
+        let acceptor = spawn_acceptor(unix_listener, one_export(4096), 0, jobs_tx);
+        std::thread::sleep(Duration::from_millis(100));
+
+        assert!(!acceptor.is_finished(), "Acceptor must back off on WouldBlock, not exit");
+
+        let _ = std::fs::remove_file(&unix_path);
+    }
+
+    #[test]
+    fn tcp_acceptor_backs_off_on_transient_errors() {
+        let tcp_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        tcp_listener.set_nonblocking(true).unwrap();
+
+        let (jobs_tx, _jobs_rx) = sync_channel(2);
+        let acceptor = spawn_acceptor_tcp(tcp_listener, one_export(4096), 0, jobs_tx);
+        std::thread::sleep(Duration::from_millis(100));
+
+        assert!(!acceptor.is_finished(), "TCP Acceptor must back off on WouldBlock, not exit");
     }
 
     #[test]

--- a/crates/ramshared-wsl2d/src/conn.rs
+++ b/crates/ramshared-wsl2d/src/conn.rs
@@ -246,12 +246,11 @@ pub fn spawn_acceptor(
                         || kind == std::io::ErrorKind::Interrupted
                         || kind == std::io::ErrorKind::WouldBlock
                     {
-                        let jitter =
-                            (std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .unwrap_or_default()
-                                .subsec_nanos()
-                                % 10) as u64;
+                        let jitter = (std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .subsec_nanos()
+                            % 10) as u64;
                         std::thread::sleep(std::time::Duration::from_millis(backoff_ms + jitter));
                         backoff_ms = std::cmp::min(backoff_ms * 2, 1000);
                         continue;
@@ -301,12 +300,11 @@ pub fn spawn_acceptor_tcp(
                         || kind == std::io::ErrorKind::Interrupted
                         || kind == std::io::ErrorKind::WouldBlock
                     {
-                        let jitter =
-                            (std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .unwrap_or_default()
-                                .subsec_nanos()
-                                % 10) as u64;
+                        let jitter = (std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .subsec_nanos()
+                            % 10) as u64;
                         std::thread::sleep(std::time::Duration::from_millis(backoff_ms + jitter));
                         backoff_ms = std::cmp::min(backoff_ms * 2, 1000);
                         continue;
@@ -786,7 +784,10 @@ mod tests {
         let acceptor = spawn_acceptor(unix_listener, one_export(4096), 0, jobs_tx);
         std::thread::sleep(Duration::from_millis(100));
 
-        assert!(!acceptor.is_finished(), "Acceptor must back off on WouldBlock, not exit");
+        assert!(
+            !acceptor.is_finished(),
+            "Acceptor must back off on WouldBlock, not exit"
+        );
 
         let _ = std::fs::remove_file(&unix_path);
     }
@@ -800,7 +801,10 @@ mod tests {
         let acceptor = spawn_acceptor_tcp(tcp_listener, one_export(4096), 0, jobs_tx);
         std::thread::sleep(Duration::from_millis(100));
 
-        assert!(!acceptor.is_finished(), "TCP Acceptor must back off on WouldBlock, not exit");
+        assert!(
+            !acceptor.is_finished(),
+            "TCP Acceptor must back off on WouldBlock, not exit"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Resumo
Add exponential backoff with jitter on host IPC connection loss.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: add exponential backoff to wsl2d ipc acceptors | Implemented exponential backoff with jitter for transient connection errors | Handle Windows host pipe disconnects and prevent thread death | <details>Added backoff logic to `spawn_acceptor` and `spawn_acceptor_tcp`. Added tests `unix_acceptor_backs_off_on_transient_errors` and `tcp_acceptor_backs_off_on_transient_errors`.</details> |

## Issue
Closes #001

## Responsavel
@jules

## Labels
type:resilience, area:ipc

## Validacao
cargo test -p ramshared-wsl2d && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh

## Rollback trigger
High CPU usage from rapid continuous retries despite backoff, or failure to properly exit on process shutdown.

---
*PR created automatically by Jules for task [6440771154384945530](https://jules.google.com/task/6440771154384945530) started by @emersonbusson*