### PR TITLE
feat(kernel-win): enforce 512 and 4096-byte sector geometry alignment

### DIFF
--- a/drivers/windows/ramshared/virtdisk.c
+++ b/drivers/windows/ramshared/virtdisk.c
@@ -514,6 +514,19 @@ VdTranslateSrb(
 				rop = RAMSHARED_OP_WRITE;
 			}
 		}
+
+		if (rop != RAMSHARED_OP_FLUSH) {
+			if ((offset & (Disk->block_size - 1)) != 0 ||
+			    (len & (Disk->block_size - 1)) != 0) {
+				Srb->SrbStatus = SRB_STATUS_INVALID_REQUEST;
+				break;
+			}
+			if (len > Disk->size_bytes || offset > Disk->size_bytes - len) {
+				Srb->SrbStatus = SRB_STATUS_INVALID_REQUEST;
+				break;
+			}
+		}
+
 		st = QSubmit(&Disk->queue, DevExt, Srb, rop, offset, len);
 		if (st == STATUS_PENDING) {
 			Srb->SrbStatus = SRB_STATUS_PENDING;


### PR DESCRIPTION
## Issue
enforce 512 and 4096-byte sector geometry alignment in virtual disk

## Responsavel
KernelC100/2026-08-30/kernel-win/036

## Resumo
Enforce hardware boundary sanity checks for exact multiple disk sector sizes in RamShared Windows virtual miniport. Rejects unaligned offsets/lengths and implements bounds checking to prevent integer overflows.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(kernel-win): enforce sector alignment | Added sector geometry guard clauses to VdTranslateSrb | Avoid bad out of bounds access or unaligned requests | Enforces 4096/512-byte boundaries based on runtime disk properties for non-flush I/O requests. Checks `len > size` and `offset > size - len` to prevent overflow. |

## Labels
type:security, type:kernel

## Validacao
Executed `check-kernel-build-matrix.sh` and related kernel CI verification scripts.

## Rollback trigger
Revert if legitimate I/O is rejected with SRB_STATUS_INVALID_REQUEST.

---
*PR created automatically by Jules for task [17125254447986609874](https://jules.google.com/task/17125254447986609874) started by @emersonbusson*