### PR TITLE
feat: enforce static C ABI layout assertions for dxg structs

### DIFF
--- a/crates/ramshared-dxg/src/lib.rs
+++ b/crates/ramshared-dxg/src/lib.rs
@@ -49,6 +49,15 @@ pub mod uapi {
         pub available_for_reservation: u64,
         pub physical_adapter_index: u32,
     }
+
+    const _: () = {
+        assert!(std::mem::size_of::<AdapterInfo>() == 20);
+        assert!(std::mem::align_of::<AdapterInfo>() == 4);
+        assert!(std::mem::size_of::<EnumAdapters2>() == 16);
+        assert!(std::mem::align_of::<EnumAdapters2>() == 8);
+        assert!(std::mem::size_of::<QueryVideoMemoryInfo>() == 56);
+        assert!(std::mem::align_of::<QueryVideoMemoryInfo>() == 8);
+    };
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Issue
audit C struct alignment and padding against Linux kernel dxgkrnl ABI

## Responsavel
jules

## Resumo
Enforce static compile-time assertions for `AdapterInfo`, `EnumAdapters2`, and `QueryVideoMemoryInfo` in the `ramshared-dxg` crate to ensure they strictly align with the Linux kernel `dxgkrnl.h` struct sizes and alignments.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat: enforce static C ABI layout assertions for dxg structs | Added static assertions for C ABI sizes and alignments in `crates/ramshared-dxg/src/lib.rs` | To prevent layout mismatches across FFI kernel boundaries. | <details><summary>detalhes</summary>Added `const _: ()` block validating `size_of` and `align_of` for dxg structs.</details> |

## Labels
type:ffi, type:kernel

## Validacao
Executed `cargo test` and static layout assertions passed.
Ran `./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
Revert if static assertions fail indicating mismatched layouts.

---
*PR created automatically by Jules for task [10419766263791224811](https://jules.google.com/task/10419766263791224811) started by @emersonbusson*