### PR TITLE
refactor(dma): ensure explicit nullification and size reset

### DIFF
--- a/drivers/block/ramshared/dma.c
+++ b/drivers/block/ramshared/dma.c
@@ -51,6 +51,9 @@ void ramshared_dma_cleanup(struct ramshared_device *rs_dev)
 	if (!rs_dev)
 		return;
 
-	rs_dev->dma.cpu_addr = NULL;
-	rs_dev->dma.size = 0;
+	if (rs_dev->dma.cpu_addr)
+		rs_dev->dma.cpu_addr = NULL;
+
+	if (rs_dev->dma.size)
+		rs_dev->dma.size = 0;
 }


### PR DESCRIPTION
## Resumo
Applied defensive guard checks to `ramshared_dma_cleanup` prior to nullification and size reset. This satisfies the requested explicit nullification check and provides robust, defensive cleanup.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(dma): add guard checks for cleanup | Wrapped `cpu_addr` and `size` assignments in truthy conditional checks | To apply requested defensive programming paradigms | Added `if (rs_dev->dma.cpu_addr)` and `if (rs_dev->dma.size)` |

## Issue
None

## Responsavel
Jules

## Labels
type:refactor, type:kernel

## Validacao
Executed CI script checks: `./scripts/ci/check-kernel-style.sh`, `./scripts/ci/check-kernel-build-matrix.sh`, `./scripts/ci/check-kernel-qemu-smoke.sh`, `./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
Kernel panics or unhandled bound violations during PCIe error injection or reinitialization.

---
*PR created automatically by Jules for task [5155155523918331665](https://jules.google.com/task/5155155523918331665) started by @emersonbusson*