### PR TITLE
feat(kernel-win): handle SCSIOP_SYNCHRONIZE_CACHE and write flush commands

### DIFF
--- a/drivers/windows/ramshared/virtdisk.c
+++ b/drivers/windows/ramshared/virtdisk.c
@@ -330,6 +330,70 @@ VdHandleReportLuns(_Inout_ PSCSI_REQUEST_BLOCK Srb, _In_ BOOLEAN Present)
 }
 
 static BOOLEAN
+VdHandleModeSense(_In_opt_ PVIRTUAL_DISK Disk, _Inout_ PSCSI_REQUEST_BLOCK Srb)
+{
+	UCHAR response[32];
+	ULONG responseLen;
+	ULONG transferLen;
+	ULONG allocationLen;
+	UCHAR page;
+
+	UNREFERENCED_PARAMETER(Disk);
+
+	RtlZeroMemory(response, sizeof(response));
+
+	if (Srb->Cdb[0] == SCSIOP_MODE_SENSE) {
+		page = Srb->Cdb[2] & 0x3F;
+		allocationLen = Srb->Cdb[4];
+		response[0] = 3; /* Length */
+		response[1] = 0; /* Medium type */
+		response[2] = 0; /* Device-specific parameter (no write protect) */
+		response[3] = 0; /* Block descriptor length */
+		responseLen = 4;
+	} else {
+		page = Srb->Cdb[2] & 0x3F;
+		allocationLen = ((ULONG)Srb->Cdb[7] << 8) | Srb->Cdb[8];
+		response[0] = 0; /* Length MSB */
+		response[1] = 7; /* Length LSB */
+		response[2] = 0; /* Medium type */
+		response[3] = 0; /* Device-specific parameter */
+		response[6] = 0; /* Block descriptor length MSB */
+		response[7] = 0; /* Block descriptor length LSB */
+		responseLen = 8;
+	}
+
+	if (page == 0x08 || page == 0x3F) {
+		/* Caching Page (0x08) */
+		response[responseLen + 0] = 0x08; /* Page Code */
+		response[responseLen + 1] = 0x12; /* Page Length */
+		response[responseLen + 2] = 0x04; /* WCE = 1 */
+		responseLen += 20;
+		if (Srb->Cdb[0] == SCSIOP_MODE_SENSE) {
+			response[0] = (UCHAR)(responseLen - 1);
+		} else {
+			ULONG len = responseLen - 2;
+			response[0] = (UCHAR)((len >> 8) & 0xFF);
+			response[1] = (UCHAR)(len & 0xFF);
+		}
+	} else {
+		/* We don't support other pages, but we must return header */
+	}
+
+	transferLen = min(Srb->DataTransferLength, allocationLen);
+	transferLen = min(transferLen, responseLen);
+	if (transferLen != 0 && Srb->DataBuffer == NULL) {
+		Srb->SrbStatus = SRB_STATUS_ERROR;
+		return TRUE;
+	}
+	if (transferLen != 0) {
+		RtlCopyMemory(Srb->DataBuffer, response, transferLen);
+	}
+	Srb->DataTransferLength = transferLen;
+	Srb->SrbStatus = SRB_STATUS_SUCCESS;
+	return TRUE;
+}
+
+static BOOLEAN
 VdHandleReadCapacity(_In_ PVIRTUAL_DISK Disk, _Inout_ PSCSI_REQUEST_BLOCK Srb)
 {
 	UCHAR response[32];
@@ -417,10 +481,7 @@ VdTranslateSrbNoDisk(_In_ PVOID DevExt, _Inout_ PSCSI_REQUEST_BLOCK Srb)
 		break;
 	case SCSIOP_MODE_SENSE:
 	case SCSIOP_MODE_SENSE10:
-		Srb->SrbStatus = SRB_STATUS_SUCCESS;
-		if (Srb->DataBuffer && Srb->DataTransferLength >= 4) {
-			RtlZeroMemory(Srb->DataBuffer, Srb->DataTransferLength);
-		}
+		(void)VdHandleModeSense(NULL, Srb);
 		break;
 	case 0xA0: /* REPORT LUNS — no LUN until CREATE_DISK */
 		VdHandleReportLuns(Srb, FALSE);
@@ -467,10 +528,7 @@ VdTranslateSrb(
 
 	case SCSIOP_MODE_SENSE:
 	case SCSIOP_MODE_SENSE10:
-		Srb->SrbStatus = SRB_STATUS_SUCCESS;
-		if (Srb->DataBuffer && Srb->DataTransferLength >= 4) {
-			RtlZeroMemory(Srb->DataBuffer, Srb->DataTransferLength);
-		}
+		(void)VdHandleModeSense(Disk, Srb);
 		break;
 
 	case SCSIOP_READ:


### PR DESCRIPTION
## Issue
Ensure volatile writes are committed via SCSIOP_SYNCHRONIZE_CACHE.

## Responsavel
jules

## Resumo
The StorPort virtual disk driver now handles MODE SENSE requests to return the Caching Page (0x08) with the Write Cache Enable (WCE) bit set to 1. This instructs the Windows OS to send `SCSIOP_SYNCHRONIZE_CACHE` commands, which the driver natively maps to `RAMSHARED_OP_FLUSH` to flush the userspace volatile backend cache correctly.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(kernel-win): handle SCSIOP_SYNCHRONIZE_CACHE and write flush commands | Implemented `VdHandleModeSense` to report WCE=1 | Windows won't send flush requests unless the block device explicitly reports write caching enabled | <details><summary>detalhes</summary>Applies to both 6-byte and 10-byte MODE SENSE</details> |

## Labels
type:feat, type:kernel-win

## Validacao
Run full CI suite (`./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`).

## Rollback trigger
Storage stack fails to mount the disk or issues BSOD during initialization due to invalid mode sense response layout.

---
*PR created automatically by Jules for task [4589576475156052650](https://jules.google.com/task/4589576475156052650) started by @emersonbusson*