### PR TITLE
refactor(kernel): eliminate sector overflow via checked arithmetic

### DIFF
--- a/drivers/block/ramshared/queue.c
+++ b/drivers/block/ramshared/queue.c
@@ -11,6 +11,7 @@
 #include <linux/dma-mapping.h>
 #include <linux/highmem.h>
 #include <linux/io.h>
+#include <linux/overflow.h>
 #include "ramshared.h"
 #include "compat.h"
 
@@ -49,12 +50,15 @@ static blk_status_t ramshared_queue_rq(struct blk_mq_hw_ctx *hctx,
 {
 	struct request *rq = bd->rq;
 	struct ramshared_device *rs_dev = rq->q->queuedata;
-	loff_t pos = (loff_t)blk_rq_pos(rq) << RAMSHARED_SECTOR_SHIFT;
+	loff_t pos;
 	size_t len = blk_rq_bytes(rq);
 	blk_status_t status = BLK_STS_OK;
 	struct bio *bio;
 
 	if (unlikely(!rs_dev || !rs_dev->dma.cpu_addr))
+		return BLK_STS_IOERR;
+
+	if (unlikely(check_shl_overflow((loff_t)blk_rq_pos(rq), RAMSHARED_SECTOR_SHIFT, &pos)))
 		return BLK_STS_IOERR;
 
 	if (unlikely(pos + len > rs_dev->capacity_bytes)) {
@@ -104,13 +108,16 @@ static int ramshared_bdev_rw_page(struct block_device *bdev, sector_t sector,
 				  struct page *page, enum req_op op)
 {
 	struct ramshared_device *rs_dev = bdev->bd_disk->private_data;
-	loff_t pos = (loff_t)sector << RAMSHARED_SECTOR_SHIFT;
+	loff_t pos;
 	size_t len = PAGE_SIZE;
 	void __iomem *vram_ptr;
 	void *mem;
 	int is_write = op_is_write(op);
 
 	if (unlikely(!rs_dev || !rs_dev->dma.cpu_addr))
+		return -EIO;
+
+	if (unlikely(check_shl_overflow((loff_t)sector, RAMSHARED_SECTOR_SHIFT, &pos)))
 		return -EIO;
 
 	if (unlikely(pos + len > rs_dev->capacity_bytes))


### PR DESCRIPTION
## Issue
kernel-harden

## Responsavel
Jules

## Resumo
Eliminated integer overflow vulnerabilities in sector-to-byte offset calculations. By converting explicit bit-shifts to `check_shl_overflow` macro in `queue_rq` and `bdev_rw_page` handlers, we enforce physical hardware bounds safely.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Add safe overflow checking to sector calculations | Enforce defensive guard clauses against arithmetic overflows | <details><summary>detalhes</summary>Included `<linux/overflow.h>` and used `check_shl_overflow` macro returning standard BLK_STS_IOERR or -EIO.</details> |

## Labels
type:kernel, type:refactor, type:security

## Validacao
Executed compilation and verification checks: `./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
Revert if driver fails to bind, or blocks valid bio requests unexpectedly.

---
*PR created automatically by Jules for task [13368936147910921844](https://jules.google.com/task/13368936147910921844) started by @emersonbusson*