### PR TITLE
fix(c-bench): use CLOCK_MONOTONIC_RAW to eliminate NTP skew

### DIFF
--- a/tools/benchmarks/kernel_vram_bench.c
+++ b/tools/benchmarks/kernel_vram_bench.c
@@ -31,7 +31,7 @@ typedef int (*cuMemcpyDtoH_t)(void*, uint64_t, size_t);
 
 static double get_time_sec(void) {
 	struct timespec ts;
-	clock_gettime(CLOCK_MONOTONIC, &ts);
+	clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
 	return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
 }
 


### PR DESCRIPTION
## Issue
c-bench/057

## Responsavel
Jules

## Resumo
Replaced CLOCK_MONOTONIC with CLOCK_MONOTONIC_RAW in `tools/benchmarks/kernel_vram_bench.c` to prevent NTP adjustments from skewing DMA bandwidth and latency measurements.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix(c-bench): use CLOCK_MONOTONIC_RAW | Changed clock_gettime clock ID | To prevent NTP from skewing latency benchmarks | <details><summary>detalhes</summary>Updated get_time_sec in tools/benchmarks/kernel_vram_bench.c to use CLOCK_MONOTONIC_RAW</details> |

## Labels
type:bench

## Validacao
- Compiled `tools/benchmarks/kernel_vram_bench.c` with `-Wall -Wextra -Werror`
- Executed full CI suite scripts: `./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
Revert if compilation fails on older distributions lacking CLOCK_MONOTONIC_RAW or if runtime errors related to gettime occur.

---
*PR created automatically by Jules for task [14556360938334647663](https://jules.google.com/task/14556360938334647663) started by @emersonbusson*