### PR TITLE
feat: define queue context struct and lock synchronization declarations

### DIFF
--- a/drivers/windows/ramshared/queue.h
+++ b/drivers/windows/ramshared/queue.h
@@ -12,6 +12,7 @@
 
 #include <ntddk.h>
 #include <storport.h>
+#include <wdf.h>
 #include "protocol.h"
 
 typedef enum _RAMSHARED_SLOT_STATE {
@@ -34,6 +35,13 @@ typedef struct _RAMSHARED_INFLIGHT {
 	UINT32 BufSlot;
 	RAMSHARED_SLOT_STATE State;
 } RAMSHARED_INFLIGHT, *PRAMSHARED_INFLIGHT;
+
+typedef struct _RAMSHARED_QUEUE_CONTEXT {
+	WDFQUEUE Queue;
+	WDFSPINLOCK Lock;
+} RAMSHARED_QUEUE_CONTEXT, *PRAMSHARED_QUEUE_CONTEXT;
+
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(RAMSHARED_QUEUE_CONTEXT, QueueGetContext)
 
 typedef struct _RAMSHARED_QUEUE {
 	PMDL SqMdl;


### PR DESCRIPTION
## Issue
TASK_TITLE: queue context struct definition and lock synchronization declarations

## Responsavel
Jules

## Resumo
Added the definition for `RAMSHARED_QUEUE_CONTEXT` and the type-safe accessor `WDF_DECLARE_CONTEXT_TYPE_WITH_NAME` in `queue.h`. Also added the lock synchronization declarations (`WDFSPINLOCK`) inside the context struct, and included the missing `wdf.h` header.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: define queue context struct and lock synchronization declarations | Added queue context struct and WDF macro. | To safely store queue-specific context like the queue handle and lock for KMDF driver operations. | <details><summary>detalhes</summary>Added `RAMSHARED_QUEUE_CONTEXT` with `WDFQUEUE` and `WDFSPINLOCK`, included `<wdf.h>`, and used `WDF_DECLARE_CONTEXT_TYPE_WITH_NAME`.</details> |

## Labels
type:feat, type:kernel-win

## Validacao
Executed CI scripts to ensure the project compiles and checks pass.

## Rollback trigger
Revert if the struct definitions or WDF includes cause build regressions in standard WDM/StorPort builds that do not support KMDF.

---
*PR created automatically by Jules for task [10299927832897069766](https://jules.google.com/task/10299927832897069766) started by @emersonbusson*