### PR TITLE
fix(kernel-win): validate IOCTL output buffer length

### DIFF
--- a/drivers/windows/ramshared/control.c
+++ b/drivers/windows/ramshared/control.c
@@ -103,6 +103,7 @@ CtlDispatchDeviceControl(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp)
 	PIO_STACK_LOCATION irpSp;
 	ULONG code;
 	ULONG inLen;
+	ULONG outLen;
 	PVOID buf;
 	NTSTATUS status = STATUS_INVALID_DEVICE_REQUEST;
 	ULONG_PTR info = 0;
@@ -114,11 +115,12 @@ CtlDispatchDeviceControl(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp)
 	irpSp = IoGetCurrentIrpStackLocation(Irp);
 	code = irpSp->Parameters.DeviceIoControl.IoControlCode;
 	inLen = irpSp->Parameters.DeviceIoControl.InputBufferLength;
+	outLen = irpSp->Parameters.DeviceIoControl.OutputBufferLength;
 	buf = Irp->AssociatedIrp.SystemBuffer;
 
 	switch (code) {
 	case IOCTL_RAMSHARED_REGISTER_QUEUE:
-		if (inLen != sizeof(RAMSHARED_REGISTER) || buf == NULL) {
+		if (inLen != sizeof(RAMSHARED_REGISTER) || outLen != 0 || buf == NULL) {
 			status = STATUS_INVALID_PARAMETER;
 			break;
 		}
@@ -144,7 +146,7 @@ CtlDispatchDeviceControl(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp)
 
 	case IOCTL_RAMSHARED_UNREGISTER_QUEUE:
 		/* Zero-input IOCTL: reject non-zero input length (DT-5). */
-		if (inLen != 0) {
+		if (inLen != 0 || outLen != 0) {
 			status = STATUS_INVALID_PARAMETER;
 			break;
 		}
@@ -161,7 +163,7 @@ CtlDispatchDeviceControl(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp)
 		break;
 
 	case IOCTL_RAMSHARED_COMMIT_AND_FETCH:
-		if (inLen != 0) {
+		if (inLen != 0 || outLen != 0) {
 			status = STATUS_INVALID_PARAMETER;
 			break;
 		}
@@ -181,7 +183,7 @@ CtlDispatchDeviceControl(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp)
 		break;
 
 	case IOCTL_RAMSHARED_CREATE_DISK:
-		if (inLen != sizeof(RAMSHARED_DISK_PARAMS) || buf == NULL) {
+		if (inLen != sizeof(RAMSHARED_DISK_PARAMS) || outLen != 0 || buf == NULL) {
 			status = STATUS_INVALID_PARAMETER;
 			break;
 		}
@@ -189,7 +191,7 @@ CtlDispatchDeviceControl(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp)
 		break;
 
 	case IOCTL_RAMSHARED_DESTROY_DISK:
-		if (inLen != 0) {
+		if (inLen != 0 || outLen != 0) {
 			status = STATUS_INVALID_PARAMETER;
 			break;
 		}


### PR DESCRIPTION
## Issue
N/A

## Responsavel
Jules

## Resumo
Enforces strict `OutputBufferLength == 0` validation for all `METHOD_BUFFERED` IOCTLs in `drivers/windows/ramshared/control.c`. This prevents the I/O manager from potentially copying uninitialized `SystemBuffer` kernel memory back to user space when a non-zero output buffer is inappropriately supplied alongside a non-zero `Information` count (e.g. `COMMIT_AND_FETCH`).

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| fix(kernel-win): validate IOCTL output buffer length | Added `outLen` check to all IOCTL guard clauses. | To prevent uninitialized kernel memory leakage via `METHOD_BUFFERED` mechanisms. | `outLen != 0` immediately returns `STATUS_INVALID_PARAMETER`. |

## Labels
type:fix, type:security, type:kernel-win

## Validacao
- `./scripts/docs-check.sh`
- `./scripts/ci/check-kernel-style.sh`
- `./scripts/ci/check-kernel-build-matrix.sh`
- `./scripts/ci/check-kernel-sparse.sh`
- `./scripts/ci/check-kernel-checkpatch.sh`
- `./scripts/ci/check-kernel-abi-guard.sh`
- `./scripts/ci/check-kernel-qemu-smoke.sh`
- `./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
Revert if the strict validation breaks legitimate user-mode tools that mistakenly request an output buffer despite no payload being provided.

---
*PR created automatically by Jules for task [17558955258534248078](https://jules.google.com/task/17558955258534248078) started by @emersonbusson*