### PR TITLE
ffi-abi: guard checks for SQE ring entry availability before submission

### DIFF
--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -234,6 +234,7 @@ fn submit_uring_cmd80(fd: RawFd, cmd_op: u32, cmd: [u8; 80]) -> io::Result<i32> 
 
     {
         let mut sq = ring.submission();
+        sq.sync();
         if sq.is_full() {
             return Err(io::Error::other("io_uring submission queue is full"));
         }
@@ -330,6 +331,7 @@ impl UblkFetchRing {
             // while the FETCH calls are parked; the kernel only accesses the buffer when
             // serving I/O, which requires `START_DEV` (not invoked in this path).
             let mut sq = ring.submission();
+            sq.sync();
             if sq.is_full() {
                 return Err(io::Error::other("io_uring submission queue is full"));
             }
@@ -494,6 +496,7 @@ impl UblkServer {
         // to `self.buffers[tag]`, which remains valid for the server's lifetime; `self.fd`
         // remains open. The kernel only accesses the buffer to serve I/O on this thread.
         let mut sq = self.ring.submission();
+        sq.sync();
         if sq.is_full() {
             return Err(io::Error::other("io_uring submission queue is full"));
         }


### PR DESCRIPTION
## Issue
ffi-abi-070

## Responsavel
jules

## Resumo
Add `sq.sync()` before checking `sq.is_full()` in `crates/ramshared-uring/src/lib.rs` to ensure the io_uring submission ring is synchronized with the kernel before evaluating if it's full.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| ffi-abi: guard checks for SQE ring entry availability before submission | Added `sq.sync()` before `sq.is_full()` checks in `submit_uring_cmd80`, `UblkFetchRing::submit_fetch_all`, and `UblkServer::push` | To synchronize the user-space submission queue state with the kernel, preventing false positives where `is_full()` returns true despite the kernel having already consumed SQEs. | <details><summary>detalhes</summary>Modified `crates/ramshared-uring/src/lib.rs` to insert `sq.sync()`.</details> |

## Labels
type:kernel, type:refactor

## Validacao
Ran `./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`.

## Rollback trigger
Revert if the tests fail or if there are unexpected panics related to the submission queue being full.

---
*PR created automatically by Jules for task [13958522589735629747](https://jules.google.com/task/13958522589735629747) started by @emersonbusson*