### PR TITLE
feat(kernel-win): add LBA to byte conversion bounds checking

### DIFF
--- a/drivers/windows/ramshared/virtdisk.c
+++ b/drivers/windows/ramshared/virtdisk.c
@@ -490,9 +490,11 @@ VdTranslateSrb(
 			offset = 0;
 			len = 0;
 		} else {
+			UINT64 lba;
+
 			/* Parse LBA from CDB (10-byte and 16-byte forms). */
 			if (op == SCSIOP_READ16 || op == SCSIOP_WRITE16) {
-				offset = ((UINT64)Srb->Cdb[2] << 56) |
+				lba = ((UINT64)Srb->Cdb[2] << 56) |
 					 ((UINT64)Srb->Cdb[3] << 48) |
 					 ((UINT64)Srb->Cdb[4] << 40) |
 					 ((UINT64)Srb->Cdb[5] << 32) |
@@ -501,13 +503,31 @@ VdTranslateSrb(
 					 ((UINT64)Srb->Cdb[8] << 8) |
 					 ((UINT64)Srb->Cdb[9]);
 			} else {
-				offset = ((UINT64)Srb->Cdb[2] << 24) |
+				lba = ((UINT64)Srb->Cdb[2] << 24) |
 					 ((UINT64)Srb->Cdb[3] << 16) |
 					 ((UINT64)Srb->Cdb[4] << 8) |
 					 ((UINT64)Srb->Cdb[5]);
 			}
-			offset *= Disk->block_size;
 			len = Srb->DataTransferLength;
+
+			if (!VdCheckLbaBounds(Disk, lba, len, &offset)) {
+				/*
+				 * Illegal request, Logical block address out of range.
+				 * Use 0x05 (ILLEGAL_REQUEST), ASC=0x21, ASCQ=0x00.
+				 */
+				Srb->SrbStatus = SRB_STATUS_INVALID_REQUEST;
+				Srb->ScsiStatus = SCSISTAT_CHECK_CONDITION;
+				if (Srb->SenseInfoBuffer && Srb->SenseInfoBufferLength >= 18) {
+					UCHAR *sense = (UCHAR *)Srb->SenseInfoBuffer;
+					RtlZeroMemory(sense, Srb->SenseInfoBufferLength);
+					sense[0] = 0x70;
+					sense[2] = 0x05; /* ILLEGAL REQUEST */
+					sense[7] = 10;
+					sense[12] = 0x21; /* LOGICAL BLOCK ADDRESS OUT OF RANGE */
+				}
+				break;
+			}
+
 			if (op == SCSIOP_READ || op == SCSIOP_READ16) {
 				rop = RAMSHARED_OP_READ;
 			} else {

--- a/drivers/windows/ramshared/virtdisk.h
+++ b/drivers/windows/ramshared/virtdisk.h
@@ -45,3 +45,40 @@ BOOLEAN VdOwnerMatches(_In_ PEPROCESS Process);
 BOOLEAN VdOwnerExited(VOID);
 BOOLEAN VdApplyRegisteredQueueDepth(_Inout_ PVIRTUAL_DISK Disk,
 				    _In_ PVOID DevExt);
+
+/*
+ * Defensive Physical Check:
+ * Validate sector-to-byte translations against 64-bit integer overflow and disk capacity.
+ * LBA * block_size could overflow MAXULONG64. We avoid this by bounds-checking LBA.
+ */
+FORCEINLINE
+BOOLEAN
+VdCheckLbaBounds(
+	_In_ PVIRTUAL_DISK Disk,
+	_In_ UINT64 Lba,
+	_In_ UINT32 Length,
+	_Out_ UINT64 *Offset
+	)
+{
+	UINT64 max_lba;
+
+	if (Disk == NULL || Disk->block_size == 0 || Disk->size_bytes == 0)
+		return FALSE;
+
+	max_lba = Disk->size_bytes / Disk->block_size;
+
+	/*
+	 * Guard against LBA overflow or out-of-bounds access.
+	 * Also verify length doesn't cause overflow when added to the offset.
+	 * Length must be a multiple of block_size.
+	 */
+	if (Lba >= max_lba || (Length & (Disk->block_size - 1)) != 0)
+		return FALSE;
+
+	*Offset = Lba * Disk->block_size;
+
+	if (*Offset > Disk->size_bytes || Length > Disk->size_bytes - *Offset)
+		return FALSE;
+
+	return TRUE;
+}


### PR DESCRIPTION
## Issue
geometry descriptor constants and sector conversion helper macros

## Responsavel
Jules

## Resumo
Add type-safe helper macro `VdCheckLbaBounds` for LBA to byte offset conversion with 64-bit overflow prevention. Validate in translation path for read and write. Return invalid request on out-of-range bounds.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(kernel-win): add LBA to byte conversion bounds checking | Implementation | 64-bit overflow prevention during sector/byte geometry conversions | <details><summary>detalhes</summary>Added VdCheckLbaBounds.</details> |

## Labels
type:kernel

## Validacao
./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh

## Rollback trigger
Compile failures or BSODs.

---
*PR created automatically by Jules for task [4872716227177351471](https://jules.google.com/task/4872716227177351471) started by @emersonbusson*