### PR TITLE
feat(kernel-win): validate RegistryPath parameter in DriverEntry

### DIFF
--- a/drivers/windows/ramshared/driver.c
+++ b/drivers/windows/ramshared/driver.c
@@ -255,6 +255,9 @@ DriverEntry(_In_ PDRIVER_OBJECT DriverObject, _In_ PUNICODE_STRING RegistryPath)
 	HW_INITIALIZATION_DATA hw;
 	NTSTATUS status;
 
+	if (RegistryPath == NULL || RegistryPath->Buffer == NULL || RegistryPath->Length == 0)
+		return STATUS_INVALID_PARAMETER;
+
 	RtlZeroMemory(&hw, sizeof(hw));
 	hw.HwInitializationDataSize = sizeof(HW_INITIALIZATION_DATA);
 	hw.AdapterInterfaceType = Internal;


### PR DESCRIPTION
## Resumo
Added defensive validation to ensure PUNICODE_STRING RegistryPath is non-null and possesses a valid length before proceeding with StorPort initialization.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(kernel-win): validate RegistryPath | Added guard clause in DriverEntry | To prevent invalid pointer dereferences | Checks !RegistryPath, !RegistryPath->Buffer, and RegistryPath->Length == 0 |

## Labels
type:security, type:kernel-win

## Validacao
Executed standalone CI suite: docs-check, check-kernel-style, check-kernel-build-matrix, check-kernel-sparse, check-kernel-checkpatch, check-kernel-abi-guard, check-kernel-qemu-smoke, check-adversarial-invariants.

## Rollback trigger
Revert if driver load fails under specific configurations due to overly strict bounds checks on RegistryPath.

## Issue
None

## Responsavel
Jules

---
*PR created automatically by Jules for task [10693795836170955032](https://jules.google.com/task/10693795836170955032) started by @emersonbusson*