### PR TITLE
feat(c-bench): clamp benchmark buffer size to physical GPU VRAM capacity

### DIFF
--- a/tools/benchmarks/kernel_vram_bench.c
+++ b/tools/benchmarks/kernel_vram_bench.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <time.h>
 #include <dlfcn.h>
+#include <errno.h>
 
 #define DEFAULT_CHUNK_MIB 256
 #define MIB_TO_BYTES(mib) ((size_t)(mib) * 1024 * 1024)
@@ -112,6 +113,19 @@ int main(int argc, char **argv) {
 	cuMemGetInfo(&free_b, &total_b);
 	printf("[+] GPU Memory: %zu MiB free / %zu MiB total\n",
 	       free_b / (1024 * 1024), total_b / (1024 * 1024));
+
+	if (chunk_bytes > free_b) {
+		chunk_mib = (int)(free_b / (1024 * 1024));
+		chunk_bytes = MIB_TO_BYTES(chunk_mib);
+		printf("[!] Clamping benchmark buffer to %d MiB to fit physical VRAM\n", chunk_mib);
+	}
+
+	if (chunk_bytes == 0) {
+		fprintf(stderr, "[-] Error: Insufficient free VRAM for benchmark.\n");
+		cuCtxDestroy(ctx);
+		dlclose(lib);
+		return -ENOMEM;
+	}
 
 	// Allocate Pinned Host Memory
 	void *host_pinned = NULL;


### PR DESCRIPTION
## Resumo
Clamped the requested benchmark buffer size to the physical GPU VRAM capacity in `tools/benchmarks/kernel_vram_bench.c` to prevent Out-Of-Memory (OOM) driver crashes. Also enforces a semantic error return (`-ENOMEM`) if sufficient memory is unavailable.

## Issue
clamp benchmark buffer size to physical GPU VRAM capacity

## Responsavel
Jules

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(c-bench): clamp benchmark buffer size to physical GPU VRAM capacity | Clamped buffer to VRAM limit | To avoid OOM driver crashes | <details><summary>detalhes</summary>Added guard check comparing chunk_bytes to free_b, adjusting allocation size accordingly. Returns -ENOMEM if sufficient VRAM is absent.</details> |

## Labels
type:kernel, type:refactor

## Validacao
Compiled `tools/benchmarks/kernel_vram_bench.c` utilizing gcc with `-Wall -Wextra -Werror` to verify code correctness and clean integration.

## Rollback trigger
Revert if clamping logic computes an incorrect buffer size, preventing benchmarks on capable devices.

---
*PR created automatically by Jules for task [11286391318769344424](https://jules.google.com/task/11286391318769344424) started by @emersonbusson*