### PR TITLE
docs: report finding on already-validated poolstress allocation

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,26 @@
+FINDING ONLY REPORT
+
+Task: guard clauses on pool allocation handles in poolstress harness
+Target File: drivers/windows/tools/poolstress/poolstress.c
+Objective: Check ExAllocatePoolWithTag return pointers with guard clauses before writing test patterns.
+
+Findings:
+1. The target file `drivers/windows/tools/poolstress/poolstress.c` does not use the legacy `ExAllocatePoolWithTag` function for allocation. It has already been migrated to the modern equivalent `ExAllocatePool2`.
+2. The return pointer from `ExAllocatePool2` is already properly validated with a linear guard clause before any test patterns are written.
+
+Evidence from `drivers/windows/tools/poolstress/poolstress.c`:
+```c
+			bytes = (SIZE_T)in->NGb << 30;
+			g_Pool = ExAllocatePool2(POOL_FLAG_PAGED, bytes, 'ssPR');
+			if (!g_Pool) {
+				status = STATUS_INSUFFICIENT_RESOURCES;
+				break;
+			}
+			g_PoolSize = bytes;
+			/* Fill every byte in bounded BCrypt calls (DT-21). */
+			PoolstressFill((PUCHAR)g_Pool, bytes);
+```
+As shown in the excerpt, `g_Pool` is checked against NULL. If it is NULL, the code assigns `STATUS_INSUFFICIENT_RESOURCES` and breaks out of the switch case, successfully preventing any null-pointer dereference during the subsequent `PoolstressFill` invocation or page touching loop.
+
+Conclusion:
+No safe code modification is required or possible, as the codebase already fully implements the requested architectural principle (guard clauses on pool allocations) using the correct, modern API (`ExAllocatePool2`).


### PR DESCRIPTION
## Resumo
The task requested adding guard clauses to check `ExAllocatePoolWithTag` return pointers in the poolstress harness. An investigation revealed that the code has already been migrated to `ExAllocatePool2` and properly validates the returned handle (`g_Pool`) with a linear guard clause before writing any test patterns. Therefore, a FINDING_ONLY report was produced instead of code modifications.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | docs: add FINDING_ONLY report for poolstress allocation check | Code is already compliant with the requested objective. | <details><summary>detalhes</summary>Added FINDING_ONLY.txt documenting that ExAllocatePool2 is already checked with a guard clause.</details> |

## Labels
type:docs, type:kernel

## Validacao
Executed the full C/Kernel validation suite to ensure no regressions: `./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
Revert if the FINDING_ONLY report is deemed incorrect and actual code modification was intended.

## Issue
#61

## Responsavel
Jules

---
*PR created automatically by Jules for task [15023633163283016752](https://jules.google.com/task/15023633163283016752) started by @emersonbusson*