### PR TITLE
docs: report architectural mismatch for WDF audit

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,3 @@
+The task requested an audit of WDF (Windows Driver Framework) object hierarchy and parent-child cleanup relationships in drivers/windows/ramshared/driver.c to eliminate pool leaks.
+However, this is an architectural mismatch. The RamShared Windows driver is a WDM/StorPort driver (as evident by the inclusion of ntddstor.h, the use of HW_INITIALIZATION_DATA, and StorPort initialization routines like HwStorFindAdapter, StorPortInitialize).
+It does not use KMDF or any WDF objects. Therefore, there are no WDF objects to audit, and safe code modification to fulfill this objective is not possible.


### PR DESCRIPTION
## Resumo
The task requested an audit of WDF object hierarchy and parent-child cleanup relationships. However, the RamShared Windows driver is a WDM/StorPort driver, not a KMDF driver. There are no WDF objects to audit. Produced FINDING_ONLY report.
## Issue
audit WDF object hierarchy and parent-child cleanup relationships
## Responsavel
Jules
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: report architectural mismatch for WDF audit | Added FINDING_ONLY report | Driver is WDM/StorPort, not KMDF | <details><summary>detalhes</summary>Added FINDING_ONLY.txt explaining the mismatch.</details> |
## Labels
type:docs, type:kernel
## Validacao
Grep for Wdf returned nothing. Checked driver.c and confirmed StorPort API usage. Ran CI test suite.
## Rollback trigger
Revert if the CI pipeline fails.

---
*PR created automatically by Jules for task [3256221175353678559](https://jules.google.com/task/3256221175353678559) started by @emersonbusson*