### PR TITLE
refactor: audit packed alignment and typedefs in Windows driver header

### DIFF
--- a/drivers/windows/ramshared/driver.h
+++ b/drivers/windows/ramshared/driver.h
@@ -18,6 +18,7 @@
  */
 #define RAMSHARED_MATRIX_MAX_IO (256u * 1024u)
 
+#pragma pack(push, 8)
 /* Device extension for the StorPort adapter (virtual). */
 typedef struct _RAMSHARED_ADAPTER_EXT {
 	PVOID StorPortExt; /* reserved for StorPort-owned memory */
@@ -25,9 +26,10 @@ typedef struct _RAMSHARED_ADAPTER_EXT {
 	struct _RAMSHARED_QUEUE *Queue;
 	PDEVICE_OBJECT ControlDevice;
 	UNICODE_STRING ControlLink;
-	BOOLEAN QueueRegistered;
-	BOOLEAN AdapterStopped;
+	ramshared_u8 QueueRegistered;
+	ramshared_u8 AdapterStopped;
 } RAMSHARED_ADAPTER_EXT, *PRAMSHARED_ADAPTER_EXT;
+#pragma pack(pop)
 
 DRIVER_INITIALIZE DriverEntry;
 


### PR DESCRIPTION
## Issue
audit packed alignment and typedefs in Windows driver header

## Responsavel
Jules

## Resumo
Enforced explicit `#pragma pack(push, 8)` for `RAMSHARED_ADAPTER_EXT` and replaced `BOOLEAN` with the fixed-width integer type `ramshared_u8` in `drivers/windows/ramshared/driver.h`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor: audit packed alignment and typedefs in Windows driver header | Applied explicit #pragma pack and fixed-width types to driver header. | To guarantee ABI structure size predictability and adhere to the project's specification. | <details><summary>detalhes</summary>Wrapped RAMSHARED_ADAPTER_EXT in `#pragma pack(push, 8)` and changed `BOOLEAN` to `ramshared_u8`.</details> |

## Labels
type:refactor, type:kernel-win

## Validacao
Ran `./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`.

## Rollback trigger
Build failures or Windows kernel test failures.

---
*PR created automatically by Jules for task [5321203007756383862](https://jules.google.com/task/5321203007756383862) started by @emersonbusson*