### PR TITLE
kernel: guard macros for Linux kernel 5.15 to 6.x blk-mq API differences

### DIFF
--- a/drivers/block/ramshared/compat.h
+++ b/drivers/block/ramshared/compat.h
@@ -20,9 +20,12 @@
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0)
 /* Linux 6.9 - 6.10 Paradigm: 3-arg blk_mq_alloc_disk with queue_limits */
 #define RAMSHARED_HAVE_QUEUE_LIMITS_PARAM	1
-#else
+#elif defined(blk_mq_alloc_disk) || LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
 /* Linux <= 6.8 Paradigm: 2-arg blk_mq_alloc_disk and standalone mutators */
 #define RAMSHARED_HAVE_LEGACY_BLK_ALLOC		1
+#else
+/* Fallback: older blk_alloc_disk with separate queue init */
+#define RAMSHARED_HAVE_VERY_LEGACY_BLK_ALLOC	1
 #endif
 
 /**
@@ -75,7 +78,7 @@ static inline struct gendisk *ramshared_alloc_disk(struct blk_mq_tag_set *set,
 	}
 	return disk;
 
-#else /* Linux <= 6.8 (Ubuntu 22.04 LTS, Ubuntu 24.04 LTS) */
+#elif defined(RAMSHARED_HAVE_LEGACY_BLK_ALLOC) /* Linux <= 6.8 (Ubuntu 22.04 LTS, Ubuntu 24.04 LTS) */
 	struct gendisk *disk = blk_mq_alloc_disk(set, queuedata);
 	struct request_queue *q;
 
@@ -83,6 +86,39 @@ static inline struct gendisk *ramshared_alloc_disk(struct blk_mq_tag_set *set,
 		return disk;
 
 	q = disk->queue;
+	blk_queue_flag_set(QUEUE_FLAG_NONROT, q);
+	blk_queue_flag_set(QUEUE_FLAG_SYNCHRONOUS, q);
+	blk_queue_flag_set(QUEUE_FLAG_NOWAIT, q);
+
+	blk_queue_logical_block_size(q, sector_size);
+	blk_queue_physical_block_size(q, PAGE_SIZE);
+	blk_queue_io_min(q, PAGE_SIZE);
+	blk_queue_io_opt(q, 64 * 1024);
+	blk_queue_max_hw_sectors(q, max_sectors);
+	blk_queue_max_segments(q, USHRT_MAX);
+	blk_queue_max_segment_size(q, UINT_MAX);
+	blk_queue_dma_alignment(q, 511);
+	blk_queue_max_discard_sectors(q, UINT_MAX);
+	q->limits.discard_granularity = PAGE_SIZE;
+
+	return disk;
+
+#else /* Pre blk_mq_alloc_disk era (e.g. older 5.15 forks) */
+	struct request_queue *q = blk_mq_init_queue(set);
+	struct gendisk *disk;
+
+	if (IS_ERR(q))
+		return ERR_CAST(q);
+
+	disk = blk_alloc_disk(NUMA_NO_NODE);
+	if (!disk) {
+		blk_cleanup_queue(q);
+		return ERR_PTR(-ENOMEM);
+	}
+
+	disk->queue = q;
+	disk->private_data = queuedata;
+
 	blk_queue_flag_set(QUEUE_FLAG_NONROT, q);
 	blk_queue_flag_set(QUEUE_FLAG_SYNCHRONOUS, q);
 	blk_queue_flag_set(QUEUE_FLAG_NOWAIT, q);


### PR DESCRIPTION
## Resumo
Implement fallback compatibility shims for kernels where `blk_mq_alloc_disk` is not available, falling back to older `blk_alloc_disk` with explicit `blk_mq_init_queue`. Fixed versioning logic for Linux >= 5.15 and properly deleted temporary mock scripts.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| kernel: guard macros for Linux kernel 5.15 to 6.x blk-mq API differences | Refactored ramshared_alloc_disk macro branches | To handle blk-mq API changes and backported LTS kernel missing macros safely. | Added #ifdef guards and fallback blk_alloc_disk paradigm logic. |

## Issue
None

## Responsavel
Jules

## Labels
type:kernel

## Validacao
`./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
Kernel panic, BSOD, or compilation failure on LTS builds with multiple blk definitions.

---
*PR created automatically by Jules for task [17980937599850456392](https://jules.google.com/task/17980937599850456392) started by @emersonbusson*