### PR TITLE
feat(c-bench): semantic NTSTATUS error returns on stress test exhaustion

### DIFF
--- a/drivers/windows/tools/poolstress/poolstress.c
+++ b/drivers/windows/tools/poolstress/poolstress.c
@@ -98,9 +98,11 @@ PoolstressDispatch(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp)
 			bytes = (SIZE_T)in->NGb << 30;
 			g_Pool = ExAllocatePool2(POOL_FLAG_PAGED, bytes, 'ssPR');
 			if (!g_Pool) {
-				status = STATUS_INSUFFICIENT_RESOURCES;
+				DbgPrint("poolstress: ExAllocatePool2 failed for %lu GB (%Iu bytes)\n", in->NGb, bytes);
+				status = STATUS_NO_MEMORY;
 				break;
 			}
+			DbgPrint("poolstress: ExAllocatePool2 success for %lu GB (%Iu bytes)\n", in->NGb, bytes);
 			g_PoolSize = bytes;
 			/* Fill every byte in bounded BCrypt calls (DT-21). */
 			PoolstressFill((PUCHAR)g_Pool, bytes);


### PR DESCRIPTION
## Issue
ITEM-8 / DT-11

## Responsavel
Jules

## Resumo
Updated `poolstress.c` to return `STATUS_NO_MEMORY` instead of `STATUS_INSUFFICIENT_RESOURCES` upon `ExAllocatePool2` failure, and added detailed diagnostic `DbgPrint` summaries for both allocation success and failure.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| poolstress error handling | Changed poolstress.c to return STATUS_NO_MEMORY on alloc failure and print summary | To satisfy architectural principles for precise semantic error returns and detailed diagnostics | <details><summary>detalhes</summary>Added DbgPrint for both success and failure cases indicating the requested size.</details> |

## Labels
type:refactor, type:kernel

## Validacao
Ran the complete RamShared CI suite: `./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
Revert if the change causes test automation script failures relying on the legacy `STATUS_INSUFFICIENT_RESOURCES` behavior or if `DbgPrint` outputs spam the kernel log excessively.

---
*PR created automatically by Jules for task [5640854845996620075](https://jules.google.com/task/5640854845996620075) started by @emersonbusson*