### PR TITLE
chore: document WDF architectural mismatch in FINDING_ONLY.txt

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,3 @@
+Architectural Mismatch:
+The task requested to audit WdfRequestComplete paths to ensure memory buffers are freed exactly once in drivers/windows/ramshared/control.c.
+However, the RamShared Windows codebase is a WDM/StorPort driver that uses raw PIRP handling and IoCompleteRequest. There are no WDF/KMDF functions or WDFREQUEST objects in this codebase. Thus, this constitutes an unresolvable architectural mismatch and no safe code modification can be performed.


### PR DESCRIPTION
## Issue
eliminate double-free vulnerabilities in IOCTL failure unwinding

## Responsavel
Jules

## Resumo
Created a FINDING_ONLY.txt report as requested due to an architectural mismatch. The task requested auditing WdfRequestComplete paths, but the driver utilizes WDM/StorPort with raw PIRP and IoCompleteRequest, containing no KMDF/WDF objects.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | Create FINDING_ONLY report | Documented architectural mismatch | <details><summary>detalhes</summary>Added FINDING_ONLY.txt</details> |

## Labels
type:kernel

## Validacao
./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh

## Rollback trigger
Revert if the finding report is considered inaccurate or if WDF APIs are somehow introduced in another branch.

---
*PR created automatically by Jules for task [3288240287436887801](https://jules.google.com/task/3288240287436887801) started by @emersonbusson*