### PR TITLE
fix: prevent integer overflow in zero-copy bounds checks

### DIFF
--- a/drivers/block/ramshared/queue.c
+++ b/drivers/block/ramshared/queue.c
@@ -57,7 +57,7 @@ static blk_status_t ramshared_queue_rq(struct blk_mq_hw_ctx *hctx,
 	if (unlikely(!rs_dev || !rs_dev->dma.cpu_addr))
 		return BLK_STS_IOERR;
 
-	if (unlikely(pos + len > rs_dev->capacity_bytes)) {
+	if (unlikely(pos < 0 || len > rs_dev->capacity_bytes || pos > rs_dev->capacity_bytes - len)) {
 		dev_err_ratelimited(rs_dev->dev,
 			"I/O bounds violation: pos=%lld, len=%zu, cap=%llu\n",
 			pos, len, rs_dev->capacity_bytes);
@@ -111,10 +111,10 @@ static int ramshared_bdev_rw_page(struct block_device *bdev, sector_t sector,
 	int is_write = op_is_write(op);
 
 	if (unlikely(!rs_dev || !rs_dev->dma.cpu_addr))
-		return -EIO;
+		return -ENODEV;
 
-	if (unlikely(pos + len > rs_dev->capacity_bytes))
-		return -EIO;
+	if (unlikely(pos < 0 || len > rs_dev->capacity_bytes || pos > rs_dev->capacity_bytes - len))
+		return -ERANGE;
 
 	vram_ptr = rs_dev->dma.cpu_addr + pos;
 	mem = kmap_local_page(page);

--- a/pr-body.patch
+++ b/pr-body.patch
@@ -1,0 +1,1 @@
+diff --git a/.github/pull_request_template.md b/.github/pull_request_template.md


### PR DESCRIPTION
## Issue
zero-copy memcpy bounds validation in ramshared_queue_transfer

## Responsavel
Jules

## Resumo
Replaced simple sum-based bounds validations in block queues (`pos + len > capacity`) with rigorous arithmetic checks (`pos < 0 || len > capacity || pos > capacity - len`) to explicitly prevent zero-copy integer overflows during I/O transfer. Replaced generic `-EIO` with semantic `-ENODEV` and `-ERANGE` kernel errors where appropriate.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|--------|-----------|-------------|----------|
| 1 | Updated bounds check logic and errnos in queue.c | To prevent out-of-bounds memcpy vulnerabilities from integer overflows | Changed `pos + len` checks to validate components and differences; updated to `-ENODEV` and `-ERANGE`. |

## Labels
type:kernel, type:security, type:refactor

## Validacao
Ran the complete kernel CI script suite successfully.

## Rollback trigger
Revert if the updated bounds validation triggers falsely on valid I/O sizes, or if new errors cause regressions in disk initializations.

---
*PR created automatically by Jules for task [15013594667517672267](https://jules.google.com/task/15013594667517672267) started by @emersonbusson*