### PR TITLE
kernel: validate 64-bit DMA coherent mask before falling back

### DIFF
--- a/drivers/block/ramshared/dma.c
+++ b/drivers/block/ramshared/dma.c
@@ -16,9 +16,20 @@ int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
 {
 	int bar = 0;
 	resource_size_t bar_start, bar_len;
+	int ret;
 
 	if (!rs_dev || !pdev)
 		return -EINVAL;
+
+	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
+	if (ret) {
+		dev_warn(&pdev->dev, "64-bit DMA failed, attempting 32-bit DMA\n");
+		ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
+		if (ret) {
+			dev_err(&pdev->dev, "no usable DMA configuration\n");
+			return ret;
+		}
+	}
 
 	bar_start = pci_resource_start(pdev, bar);
 	bar_len = pci_resource_len(pdev, bar);

--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -58,16 +58,6 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 
 	pci_set_master(pdev);
 
-	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
-	if (ret) {
-		dev_warn(&pdev->dev, "64-bit DMA failed, attempting 32-bit DMA\n");
-		ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
-		if (ret) {
-			dev_err(&pdev->dev, "no usable DMA configuration\n");
-			goto err_disable_pci;
-		}
-	}
-
 	ret = pci_request_mem_regions(pdev, RAMSHARED_DRIVER_NAME);
 	if (ret) {
 		dev_err(&pdev->dev, "failed to claim PCIe memory regions\n");
@@ -100,6 +90,7 @@ err_dma_cleanup:
 err_release_regions:
 	pci_release_mem_regions(pdev);
 err_disable_pci:
+	pci_clear_master(pdev);
 	pci_disable_device(pdev);
 	return ret;
 }
@@ -114,6 +105,7 @@ static void ramshared_pci_remove(struct pci_dev *pdev)
 	ramshared_queue_cleanup(rs_dev);
 	ramshared_dma_cleanup(rs_dev);
 	pci_release_mem_regions(pdev);
+	pci_clear_master(pdev);
 	pci_disable_device(pdev);
 
 	dev_info(&pdev->dev, "RamShared device removed successfully\n");


### PR DESCRIPTION
## Resumo
Moved DMA mask negotiation to dma.c and added pci_clear_master in main.c

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| kernel: validate 64-bit DMA coherent mask before falling back | Validate DMA mask | Ensure safe memory operations | Modified dma.c and main.c |

## Issue
KernelC100/2026-08-30/kernel-linux/009

## Responsavel
Jules

## Labels
type:kernel, type:refactor

## Validacao
Run ./scripts/ci/*.sh test scripts

## Rollback trigger
Revert if the DMA mask negotiation triggers device failures during probe.

---
*PR created automatically by Jules for task [397161251971746731](https://jules.google.com/task/397161251971746731) started by @emersonbusson*