### PR TITLE
refactor(kernel): optimize ramshared.h struct layouts for 64-bit alignment

### DIFF
--- a/drivers/block/ramshared/ramshared.h
+++ b/drivers/block/ramshared/ramshared.h
@@ -19,39 +19,39 @@
 /**
  * struct ramshared_dma_region - PCIe DMA memory descriptor
  * @pci_addr: Physical PCIe bus address
+ * @dma_handle: DMA bus address mapping
  * @cpu_addr: Kernel virtual address mapped with write-combining
  * @size: Size of the allocated region in bytes
- * @dma_handle: DMA bus address mapping
  */
 struct ramshared_dma_region {
 	phys_addr_t	pci_addr;
+	dma_addr_t	dma_handle;
 	void __iomem	*cpu_addr;
 	size_t		size;
-	dma_addr_t	dma_handle;
 };
 
 /**
  * struct ramshared_device - Main in-tree block device state
- * @disk: gendisk descriptor
- * @tag_set: blk-mq tag set
- * @dma: DMA memory region
  * @capacity_bytes: Total available VRAM capacity in bytes
- * @dev: Pointer to underlying struct device
- * @lock: Mutex protecting device state transitions
  * @dma_transfers_total: Diagnostic counter for completed transfers
  * @read_bytes: Total bytes read
  * @write_bytes: Total bytes written
+ * @disk: gendisk descriptor
+ * @dev: Pointer to underlying struct device
+ * @dma: DMA memory region
+ * @tag_set: blk-mq tag set
+ * @lock: Mutex protecting device state transitions
  */
 struct ramshared_device {
-	struct gendisk			*disk;
-	struct blk_mq_tag_set		tag_set;
-	struct ramshared_dma_region	dma;
 	u64				capacity_bytes;
-	struct device			*dev;
-	struct mutex			lock;
 	atomic64_t			dma_transfers_total;
 	atomic64_t			read_bytes;
 	atomic64_t			write_bytes;
+	struct gendisk			*disk;
+	struct device			*dev;
+	struct ramshared_dma_region	dma;
+	struct blk_mq_tag_set		tag_set;
+	struct mutex			lock;
 };
 
 int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev);


### PR DESCRIPTION
## Resumo
Reordered fields in `ramshared_dma_region` and `ramshared_device` structures to descend by alignment size. This naturally aligns 64-bit fields (`u64` and `atomic64_t`) and packs structures tightly without padding holes, preventing CPU misaligned access faults on architectures that are sensitive to alignment.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|--------|-----------|-------------|----------|
| 1 | Reordered `ramshared_dma_region` and `ramshared_device` fields | To optimize memory layout and ensure 64-bit alignment. | Packed members by descending alignment size. |

## Issue
audit packed struct layout and 64-bit member alignment in ramshared.h

## Responsavel
Jules

## Labels
type:refactor, type:kernel

## Validacao
Executed standalone CI test suite including kernel build matrix and sparse checking.

## Rollback trigger
Revert if the structural changes introduce build regressions on specific architectures or runtime panic on structure member access.

---
*PR created automatically by Jules for task [12942500276494189063](https://jules.google.com/task/12942500276494189063) started by @emersonbusson*