### PR TITLE
feat(kernel): enforce strict bounds check on PCIe BAR offset and transfer length

### DIFF
--- a/drivers/block/ramshared/queue.c
+++ b/drivers/block/ramshared/queue.c
@@ -57,10 +57,10 @@ static blk_status_t ramshared_queue_rq(struct blk_mq_hw_ctx *hctx,
 	if (unlikely(!rs_dev || !rs_dev->dma.cpu_addr))
 		return BLK_STS_IOERR;
 
-	if (unlikely(pos + len > rs_dev->capacity_bytes)) {
+	if (unlikely(pos > rs_dev->dma.size || len > rs_dev->dma.size - pos)) {
 		dev_err_ratelimited(rs_dev->dev,
-			"I/O bounds violation: pos=%lld, len=%zu, cap=%llu\n",
-			pos, len, rs_dev->capacity_bytes);
+			"I/O bounds violation: pos=%lld, len=%zu, mapped=%zu\n",
+			pos, len, rs_dev->dma.size);
 		return BLK_STS_IOERR;
 	}
 
@@ -113,8 +113,8 @@ static int ramshared_bdev_rw_page(struct block_device *bdev, sector_t sector,
 	if (unlikely(!rs_dev || !rs_dev->dma.cpu_addr))
 		return -EIO;
 
-	if (unlikely(pos + len > rs_dev->capacity_bytes))
-		return -EIO;
+	if (unlikely(pos > rs_dev->dma.size || len > rs_dev->dma.size - pos))
+		return -ERANGE;
 
 	vram_ptr = rs_dev->dma.cpu_addr + pos;
 	mem = kmap_local_page(page);


### PR DESCRIPTION
## Resumo
Enforce strict bounds checking on PCIe BAR offset and transfer length to prevent out-of-bounds DMA transfers and mitigate integer overflow vulnerabilities in bounds validation.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(kernel): enforce strict bounds check on PCIe BAR offset and transfer length | Implemented safe checked arithmetic `pos > size || len > size - pos` in `ramshared_queue_rq` and `ramshared_bdev_rw_page` bounds validation logic, and updated error returns to `-ERANGE` | To adhere to architectural principles regarding physical sanity checks, strict guard clauses, semantic error returns, and mitigate integer overflow vulnerabilities in DMA bounds validation | <details><summary>detalhes</summary>Modified `drivers/block/ramshared/queue.c` to use `rs_dev->dma.size` and checked arithmetic</details> |

## Labels
type:security, type:kernel

## Validacao
Run `./scripts/docs-check.sh && ./scripts/ci/check-kernel-style.sh && ./scripts/ci/check-kernel-build-matrix.sh && ./scripts/ci/check-kernel-sparse.sh && ./scripts/ci/check-kernel-checkpatch.sh && ./scripts/ci/check-kernel-abi-guard.sh && ./scripts/ci/check-kernel-qemu-smoke.sh && ./scripts/ci/check-adversarial-invariants.sh`

## Rollback trigger
Revert if DMA bounds validation logic causes kernel panic, BSOD, or false-positive BLK_STS_IOERR or -ERANGE failures on valid in-bounds I/O.

---
*PR created automatically by Jules for task [227871085972108043](https://jules.google.com/task/227871085972108043) started by @emersonbusson*