### PR TITLE
feat(kernel-win): add protocol handshake header with magic bytes

### DIFF
--- a/crates/ramshared-winsvc/src/proto.rs
+++ b/crates/ramshared-winsvc/src/proto.rs
@@ -7,6 +7,7 @@
 pub const ABI_VERSION: u32 = 1;
 pub const MAX_QD: u32 = 256;
 pub const MAX_IO: u32 = 1 << 20;
+pub const PROTO_MAGIC: u32 = 0x5241_4D53; // 'RAMS'
 pub const RING_MAGIC: u32 = 0x5253_5244; // 'RSRD'
 
 pub const OP_READ: u32 = 0;
@@ -39,6 +40,15 @@ pub struct Sqe {
 pub struct Cqe {
     pub tag: u64,
     pub status: i32,
+    pub reserved: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProtoHdr {
+    pub magic: u32,
+    pub version: u32,
+    pub header_len: u32,
     pub reserved: u32,
 }
 
@@ -81,6 +91,7 @@ const _: () = {
     assert!(core::mem::size_of::<Sqe>() == 32);
     assert!(core::mem::align_of::<Sqe>() <= 8);
     assert!(core::mem::size_of::<Cqe>() == 16);
+    assert!(core::mem::size_of::<ProtoHdr>() == 16);
     assert!(core::mem::size_of::<RingHdr>() == 16);
     assert!(core::mem::size_of::<Register>() == 72);
     assert!(core::mem::size_of::<DiskParams>() == 32);
@@ -130,6 +141,7 @@ mod tests {
         assert_eq!(ABI_VERSION, 1);
         assert_eq!(MAX_QD, 256);
         assert_eq!(MAX_IO, 1 << 20);
+        assert_eq!(PROTO_MAGIC, 0x5241_4D53);
         assert_eq!(RING_MAGIC, 0x5253_5244);
     }
 }

--- a/docs/governance/rust-slice-coverage.json
+++ b/docs/governance/rust-slice-coverage.json
@@ -157,7 +157,7 @@
         "-p",
         "ramshared-winsvc",
         "--files",
-        "crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs",
+        "crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs,crates/ramshared-winsvc/src/proto.rs",
         "--min",
         "80"
       ],
@@ -171,7 +171,8 @@
         "crates/ramshared-winsvc/src/broker_tenant.rs",
         "crates/ramshared-winsvc/src/runtime.rs",
         "crates/ramshared-winsvc/src/service.rs",
-        "crates/ramshared-winsvc/src/host_safety.rs"
+        "crates/ramshared-winsvc/src/host_safety.rs",
+        "crates/ramshared-winsvc/src/proto.rs"
       ],
       "min": 80
     },

--- a/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
+++ b/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
@@ -489,7 +489,7 @@ those shared sources as evidence without creating a second coverage owner.
 - [x] `cargo clippy -p ramshared-cuda -p ramshared-block -p ramshared-winsvc --all-targets -- -D warnings`
 - [x] `cargo test -p ramshared-cuda -p ramshared-block -p ramshared-winsvc`
 - [x] `cargo build -p ramshared-winsvc --target x86_64-pc-windows-msvc`
-- [x] `node tools/ci/check-rust-slice-coverage.mjs -p ramshared-winsvc --files crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs --min 80`
+- [x] `node tools/ci/check-rust-slice-coverage.mjs -p ramshared-winsvc --files crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs,crates/ramshared-winsvc/src/proto.rs --min 80`
   (also CUDA probe cover ≥80% when `crates/ramshared-cuda/src/probe.rs` is in the gate set)
 - [ ] If pure planning logic changes in `crates/ramshared-cuda/src/driver.rs`, include that file in a
   separate `ramshared-cuda` cover gate at >=80%; hardware-only lines remain live-E2E evidence.

--- a/drivers/windows/ramshared/protocol.h
+++ b/drivers/windows/ramshared/protocol.h
@@ -32,7 +32,16 @@ typedef uint8_t ramshared_u8;
 #define RAMSHARED_ABI_VERSION 1u
 #define RAMSHARED_MAX_QD 256u	/* queue_depth max; power of two */
 #define RAMSHARED_MAX_IO (1u << 20) /* 1 MiB per bounce slot */
+#define RAMSHARED_PROTO_MAGIC 0x52414D53u /* 'RAMS' */
 #define RAMSHARED_RING_MAGIC 0x52535244u /* 'RSRD' */
+
+/* Protocol handshake header */
+typedef struct _RAMSHARED_PROTO_HDR {
+	ramshared_u32 magic;
+	ramshared_u32 version;
+	ramshared_u32 header_len;
+	ramshared_u32 reserved;
+} RAMSHARED_PROTO_HDR, *PRAMSHARED_PROTO_HDR;
 
 enum ramshared_op {
 	RAMSHARED_OP_READ = 0,
@@ -111,6 +120,7 @@ typedef struct _RAMSHARED_DISK_PARAMS {
 #ifdef __cplusplus
 static_assert(sizeof(RAMSHARED_SQE) == 32, "RAMSHARED_SQE size");
 static_assert(sizeof(RAMSHARED_CQE) == 16, "RAMSHARED_CQE size");
+static_assert(sizeof(RAMSHARED_PROTO_HDR) == 16, "RAMSHARED_PROTO_HDR size");
 static_assert(sizeof(RAMSHARED_RING_HDR) == 16, "RAMSHARED_RING_HDR size");
 static_assert(sizeof(RAMSHARED_REGISTER) == 72, "RAMSHARED_REGISTER size");
 static_assert(sizeof(RAMSHARED_DISK_PARAMS) == 32, "RAMSHARED_DISK_PARAMS size");


### PR DESCRIPTION
## Resumo
Add `RAMSHARED_PROTO_HDR` with magic bytes 0x52414D53 to establish a version handshake protocol between Ring-0 driver and Ring-3 service. Rust mirror updated identically.

## Issue
kernel-win: version handshake protocol header definition with magic bytes

## Responsavel
Jules

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(kernel-win): add protocol header | Added `RAMSHARED_PROTO_HDR` to C header and `ProtoHdr` to Rust | Require a structured handshake with magic bytes 0x52414D53 | <details><summary>detalhes</summary>Includes size assertions in both files to ensure ABI parity.</details> |

## Labels
type:feat, type:kernel-win

## Validacao
`cargo test -p ramshared-winsvc` completed successfully. `git diff` validated. `docs-check.sh` and kernel scripts passed.

## Rollback trigger
Revert if driver-service version handshake fails or causes ABI misalignments.

---
*PR created automatically by Jules for task [3663960255951439730](https://jules.google.com/task/3663960255951439730) started by @emersonbusson*