### PR TITLE
fix(kernel): ensure wmb() used for PCIe Write-Combining synchronization

### DIFF
--- a/drivers/block/ramshared/queue.c
+++ b/drivers/block/ramshared/queue.c
@@ -33,7 +33,7 @@ static blk_status_t ramshared_process_bio(struct ramshared_device *rs_dev,
 			atomic64_add(len, &rs_dev->read_bytes);
 		} else if (op == REQ_OP_WRITE) {
 			memcpy_toio(vram_ptr, src_or_dst, len);
-			dma_wmb();
+			wmb();
 			atomic64_add(len, &rs_dev->write_bytes);
 		}
 		kunmap_local(src_or_dst);
@@ -77,13 +77,13 @@ static blk_status_t ramshared_queue_rq(struct blk_mq_hw_ctx *hctx,
 		}
 		break;
 	case REQ_OP_FLUSH:
-		dma_wmb();
+		wmb();
 		status = BLK_STS_OK;
 		break;
 	case REQ_OP_DISCARD:
 	case REQ_OP_SECURE_ERASE:
 		memset_io(rs_dev->dma.cpu_addr + pos, 0, len);
-		dma_wmb();
+		wmb();
 		status = BLK_STS_OK;
 		break;
 	default:
@@ -121,7 +121,7 @@ static int ramshared_bdev_rw_page(struct block_device *bdev, sector_t sector,
 
 	if (is_write) {
 		memcpy_toio(vram_ptr, mem, len);
-		dma_wmb();
+		wmb();
 		atomic64_add(len, &rs_dev->write_bytes);
 	} else {
 		dma_rmb();


### PR DESCRIPTION
## Issue
TASK-0021

## Responsavel
kernel-coder

## Resumo
Replaced lightweight `dma_wmb()` with robust `wmb()` in PCIe Write-Combining write mappings to guarantee data flush before signaling I/O completion.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Replaced dma_wmb() with wmb() | Ensure write-combined buffers are flushed to PCIe endpoint | Enforces strict hardware synchronization for DMA writes before completion |

## Labels
type:kernel, type:security, type:refactor

## Validacao
Ran `./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh` successfully.

## Rollback trigger
If kernel panic or unexpected kernel slowdown is observed under typical synthetic load that proves wmb() has prohibitive cost or adverse effects.

---
*PR created automatically by Jules for task [1886846124420795587](https://jules.google.com/task/1886846124420795587) started by @emersonbusson*