### PR TITLE
feat(kernel): enforce checked 64-bit mul for capacity_bytes

### DIFF
--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -11,6 +11,10 @@
 #include <linux/pci.h>
 #include "ramshared.h"
 
+#ifndef check_mul_overflow
+#define check_mul_overflow(a, b, d) __builtin_mul_overflow(a, b, d)
+#endif
+
 MODULE_AUTHOR("Emerson Busson");
 MODULE_DESCRIPTION("Hardware-Accelerated VRAM Block Driver");
 MODULE_LICENSE("GPL");
@@ -44,7 +48,8 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 		return -ENOMEM;
 
 	rs_dev->dev = &pdev->dev;
-	rs_dev->capacity_bytes = (u64)capacity_mb * 1024 * 1024;
+	if (check_mul_overflow((u64)capacity_mb, 1048576ULL, &rs_dev->capacity_bytes))
+		return -ERANGE;
 	mutex_init(&rs_dev->lock);
 	atomic64_set(&rs_dev->dma_transfers_total, 0);
 	atomic64_set(&rs_dev->read_bytes, 0);


### PR DESCRIPTION
## Resumo
Enforce checked 64-bit multiplication for capacity_bytes calculation using __builtin_mul_overflow to prevent integer overflow.
     
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(kernel): enforce checked 64-bit mul for capacity_bytes | Added checked multiplication for capacity_bytes | To prevent arithmetic wrap-arounds | Fallback to __builtin_mul_overflow used to support environments lacking linux/overflow.h |
     
## Issue
KernelC-100
     
## Responsavel
Emerson Busson
     
## Labels
type:kernel, type:security
     
## Validacao
Ran CI check kernel scripts.
     
## Rollback trigger
Build failure due to missing GCC/Clang built-ins or probe failures returning -ERANGE unexpectedly.

---
*PR created automatically by Jules for task [15119229496047008667](https://jules.google.com/task/15119229496047008667) started by @emersonbusson*