### PR TITLE
docs: add FINDING_ONLY report for bounce buffer architectural mismatch

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,5 @@
+The task requested to prevent kernel pool memory leaks during unaligned SCSI read/write handling by ensuring intermediate bounce buffers are freed in finally blocks under all error conditions in drivers/windows/ramshared/virtdisk.c.
+
+However, upon inspecting virtdisk.c and the overall RamShared driver architecture, there are no dynamic kernel pool allocations (e.g., ExAllocatePool2, ExAllocatePoolWithTag) performed for intermediate bounce buffers during SCSI read/write handling. Instead, the driver uses a pre-allocated fixed memory ring (Q->Data) mapped via MDL (Q->DataMdl) for bounce buffering, managed by the QSubmit and QCommitAndFetch functions in queue.c.
+
+Because virtdisk.c does not allocate per-request bounce buffers from the kernel pool, there are no pool memory leaks to fix, and the requested modification represents an architectural mismatch. No safe code modification is possible.


### PR DESCRIPTION
## Issue
prevent kernel pool memory leaks during unaligned SCSI read/write handling

## Responsavel
Jules

## Resumo
Added a FINDING_ONLY.txt report documenting an architectural mismatch, as the driver uses a pre-allocated ring buffer (Q->Data) rather than dynamically allocated kernel pool bounce buffers.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | Added FINDING_ONLY.txt | To document architectural mismatch | <details><summary>detalhes</summary>No dynamic kernel pool allocations exist in virtdisk.c for bounce buffering.</details> |

## Labels
type:docs, type:kernel

## Validacao
Ran CI scripts: `./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
Delete FINDING_ONLY.txt if the finding is deemed incorrect.

---
*PR created automatically by Jules for task [11971271114657356105](https://jules.google.com/task/11971271114657356105) started by @emersonbusson*