### PR TITLE
feat(core): add guard clauses and fallback wrappers for devm_ioremap_wc

### DIFF
--- a/drivers/block/ramshared/compat.h
+++ b/drivers/block/ramshared/compat.h
@@ -13,6 +13,8 @@
 #include <linux/version.h>
 #include <linux/blkdev.h>
 #include <linux/blk-mq.h>
+#include <linux/io.h>
+#include <linux/err.h>
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
 /* Linux 6.11+ Paradigm: Features embedded in struct queue_limits */
@@ -100,6 +102,40 @@ static inline struct gendisk *ramshared_alloc_disk(struct blk_mq_tag_set *set,
 
 	return disk;
 #endif
+}
+
+/**
+ * ramshared_devm_ioremap_wc - Fallback compatibility wrapper for devm_ioremap_wc
+ * @dev: Pointer to struct device
+ * @offset: Physical PCIe BAR offset
+ * @size: Allocation size
+ *
+ * Provides guard clauses and unified ERR_PTR handling across kernel versions.
+ */
+static inline void __iomem *
+ramshared_devm_ioremap_wc(struct device *dev, resource_size_t offset, size_t size)
+{
+	void __iomem *addr;
+
+	if (!dev)
+		return ERR_PTR(-ENODEV);
+
+	if (size == 0)
+		return ERR_PTR(-EINVAL);
+
+	if ((offset & (PAGE_SIZE - 1)) != 0 || (size & (PAGE_SIZE - 1)) != 0)
+		return ERR_PTR(-EINVAL);
+
+#if defined(devm_ioremap_wc) || LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
+	addr = devm_ioremap_wc(dev, offset, size);
+#else
+	addr = devm_ioremap(dev, offset, size);
+#endif
+
+	if (!addr)
+		return ERR_PTR(-ENOMEM);
+
+	return addr;
 }
 
 #endif /* _RAMSHARED_COMPAT_H */

--- a/drivers/block/ramshared/dma.c
+++ b/drivers/block/ramshared/dma.c
@@ -11,6 +11,7 @@
 #include <linux/dma-mapping.h>
 #include <linux/io.h>
 #include "ramshared.h"
+#include "compat.h"
 
 int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
 {
@@ -32,12 +33,14 @@ int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
 	rs_dev->dma.size = min_t(size_t, bar_len, rs_dev->capacity_bytes);
 
 	/* Map PCIe VRAM BAR using Write-Combining for peak throughput */
-	rs_dev->dma.cpu_addr = devm_ioremap_wc(&pdev->dev, rs_dev->dma.pci_addr,
-					       rs_dev->dma.size);
-	if (!rs_dev->dma.cpu_addr) {
-		dev_err(&pdev->dev, "failed to ioremap_wc VRAM BAR0 (%zu bytes)\n",
-			rs_dev->dma.size);
-		return -ENOMEM;
+	rs_dev->dma.cpu_addr = ramshared_devm_ioremap_wc(&pdev->dev, rs_dev->dma.pci_addr,
+							 rs_dev->dma.size);
+	if (IS_ERR(rs_dev->dma.cpu_addr)) {
+		int ret = PTR_ERR(rs_dev->dma.cpu_addr);
+		rs_dev->dma.cpu_addr = NULL;
+		dev_err(&pdev->dev, "failed to ioremap_wc VRAM BAR0 (%zu bytes): %d\n",
+			rs_dev->dma.size, ret);
+		return ret;
 	}
 
 	dev_info(&pdev->dev, "DMA engine mapped %zu MB VRAM at %pa\n",


### PR DESCRIPTION
## Issue
N/A

## Responsavel
Jules

## Resumo
Added guard clauses and fallback compatibility wrappers for devm_ioremap_wc in compat.h to enforce parameter sanity checks and provide unified ERR_PTR semantic returns across varying kernel versions. Updated dma.c to use the new wrapper.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(core): add guard clauses and fallback wrappers for devm_ioremap_wc | Added ramshared_devm_ioremap_wc wrapper with hardware boundary sanity checks and unified error returns. Updated dma.c. | To comply with architectural principles for defensive kernel programming, avoiding unvalidated parameters and generic error codes. | Includes checks for offset and size alignment. Updates dma init to handle IS_ERR returns. |

## Labels
type:refactor, type:kernel

## Validacao
Executed standalone CI test suite: `./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
If kernel panics or VRAM mapping fails unexpectedly in supported environments, revert the commit.

---
*PR created automatically by Jules for task [6601542709493428587](https://jules.google.com/task/6601542709493428587) started by @emersonbusson*