### PR TITLE
chore(kernel): document architectural mismatch for KMDF driver object binding validation

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,5 @@
+The task requests to prevent BSODs by defensively validating hardware device ID strings before binding a KMDF driver object in drivers/windows/ramshared/driver.c.
+
+Upon analyzing drivers/windows/ramshared/driver.c, it is clear that the RamShared driver is implemented as a WDM/StorPort virtual miniport, not a KMDF driver. The driver entry point (DriverEntry) initializes the miniport using StorPortInitialize and a raw WDM PDRIVER_OBJECT.
+
+There is no KMDF driver object (e.g., WDFDRIVER), no KMDF device object (WDFDEVICE), and no WdfDriverCreate function call where such validation would take place. You cannot validate a non-existent WDF object. The validation of hardware device ID strings for binding a KMDF driver object constitutes an architectural mismatch. Therefore, as per architectural constraints, this report documents the absence of KMDF functions and the inability to safely modify the codebase for this objective.


### PR DESCRIPTION
## Resumo
The task requested to defensively validate hardware device ID strings before binding a KMDF driver object in `drivers/windows/ramshared/driver.c` to prevent BSODs. However, the codebase is a WDM/StorPort virtual miniport utilizing `StorPortInitialize` and raw `PDRIVER_OBJECT`, not a KMDF driver. Because you cannot validate a non-existent WDF object, this constitutes an unresolvable architectural mismatch. Created `FINDING_ONLY.txt` documenting the absence of KMDF functions.
## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| Document architectural mismatch | Created FINDING_ONLY.txt | The codebase is a WDM/StorPort driver, not KMDF. | Documented the absence of KMDF functions and inability to validate a non-existent WDF object. |
## Labels
type:kernel, type:docs
## Validacao
Executed full suite of CI validation scripts.
## Rollback trigger
Revert if documentation is found to be incorrect or if a KMDF object was overlooked.

---
*PR created automatically by Jules for task [12814266180423999918](https://jules.google.com/task/12814266180423999918) started by @emersonbusson*