### PR TITLE
kernel-harden: guarantee linear cleanup on all error paths in PCIe probe to prevent resource leaks

### DIFF
--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -30,6 +30,9 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 	struct ramshared_device *rs_dev;
 	int ret;
 
+	if (!pdev || !id)
+		return -EINVAL;
+
 	dev_info(&pdev->dev, "probing RamShared hardware (capacity=%lu MiB)\n",
 		 capacity_mb);
 
@@ -62,16 +65,16 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 	if (ret) {
 		dev_warn(&pdev->dev, "64-bit DMA failed, attempting 32-bit DMA\n");
 		ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
-		if (ret) {
-			dev_err(&pdev->dev, "no usable DMA configuration\n");
-			goto err_disable_pci;
-		}
+	}
+	if (ret) {
+		dev_err(&pdev->dev, "no usable DMA configuration\n");
+		goto err_clear_master;
 	}
 
 	ret = pci_request_mem_regions(pdev, RAMSHARED_DRIVER_NAME);
 	if (ret) {
 		dev_err(&pdev->dev, "failed to claim PCIe memory regions\n");
-		goto err_disable_pci;
+		goto err_clear_master;
 	}
 
 	ret = ramshared_dma_init(rs_dev, pdev);
@@ -99,6 +102,8 @@ err_dma_cleanup:
 	ramshared_dma_cleanup(rs_dev);
 err_release_regions:
 	pci_release_mem_regions(pdev);
+err_clear_master:
+	pci_clear_master(pdev);
 err_disable_pci:
 	pci_disable_device(pdev);
 	return ret;
@@ -106,14 +111,19 @@ err_disable_pci:
 
 static void ramshared_pci_remove(struct pci_dev *pdev)
 {
-	struct ramshared_device *rs_dev = pci_get_drvdata(pdev);
+	struct ramshared_device *rs_dev;
 
+	if (!pdev)
+		return;
+
+	rs_dev = pci_get_drvdata(pdev);
 	if (!rs_dev)
 		return;
 
 	ramshared_queue_cleanup(rs_dev);
 	ramshared_dma_cleanup(rs_dev);
 	pci_release_mem_regions(pdev);
+	pci_clear_master(pdev);
 	pci_disable_device(pdev);
 
 	dev_info(&pdev->dev, "RamShared device removed successfully\n");


### PR DESCRIPTION
## Issue
kernel-harden: guarantee linear cleanup on all error paths in PCIe probe to prevent resource leaks

## Responsavel
KernelC100/2026-08-30/kernel-harden/086

## Resumo
Guarantee linear cleanup on all error paths in PCIe probe to prevent resource leaks, specifically adding guard clauses for `pdev` and `id`, flattening `dma_set_mask_and_coherent` and properly cleaning up `pci_clear_master`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | Guarantee linear cleanup in probe | To prevent resource leaks and avoid deep nested ifs | <details><summary>detalhes</summary>Added pci_clear_master error label, unnested dma mask logic, and guard pdev</details> |

## Labels
type:refactor, type:kernel

## Validacao
Ran kernel tests and static checks.

## Rollback trigger
If any kernel CI checks fail or smoke tests fail to boot.

---
*PR created automatically by Jules for task [17036351669534327461](https://jules.google.com/task/17036351669534327461) started by @emersonbusson*