### PR TITLE
security: enforce security descriptor ACL validation on IOCTLs

### DIFF
--- a/drivers/windows/ramshared/control.c
+++ b/drivers/windows/ramshared/control.c
@@ -116,6 +116,14 @@ CtlDispatchDeviceControl(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp)
 	inLen = irpSp->Parameters.DeviceIoControl.InputBufferLength;
 	buf = Irp->AssociatedIrp.SystemBuffer;
 
+	status = IoValidateDeviceIoControlAccess(Irp, (code >> 14) & 3);
+	if (!NT_SUCCESS(status)) {
+		Irp->IoStatus.Status = status;
+		Irp->IoStatus.Information = 0;
+		IoCompleteRequest(Irp, IO_NO_INCREMENT);
+		return status;
+	}
+
 	switch (code) {
 	case IOCTL_RAMSHARED_REGISTER_QUEUE:
 		if (inLen != sizeof(RAMSHARED_REGISTER) || buf == NULL) {


### PR DESCRIPTION
## Issue
Task: enforce security descriptor ACL validation on administrative IOCTLs

## Responsavel
Jules

## Resumo
Enforce security descriptor ACL validation on administrative IOCTLs using `IoValidateDeviceIoControlAccess`.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | Added ACL validation | To prevent unauthorized access to IOCTLs | Used IoValidateDeviceIoControlAccess at the top of CtlDispatchDeviceControl |

## Labels
type:security

## Validacao
Local matrix check compilation without errors.

## Rollback trigger
Revert if administrative operations are falsely blocked or BSODs occur.

---
*PR created automatically by Jules for task [13409503503942861064](https://jules.google.com/task/13409503503942861064) started by @emersonbusson*