### PR TITLE
refactor(kernel): enforce semantic blk_status_t bounds checks

### DIFF
--- a/drivers/block/ramshared/queue.c
+++ b/drivers/block/ramshared/queue.c
@@ -14,6 +14,10 @@
 #include "ramshared.h"
 #include "compat.h"
 
+#ifndef check_mul_overflow
+#define check_mul_overflow(a, b, d) __builtin_mul_overflow(a, b, d)
+#endif
+
 static blk_status_t ramshared_process_bio(struct ramshared_device *rs_dev,
 					  struct bio *bio, loff_t pos)
 {
@@ -49,7 +53,7 @@ static blk_status_t ramshared_queue_rq(struct blk_mq_hw_ctx *hctx,
 {
 	struct request *rq = bd->rq;
 	struct ramshared_device *rs_dev = rq->q->queuedata;
-	loff_t pos = (loff_t)blk_rq_pos(rq) << RAMSHARED_SECTOR_SHIFT;
+	loff_t pos;
 	size_t len = blk_rq_bytes(rq);
 	blk_status_t status = BLK_STS_OK;
 	struct bio *bio;
@@ -57,11 +61,22 @@ static blk_status_t ramshared_queue_rq(struct blk_mq_hw_ctx *hctx,
 	if (unlikely(!rs_dev || !rs_dev->dma.cpu_addr))
 		return BLK_STS_IOERR;
 
-	if (unlikely(pos + len > rs_dev->capacity_bytes)) {
+	if (unlikely(check_mul_overflow((loff_t)blk_rq_pos(rq), (loff_t)RAMSHARED_SECTOR_SIZE, &pos)))
+		return BLK_STS_IOERR;
+
+	if (unlikely(pos < 0 || len > rs_dev->capacity_bytes || pos > rs_dev->capacity_bytes - len)) {
 		dev_err_ratelimited(rs_dev->dev,
 			"I/O bounds violation: pos=%lld, len=%zu, cap=%llu\n",
 			pos, len, rs_dev->capacity_bytes);
 		return BLK_STS_IOERR;
+	}
+
+	if (req_op(rq) != REQ_OP_FLUSH) {
+		if (unlikely(pos % 4096 != 0 || len % 4096 != 0)) {
+			blk_mq_start_request(rq);
+			blk_mq_end_request(rq, BLK_STS_NOTSUPP);
+			return BLK_STS_OK;
+		}
 	}
 
 	blk_mq_start_request(rq);
@@ -104,17 +119,23 @@ static int ramshared_bdev_rw_page(struct block_device *bdev, sector_t sector,
 				  struct page *page, enum req_op op)
 {
 	struct ramshared_device *rs_dev = bdev->bd_disk->private_data;
-	loff_t pos = (loff_t)sector << RAMSHARED_SECTOR_SHIFT;
+	loff_t pos;
 	size_t len = PAGE_SIZE;
 	void __iomem *vram_ptr;
 	void *mem;
 	int is_write = op_is_write(op);
 
 	if (unlikely(!rs_dev || !rs_dev->dma.cpu_addr))
-		return -EIO;
+		return -ENODEV;
 
-	if (unlikely(pos + len > rs_dev->capacity_bytes))
-		return -EIO;
+	if (unlikely(check_mul_overflow((loff_t)sector, (loff_t)RAMSHARED_SECTOR_SIZE, &pos)))
+		return -ERANGE;
+
+	if (unlikely(pos < 0 || len > rs_dev->capacity_bytes || pos > rs_dev->capacity_bytes - len))
+		return -ERANGE;
+
+	if (unlikely(pos % 4096 != 0 || len % 4096 != 0))
+		return -EOPNOTSUPP;
 
 	vram_ptr = rs_dev->dma.cpu_addr + pos;
 	mem = kmap_local_page(page);


### PR DESCRIPTION
## Resumo\nImplemented precise semantic blk_status_t and kernel errno returns for unaligned and out-of-bounds requests in ramshared device queue. Improved bounds checking using check_mul_overflow and offset vs capacity validations to prevent kernel panic vectors.\n\n## Commits\n| Commit | O que fez | Por que fez | Detalhes |\n|---|---|---|---|\n| refactor(kernel): enforce semantic blk_status_t bounds checks | Replaced generic IO errnos with robust semantic errors, implemented bounds checks. | Prevent overflow errors and ensure unaligned IO is appropriately rejected to safeguard data integrity and system stability. | Avoid integer overflows using __builtin_mul_overflow and fixed sector math logic. |\n\n## Issue\n#1029\n\n## Responsavel\nEmerson Busson\n\n## Labels\ntype:kernel, type:refactor\n\n## Validacao\n./scripts/ci/check-kernel-style.sh\n./scripts/ci/check-kernel-build-matrix.sh\n./scripts/ci/check-kernel-qemu-smoke.sh\n./scripts/ci/check-adversarial-invariants.sh\n\n## Rollback trigger\nIf the blk_status_t limits create IO regressions during testing.

---
*PR created automatically by Jules for task [11877047063170084741](https://jules.google.com/task/11877047063170084741) started by @emersonbusson*