### PR TITLE
type:kernel: Flatten DriverEntry initialization flow with guard clauses

### DIFF
--- a/drivers/windows/ramshared/driver.c
+++ b/drivers/windows/ramshared/driver.c
@@ -255,6 +255,10 @@ DriverEntry(_In_ PDRIVER_OBJECT DriverObject, _In_ PUNICODE_STRING RegistryPath)
 	HW_INITIALIZATION_DATA hw;
 	NTSTATUS status;
 
+	if (DriverObject == NULL || RegistryPath == NULL) {
+		return STATUS_INVALID_PARAMETER;
+	}
+
 	RtlZeroMemory(&hw, sizeof(hw));
 	hw.HwInitializationDataSize = sizeof(HW_INITIALIZATION_DATA);
 	hw.AdapterInterfaceType = Internal;
@@ -305,5 +309,9 @@ DriverEntry(_In_ PDRIVER_OBJECT DriverObject, _In_ PUNICODE_STRING RegistryPath)
 
 	status = CtlCreateControlDevice(DriverObject, RamsharedSddl,
 					&GUID_DEVINTERFACE_RAMSHARED_CTL);
-	return status;
+	if (!NT_SUCCESS(status)) {
+		return status;
+	}
+
+	return STATUS_SUCCESS;
 }


### PR DESCRIPTION
## Resumo
Refactored `DriverEntry` in `drivers/windows/ramshared/driver.c` to add explicit sequential guard checks. Validated `DriverObject` and `RegistryPath` parameters at the top of the function to prevent configuration failure, returning `STATUS_INVALID_PARAMETER`. Also flattened the final `CtlCreateControlDevice` status return to use an explicit early return pattern instead of directly returning the status.

## Issue
TASK: flatten DriverEntry initialization flow with guard clauses

## Responsavel
Jules

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Add sequential guard checks to DriverEntry | Prevent potential BSODs on invalid configuration parameters and standardize early return style. | Implemented NULL pointer checks for DriverObject and RegistryPath returning STATUS_INVALID_PARAMETER; applied explicit guard clause to CtlCreateControlDevice status check. |

## Labels
type:kernel

## Validacao
Executed CI validation scripts via `./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`.

## Rollback trigger
Revert if explicit parameter validation breaks expected driver load patterns.

---
*PR created automatically by Jules for task [15036002771820214678](https://jules.google.com/task/15036002771820214678) started by @emersonbusson*