### PR TITLE
feat: sysfs attribute guard clauses and buffer size limits

### DIFF
--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -17,11 +17,55 @@ MODULE_LICENSE("GPL");
 MODULE_VERSION(RAMSHARED_DRIVER_VERSION);
 
 static unsigned long capacity_mb = 1024;
-module_param(capacity_mb, ulong, 0444);
+static int capacity_mb_set(const char *val, const struct kernel_param *kp)
+{
+	unsigned long capacity;
+	int ret;
+
+	if (!val || strnlen(val, 32) > 16)
+		return -EINVAL;
+
+	ret = kstrtoul(val, 10, &capacity);
+	if (ret)
+		return ret;
+
+	if (capacity == 0 || capacity > (1UL << 20))
+		return -ERANGE;
+
+	return param_set_ulong(val, kp);
+}
+
+static const struct kernel_param_ops capacity_mb_ops = {
+	.set = capacity_mb_set,
+	.get = param_get_ulong,
+};
+module_param_cb(capacity_mb, &capacity_mb_ops, &capacity_mb, 0444);
 MODULE_PARM_DESC(capacity_mb, "Initial VRAM block device capacity in MiB (default: 1024)");
 
 static unsigned int queue_depth = RAMSHARED_DEFAULT_QUEUE_DEPTH;
-module_param(queue_depth, uint, 0444);
+static int queue_depth_set(const char *val, const struct kernel_param *kp)
+{
+	unsigned int depth;
+	int ret;
+
+	if (!val || strnlen(val, 32) > 16)
+		return -EINVAL;
+
+	ret = kstrtouint(val, 10, &depth);
+	if (ret)
+		return ret;
+
+	if (depth < 16 || depth > 2048)
+		return -ERANGE;
+
+	return param_set_uint(val, kp);
+}
+
+static const struct kernel_param_ops queue_depth_ops = {
+	.set = queue_depth_set,
+	.get = param_get_uint,
+};
+module_param_cb(queue_depth, &queue_depth_ops, &queue_depth, 0444);
 MODULE_PARM_DESC(queue_depth, "Hardware queue depth (default: 256)");
 
 static int ramshared_pci_probe(struct pci_dev *pdev,


### PR DESCRIPTION
## Issue
TASK-0020

## Responsavel
KernelC100

## Resumo
Add guard clauses and buffer size limits to module parameters logic to ensure malformed inputs are cleanly rejected before executing bounds parsing logic.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: sysfs attribute guard clauses | Refactored module parameters into kernel_param_cb with bounds check | Enforce physical hardware bounds and reject malformed inputs | <details><summary>detalhes</summary>Prevents integer overflow and malformed parsing for module params</details> |

## Labels
type:kernel, type:refactor, type:security

## Validacao
Ran ./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh

## Rollback trigger
Revert if CI validation fails or driver fails to compile on Linux kernel builds.

---
*PR created automatically by Jules for task [16605093104177699810](https://jules.google.com/task/16605093104177699810) started by @emersonbusson*