### PR TITLE
docs(findings): document unrecognized IOCTL trap

### DIFF
--- a/docs/jules/findings/27-unrecognized-ioctl-trap.md
+++ b/docs/jules/findings/27-unrecognized-ioctl-trap.md
@@ -1,0 +1,5 @@
+# FINDING_ONLY: Unrecognized IOCTL Trap
+## Target File
+drivers/windows/ramshared/control.c
+## Conclusion
+The task requested to return STATUS_INVALID_DEVICE_REQUEST on unknown IOCTL codes instead of a generic failure. However, a review of drivers/windows/ramshared/control.c reveals that the CtlDispatchDeviceControl function already correctly handles unrecognized IOCTL codes by explicitly returning STATUS_INVALID_DEVICE_REQUEST in the default switch case (status = STATUS_INVALID_DEVICE_REQUEST; /* REFUSE_UNKNOWN_IOCTL */). Furthermore, the driver correctly operates under the Windows Driver Model (WDM) architecture. Attempting to implement the requested fix would result in redundant code or an architectural mismatch. Therefore, no safe code modification is required.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 286,
-    "classified": 275,
+    "total": 287,
+    "classified": 276,
     "excluded": 11,
     "unclassified": 0,
     "ambiguous": 0
@@ -871,6 +871,18 @@
     },
     {
       "path": "docs/jules/findings/26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "historical",
+      "freshnessDays": null
+    },
+    {
+      "path": "docs/jules/findings/27-unrecognized-ioctl-trap.md",
       "disposition": "classified",
       "ruleId": "jules-findings",
       "verification": {


### PR DESCRIPTION
## Resumo
Document that drivers/windows/ramshared/control.c already returns STATUS_INVALID_DEVICE_REQUEST on unrecognized IOCTLs.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs(findings): document unrecognized IOCTL trap | Added FINDING_ONLY report | Task requested a fix for an issue that is already handled correctly in the code | The switch statement in CtlDispatchDeviceControl correctly returns STATUS_INVALID_DEVICE_REQUEST in its default case. |
## Labels
type:docs, type:kernel
## Validacao
Executed full CI test suite.
## Rollback trigger
Any governance or formatting violation.
## Issue
TASK-033
## Responsavel
KernelC100/2026-08-30/kernel-win/033

---
*PR created automatically by Jules for task [8332461122597391311](https://jules.google.com/task/8332461122597391311) started by @emersonbusson*