### PR TITLE
refactor(c-bench): implement linear goto cleanup and precise errnos

### DIFF
--- a/tools/benchmarks/kernel_vram_bench.c
+++ b/tools/benchmarks/kernel_vram_bench.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <time.h>
 #include <dlfcn.h>
+#include <errno.h>
 
 #define DEFAULT_CHUNK_MIB 256
 #define MIB_TO_BYTES(mib) ((size_t)(mib) * 1024 * 1024)
@@ -52,22 +53,36 @@ static void *load_cuda_driver(void) {
 
 int main(int argc, char **argv) {
 	int chunk_mib = DEFAULT_CHUNK_MIB;
+	int ret = 0;
+	void *lib = NULL;
+	void *ctx = NULL;
+	void *host_pinned = NULL;
+	void *read_pinned = NULL;
+	uint64_t dev_ptr = 0;
+
 	if (argc > 1) {
 		int val = atoi(argv[1]);
-		if (val > 0 && val <= 4096) {
-			chunk_mib = val;
+		if (val <= 0 || val > 4096) {
+			fprintf(stderr, "[-] Error: Invalid chunk_mib size (must be 1-4096).\n");
+			return -EINVAL;
 		}
+		chunk_mib = val;
 	}
 	size_t chunk_bytes = MIB_TO_BYTES(chunk_mib);
+
+	if (chunk_bytes % 4096 != 0) {
+		fprintf(stderr, "[-] Error: Buffer size not 4096-byte aligned.\n");
+		return -EINVAL;
+	}
 
 	printf("=================================================================\n");
 	printf("   RamShared Hardware DMA & PCIe Bandwidth Benchmark Tool         \n");
 	printf("=================================================================\n");
 
-	void *lib = load_cuda_driver();
+	lib = load_cuda_driver();
 	if (!lib) {
 		fprintf(stderr, "[-] Error: CUDA driver library (libcuda.so.1) not found.\n");
-		return 1;
+		return -ENODEV;
 	}
 
 	cuInit_t cuInit = (cuInit_t)dlsym(lib, "cuInit");
@@ -85,69 +100,98 @@ int main(int argc, char **argv) {
 
 	if (!cuInit || !cuCtxCreate || !cuMemcpyHtoD || !cuMemcpyDtoH) {
 		fprintf(stderr, "[-] Error: Required CUDA symbols missing in library.\n");
-		dlclose(lib);
-		return 1;
+		ret = -EINVAL;
+		goto out_lib;
 	}
 
 	if (cuInit(0) != 0) {
 		fprintf(stderr, "[-] Error: cuInit failed.\n");
-		dlclose(lib);
-		return 1;
+		ret = -ENODEV;
+		goto out_lib;
 	}
 
 	int dev = 0;
-	cuDeviceGet(&dev, 0);
+	if (cuDeviceGet(&dev, 0) != 0) {
+		fprintf(stderr, "[-] Error: cuDeviceGet failed.\n");
+		ret = -ENODEV;
+		goto out_lib;
+	}
+
 	char dev_name[256] = {0};
-	cuDeviceGetName(dev_name, sizeof(dev_name), dev);
+	if (cuDeviceGetName(dev_name, sizeof(dev_name), dev) != 0) {
+		fprintf(stderr, "[-] Error: cuDeviceGetName failed.\n");
+		ret = -ENODEV;
+		goto out_lib;
+	}
 	printf("[+] Hardware: %s (PCIe Direct DMA Channel)\n", dev_name);
 
-	void *ctx = NULL;
 	if (cuCtxCreate(&ctx, 0, dev) != 0) {
 		fprintf(stderr, "[-] Error: cuCtxCreate failed.\n");
-		dlclose(lib);
-		return 1;
+		ret = -ENODEV;
+		goto out_lib;
 	}
 
 	size_t free_b = 0, total_b = 0;
-	cuMemGetInfo(&free_b, &total_b);
+	if (cuMemGetInfo(&free_b, &total_b) != 0) {
+		fprintf(stderr, "[-] Error: cuMemGetInfo failed.\n");
+		ret = -EINVAL;
+		goto out_ctx;
+	}
 	printf("[+] GPU Memory: %zu MiB free / %zu MiB total\n",
 	       free_b / (1024 * 1024), total_b / (1024 * 1024));
 
 	// Allocate Pinned Host Memory
-	void *host_pinned = NULL;
 	if (cuMemHostAlloc(&host_pinned, chunk_bytes, 0) != 0) {
 		fprintf(stderr, "[-] Error: cuMemHostAlloc failed (%d MiB).\n", chunk_mib);
-		cuCtxDestroy(ctx);
-		dlclose(lib);
-		return 1;
+		ret = -ENOMEM;
+		goto out_ctx;
 	}
-	memset(host_pinned, 0xA5, chunk_bytes);
+
+	// Fill buffers with pseudorandom test patterns (Xorshift32)
+	uint32_t seed = (uint32_t)time(NULL) | 1; // Ensure non-zero seed
+	uint32_t *hp_ptr32 = (uint32_t *)host_pinned;
+	size_t num_words = chunk_bytes / sizeof(uint32_t);
+	for (size_t i = 0; i < num_words; i++) {
+		seed ^= seed << 13;
+		seed ^= seed >> 17;
+		seed ^= seed << 5;
+		hp_ptr32[i] = seed;
+	}
 
 	// Allocate Device VRAM Buffer
-	uint64_t dev_ptr = 0;
 	if (cuMemAlloc(&dev_ptr, chunk_bytes) != 0) {
 		fprintf(stderr, "[-] Error: cuMemAlloc failed (%d MiB).\n", chunk_mib);
-		cuMemFreeHost(host_pinned);
-		cuCtxDestroy(ctx);
-		dlclose(lib);
-		return 1;
+		ret = -ENOMEM;
+		goto out_host_pinned;
 	}
 
 	// 1. Direct DMA Host -> VRAM (Push)
 	printf("[+] Benchmarking Host -> VRAM DMA (%d MiB)...\n", chunk_mib);
 	double t0 = get_time_sec();
-	cuMemcpyHtoD(dev_ptr, host_pinned, chunk_bytes);
+	if (cuMemcpyHtoD(dev_ptr, host_pinned, chunk_bytes) != 0) {
+		fprintf(stderr, "[-] Error: cuMemcpyHtoD failed.\n");
+		ret = -EFAULT;
+		goto out_dev_ptr;
+	}
 	double t1 = get_time_sec();
 	double h2d_speed = (double)chunk_mib / (t1 - t0);
 	printf("[+] H2D PCIe DMA Write: %.2f MiB/s (%.2f GiB/s) in %.4f s\n",
 	       h2d_speed, h2d_speed / 1024.0, t1 - t0);
 
 	// 2. Direct DMA VRAM -> Host (Pull)
-	void *read_pinned = NULL;
-	cuMemHostAlloc(&read_pinned, chunk_bytes, 0);
+	if (cuMemHostAlloc(&read_pinned, chunk_bytes, 0) != 0) {
+		fprintf(stderr, "[-] Error: cuMemHostAlloc (read) failed.\n");
+		ret = -ENOMEM;
+		goto out_dev_ptr;
+	}
+
 	printf("[+] Benchmarking VRAM -> Host DMA (%d MiB)...\n", chunk_mib);
 	t0 = get_time_sec();
-	cuMemcpyDtoH(read_pinned, dev_ptr, chunk_bytes);
+	if (cuMemcpyDtoH(read_pinned, dev_ptr, chunk_bytes) != 0) {
+		fprintf(stderr, "[-] Error: cuMemcpyDtoH failed.\n");
+		ret = -EFAULT;
+		goto out_read_pinned;
+	}
 	t1 = get_time_sec();
 	double d2h_speed = (double)chunk_mib / (t1 - t0);
 	printf("[+] D2H PCIe DMA Read : %.2f MiB/s (%.2f GiB/s) in %.4f s\n",
@@ -158,13 +202,21 @@ int main(int argc, char **argv) {
 	printf("\n[+] Data Integrity Proof: %s\n",
 	       match ? "PASS (100% Bit-Exact Match, Zero Corruption)" : "FAIL");
 
-	// Cleanup
-	cuMemFree(dev_ptr);
-	cuMemFreeHost(host_pinned);
-	cuMemFreeHost(read_pinned);
-	cuCtxDestroy(ctx);
-	dlclose(lib);
+	if (!match) {
+		ret = -EFAULT;
+	}
+
+out_read_pinned:
+	if (read_pinned) cuMemFreeHost(read_pinned);
+out_dev_ptr:
+	if (dev_ptr) cuMemFree(dev_ptr);
+out_host_pinned:
+	if (host_pinned) cuMemFreeHost(host_pinned);
+out_ctx:
+	if (ctx) cuCtxDestroy(ctx);
+out_lib:
+	if (lib) dlclose(lib);
 
 	printf("=================================================================\n");
-	return match ? 0 : 1;
+	return ret;
 }


### PR DESCRIPTION
## Issue
KernelC100/2026-08-30/c-bench/065

## Responsavel
Jules

## Resumo
Refactored `kernel_vram_bench.c` to use linear goto error cleanup, added explicit negative errno return codes, enforced parameter checks with 4096-byte alignment, and replaced the hardcoded `memset` with a pseudorandom Xorshift32 data fill for memory corruption pattern verification on readback.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(c-bench): implement linear goto cleanup and precise errnos | Applied goto cleanup, exact kernel errnos, and Xorshift32 pseudorandom testing | To align with strict kernel C architectural rules | <details><summary>detalhes</summary>Eliminated duplicated cleanup code and added precise error context.</details> |

## Labels
type:refactor, type:kernel, type:c-bench

## Validacao
Executed CI: `./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
Revert if `kernel_vram_bench` causes unexpected memory leaks or the readback integrity verification fails for legitimate configurations.

---
*PR created automatically by Jules for task [11278443564317029277](https://jules.google.com/task/11278443564317029277) started by @emersonbusson*