### PR TITLE
refactor(kernel-win): produce finding for WDF queue init mismatch

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,6 @@
+The task requested to "flatten WDF I/O queue initialization with guard clauses" in drivers/windows/ramshared/queue.c.
+
+1. Architectural Mismatch: The RamShared Windows driver is implemented as a WDM StorPort miniport. It does not use the Kernel-Mode Driver Framework (KMDF) or any WDF APIs (such as WdfIoQueueCreate).
+2. Existing Implementation: The queue initialization logic in drivers/windows/ramshared/queue.c (QRegister and QMapUserRegion) is already perfectly flattened using linear guard clauses and the forward goto out_err cleanup idiom, returning appropriate NTSTATUS error codes upon failure.
+
+Since there is no WDF queue initialization to flatten and the existing WDM logic is already correctly flattened, no code changes are applicable.


### PR DESCRIPTION
## Issue
flatten WDF I/O queue initialization with guard clauses
## Responsavel
KernelC100/2026-08-30/kernel-win/040
## Resumo
Produced a `FINDING_ONLY` report because the RamShared Windows driver is a WDM StorPort miniport and does not use KMDF/WDF. The existing WDM queue creation logic (`QRegister`) in `queue.c` is already perfectly flattened using linear guard clauses and early returns.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| FINDING | Created `docs/jules/findings/FINDING_ONLY.txt` | Task requested flattening WDF I/O queue which doesn't exist | <details><summary>detalhes</summary>Documented architectural mismatch and flat WDM implementation</details> |
## Labels
type:refactor, type:kernel
## Validacao
Executed complete CI validation suite.
## Rollback trigger
Revert if the findings report is misplaced or contains incorrect architectural assertions.

---
*PR created automatically by Jules for task [1771579342461858644](https://jules.google.com/task/1771579342461858644) started by @emersonbusson*