### PR TITLE
docs: finding report for main-open-close-trap

### DIFF
--- a/docs/jules/findings/27-kernel-harden-098.txt
+++ b/docs/jules/findings/27-kernel-harden-098.txt
@@ -1,0 +1,5 @@
+# FINDING_ONLY: atomic state flag validation for device open, closing, and removed states
+
+The task requests to "Use atomic bitops (test_and_set_bit, clear_bit) for device open count and removal state" in drivers/block/ramshared/main.c.
+However, after reviewing drivers/block/ramshared/main.c and drivers/block/ramshared/queue.c, there are no open or release operations defined for this block device. The block device operations (struct block_device_operations ramshared_fops) defined in queue.c only contain .owner and .rw_page, and there are no existing state flags for device open count or closing states. Implementing these would require hallucinating state flags in struct ramshared_device and modifying the ramshared_fops structure to add open and release methods, which violates the rule against hallucinating non-existent logic.
+Therefore, this task is an adversarial trap, and no safe code modification is possible.


### PR DESCRIPTION
## Resumo
Created FINDING_ONLY report for an adversarial trap in `drivers/block/ramshared/main.c`. The requested `.open` and `.release` state flags for `ramshared_fops` do not exist, and there is no state tracking in `struct ramshared_device` for device open counts. Hallucinating these features would violate constraints.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: finding report for main-open-close-trap | Created `docs/jules/findings/27-kernel-harden-098.txt` | Task requested refactoring non-existent logic | Documented missing `open`/`release` operations in block device ops. |

## Labels
type:kernel, type:refactor, type:security

## Validacao
Run CI validation scripts: `./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
N/A - No functional code changes.

---
*PR created automatically by Jules for task [16962013550515536116](https://jules.google.com/task/16962013550515536116) started by @emersonbusson*