### PR TITLE
feat(cuda): add 64-bit CUDA FFI ABI layouts

### DIFF
--- a/crates/ramshared-cuda/src/ffi.rs
+++ b/crates/ramshared-cuda/src/ffi.rs
@@ -35,6 +35,65 @@ pub type FnMemsetD8 = unsafe extern "C" fn(CuDevicePtr, u8, usize) -> CuResult;
 pub type FnMemGetInfo = unsafe extern "C" fn(*mut usize, *mut usize) -> CuResult;
 pub type FnGetErrorString = unsafe extern "C" fn(CuResult, *mut *const c_char) -> CuResult;
 
+pub type CuArray = *mut c_void;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+#[allow(non_snake_case)]
+pub struct CUDA_MEMCPY2D_v2 {
+    pub srcXInBytes: usize,
+    pub srcY: usize,
+    pub srcMemoryType: c_uint,
+    pub srcHost: *const c_void,
+    pub srcDevice: CuDevicePtr,
+    pub srcArray: CuArray,
+    pub srcPitch: usize,
+
+    pub dstXInBytes: usize,
+    pub dstY: usize,
+    pub dstMemoryType: c_uint,
+    pub dstHost: *mut c_void,
+    pub dstDevice: CuDevicePtr,
+    pub dstArray: CuArray,
+    pub dstPitch: usize,
+
+    pub WidthInBytes: usize,
+    pub Height: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+#[allow(non_snake_case)]
+pub struct CUDA_MEMCPY3D_v2 {
+    pub srcXInBytes: usize,
+    pub srcY: usize,
+    pub srcZ: usize,
+    pub srcLOD: usize,
+    pub srcMemoryType: c_uint,
+    pub srcHost: *const c_void,
+    pub srcDevice: CuDevicePtr,
+    pub srcArray: CuArray,
+    pub reserved0: *mut c_void,
+    pub srcPitch: usize,
+    pub srcHeight: usize,
+
+    pub dstXInBytes: usize,
+    pub dstY: usize,
+    pub dstZ: usize,
+    pub dstLOD: usize,
+    pub dstMemoryType: c_uint,
+    pub dstHost: *mut c_void,
+    pub dstDevice: CuDevicePtr,
+    pub dstArray: CuArray,
+    pub reserved1: *mut c_void,
+    pub dstPitch: usize,
+    pub dstHeight: usize,
+
+    pub WidthInBytes: usize,
+    pub Height: usize,
+    pub Depth: usize,
+}
+
 /// Table of resolved symbols from the CUDA driver library.
 pub struct Syms {
     pub init: FnInit,


### PR DESCRIPTION
## Issue
TASK_TITLE: audit CUDA memory pitch and device pointer FFI struct layouts

## Responsavel
KernelC-100

## Resumo
Add `CUDA_MEMCPY2D_v2` and `CUDA_MEMCPY3D_v2` FFI struct definitions to `ramshared-cuda` to match NVIDIA CUDA Driver API 64-bit specifications, ensuring byte-exact ABI alignment for memory pitch and device pointers.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(cuda): add 64-bit CUDA FFI ABI layouts | Added CUDA_MEMCPY2D_v2 and CUDA_MEMCPY3D_v2 structs with explicit memory layout. | Ensure correct physical limits and physical memory translations for kernel-level driver abstractions over memory cascade. | <details><summary>detalhes</summary>Structs mapped with correct C-types such as usize, *const c_void, and *mut c_void matching 64-bit constraints.</details> |

## Labels
type:kernel, type:refactor

## Validacao
Ran full test suite including `./scripts/docs-check.sh` and memory struct verification testing `128` bytes for 2D and `200` bytes for 3D layout matching exactly `gcc`'s output.

## Rollback trigger
Any compilation failure, FFI alignment size mismatch, or test suite pipeline CI breakages.

---
*PR created automatically by Jules for task [6061114592612641690](https://jules.google.com/task/6061114592612641690) started by @emersonbusson*