### PR TITLE
refactor: linearize queue cleanup and tagset freeing

### DIFF
--- a/drivers/block/ramshared/queue.c
+++ b/drivers/block/ramshared/queue.c
@@ -243,11 +243,13 @@ void ramshared_queue_cleanup(struct ramshared_device *rs_dev)
 	if (!rs_dev)
 		return;
 
-	if (rs_dev->disk) {
-		del_gendisk(rs_dev->disk);
-		put_disk(rs_dev->disk);
-		rs_dev->disk = NULL;
-	}
+	if (!rs_dev->disk)
+		goto free_tags;
 
+	del_gendisk(rs_dev->disk);
+	put_disk(rs_dev->disk);
+	rs_dev->disk = NULL;
+
+free_tags:
 	blk_mq_free_tag_set(&rs_dev->tag_set);
 }


### PR DESCRIPTION
## Resumo
Linearized `ramshared_queue_cleanup` by validating `rs_dev->disk` early with the Linux kernel forward goto cleanup idiom, eliminating the nested if-block while preserving the exact semantic of freeing `tag_set` even if the disk was null. Execution unwind correctly enforces the order `del_gendisk` -> `put_disk` -> `blk_mq_free_tag_set`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor: linearize queue cleanup and tagset freeing | Linearized guard clauses via forward goto | To enforce safe cleanup order and flatten execution paths | Extracted `disk` check to `goto free_tags`, un-nesting cleanup execution |

## Issue
None

## Responsavel
Jules

## Labels
type:refactor, type:kernel

## Validacao
Executed the complete suite of CI verifications including build matrix and adversarial invariants checks.

## Rollback trigger
Kernel panics or memory leaks observed during block disk unregistration.

---
*PR created automatically by Jules for task [14724538325578919352](https://jules.google.com/task/14724538325578919352) started by @emersonbusson*