### PR TITLE
feat(dxg): validate adapter handle against zero

### DIFF
--- a/crates/ramshared-dxg/src/lib.rs
+++ b/crates/ramshared-dxg/src/lib.rs
@@ -190,6 +190,9 @@ impl DxgBudgetProvider {
             .find(|info| info.luid_low == selected.low && info.luid_high == selected.high)
             .copied()
             .ok_or(DxgError::AdapterNotFound(selected))?;
+        if selected_info.adapter_handle == 0 {
+            return Err(DxgError::Malformed("adapter_handle"));
+        }
         for info in &infos {
             if info.adapter_handle != selected_info.adapter_handle {
                 close_adapter(&file, info.adapter_handle);
@@ -262,6 +265,8 @@ fn validate_enum(request: &uapi::EnumAdapters2, capacity: Option<usize>) -> Resu
 fn validate_query(query: &uapi::QueryVideoMemoryInfo) -> Result<(), DxgError> {
     if query.process != 0 {
         Err(DxgError::Malformed("process"))
+    } else if query.adapter == 0 {
+        Err(DxgError::Malformed("adapter"))
     } else {
         Ok(())
     }
@@ -499,6 +504,11 @@ mod tests {
             Err(super::DxgError::Malformed("process"))
         );
         query.process = 0;
+        assert_eq!(
+            super::validate_query(&query),
+            Err(super::DxgError::Malformed("adapter"))
+        );
+        query.adapter = 1;
         assert_eq!(super::validate_query(&query), Ok(()));
     }
 }


### PR DESCRIPTION
## Issue
sanity check dxgkrnl adapter handle and shared resource handle bounds

## Responsavel
Jules

## Resumo
Added defensive guard clauses to validate `adapter_handle` values against zero in `crates/ramshared-dxg/src/lib.rs`. The requested `shared_resource_handle` and reserved kernel ranges do not exist in the dxgkrnl WDDM `uapi` structures and were therefore not checked.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Checked `adapter_handle` for zero | Defensively validate handle values | <details><summary>detalhes</summary>Added guard clauses in `from_infos` and `validate_query` to check `adapter_handle` and `adapter` against zero.</details> |

## Labels
type:feat, type:kernel

## Validacao
./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh

## Rollback trigger
Revert if the checks cause legitimate adapter instances to fail initialization.

---
*PR created automatically by Jules for task [6132765984574810614](https://jules.google.com/task/6132765984574810614) started by @emersonbusson*