### PR TITLE
fix: substitute KMDF WdfRequestUnmarkCancelable with WDM equivalent in StorPort cancellation path

### DIFF
--- a/drivers/windows/ramshared/queue.c
+++ b/drivers/windows/ramshared/queue.c
@@ -382,16 +382,16 @@ QSubmit(
 		PIRP irp = Q->PendedFetch;
 		PDRIVER_CANCEL oldc;
 
-		Q->PendedFetch = NULL;
-		KeReleaseSpinLock(&Q->Lock, old);
 		oldc = IoSetCancelRoutine(irp, NULL);
 		if (oldc != NULL) {
+			Q->PendedFetch = NULL;
+			KeReleaseSpinLock(&Q->Lock, old);
 			irp->IoStatus.Status = STATUS_SUCCESS;
 			irp->IoStatus.Information = 0;
 			IoCompleteRequest(irp, IO_NO_INCREMENT);
+			ExReleaseRundownProtection(&Q->IoRundown);
+			return STATUS_PENDING;
 		}
-		ExReleaseRundownProtection(&Q->IoRundown);
-		return STATUS_PENDING;
 	}
 
 	KeReleaseSpinLock(&Q->Lock, old);
@@ -575,27 +575,24 @@ QCommitAndFetch(_Inout_ PRAMSHARED_QUEUE Q, _In_ PIRP Irp)
 		}
 		IoMarkIrpPending(Irp);
 		Irp->Tail.Overlay.DriverContext[0] = Q;
-		Q->PendedFetch = Irp;
-		KeReleaseSpinLock(&Q->Lock, old);
-		/* Release before long-lived pend so teardown can wait rundown. */
-		ExReleaseRundownProtection(&Q->IoRundown);
-
 		oldCancel = IoSetCancelRoutine(Irp, QCommitCancel);
+		Q->PendedFetch = Irp;
 		if (Irp->Cancel) {
 			oldCancel = IoSetCancelRoutine(Irp, NULL);
 			if (oldCancel != NULL) {
 				/* We still own completion. */
-				KeAcquireSpinLock(&Q->Lock, &old);
-				if (Q->PendedFetch == Irp) {
-					Q->PendedFetch = NULL;
-				}
+				Q->PendedFetch = NULL;
 				KeReleaseSpinLock(&Q->Lock, old);
+				ExReleaseRundownProtection(&Q->IoRundown);
 				Irp->IoStatus.Status = STATUS_CANCELLED;
 				Irp->IoStatus.Information = 0;
 				IoCompleteRequest(Irp, IO_NO_INCREMENT);
+				return STATUS_PENDING;
 			}
-			return STATUS_PENDING;
 		}
+		KeReleaseSpinLock(&Q->Lock, old);
+		/* Release before long-lived pend so teardown can wait rundown. */
+		ExReleaseRundownProtection(&Q->IoRundown);
 		return STATUS_PENDING;
 	}
 
@@ -632,8 +629,13 @@ QTeardownOnCrash(_Inout_ PRAMSHARED_QUEUE Q)
 	RtlZeroMemory(failed, sizeof(failed));
 
 	KeAcquireSpinLock(&Q->Lock, &old);
-	pending = Q->PendedFetch;
-	Q->PendedFetch = NULL;
+	pending = NULL;
+	if (Q->PendedFetch) {
+		if (IoSetCancelRoutine(Q->PendedFetch, NULL) != NULL) {
+			pending = Q->PendedFetch;
+			Q->PendedFetch = NULL;
+		}
+	}
 	Q->Registered = FALSE;
 	InterlockedExchange(&Q->QState, (LONG)RamQClosing);
 
@@ -657,11 +659,9 @@ QTeardownOnCrash(_Inout_ PRAMSHARED_QUEUE Q)
 	}
 
 	if (pending) {
-		if (IoSetCancelRoutine(pending, NULL) != NULL) {
-			pending->IoStatus.Status = STATUS_DEVICE_NOT_CONNECTED;
-			pending->IoStatus.Information = 0;
-			IoCompleteRequest(pending, IO_NO_INCREMENT);
-		}
+		pending->IoStatus.Status = STATUS_DEVICE_NOT_CONNECTED;
+		pending->IoStatus.Information = 0;
+		IoCompleteRequest(pending, IO_NO_INCREMENT);
 	}
 
 	/* RUNDOWN_UNMAP_AFTER_COPY: wait for in-flight copies before unmap. */


### PR DESCRIPTION
## Issue
prevent race conditions between I/O request completion and cancellation in queue.c

## Responsavel
KernelC100

## Resumo
The prompt requested using KMDF `WdfRequestUnmarkCancelable`. However, this is a WDM StorPort miniport driver operating on raw PIRPs. Using KMDF APIs here is a structural mismatch that would break compilation. We implemented the equivalent WDM fix using `IoSetCancelRoutine` protected by `Q->Lock` to fix the race condition safely.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix: substitute KMDF WdfRequestUnmarkCancelable with WDM equivalent in StorPort cancellation path | Replaced vulnerable IRP cancellation clearing with synchronized `IoSetCancelRoutine(irp, NULL)` calls in `QSubmit`, `QCommitAndFetch`, and `QTeardownOnCrash` under spinlock guards. | Prevent IRP completion/cancellation race conditions in WDM StorPort miniport without breaking compilation due to missing KMDF dependencies. | <details><summary>detalhes</summary>Wrapped all cancellation logic inside `Q->Lock` and ensured `Q->PendedFetch` is only cleared if `IoSetCancelRoutine` does not return NULL (meaning we still own the IRP).</details> |

## Labels
type:kernel, type:refactor

## Validacao
```bash
./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh
```

## Rollback trigger
Revert if driver hangs during heavy `CancelIo` testing or BSODs on driver unload while IRPs are pending.

---
*PR created automatically by Jules for task [7032349242769564706](https://jules.google.com/task/7032349242769564706) started by @emersonbusson*