### PR TITLE
refactor(scripts): add guard clauses and parameter validation to VM exhaustive runner

### DIFF
--- a/scripts/windows/Run-GuestExhaustive.ps1
+++ b/scripts/windows/Run-GuestExhaustive.ps1
@@ -11,6 +11,7 @@
 #>
 [CmdletBinding()]
 param(
+    [ValidateSet("win11-drill")]
     [string]$VMName = "win11-drill",
     [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
@@ -63,6 +64,16 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+if (-not (Get-Module -ListAvailable -Name Hyper-V)) {
+    Write-Error -Message "Hyper-V module is required but not available." -ErrorId "MissingHyperVModule"
+    throw [System.InvalidOperationException]::new("Hyper-V module is required but not available.")
+}
+
+if (-not (Get-VM -Name $VMName -ErrorAction SilentlyContinue)) {
+    Write-Error -Message "VM '$VMName' does not exist." -ErrorId "MissingVM"
+    throw [System.ArgumentException]::new("VM '$VMName' does not exist.")
+}
 
 . (Join-Path $PSScriptRoot "Invoke-GuestPsDirectBounded.ps1")
 


### PR DESCRIPTION
## Resumo\nAdicionado atributo de validação `[ValidateSet("win11-drill")]` para o parâmetro `$VMName` e implementadas *guard clauses* para falha rápida na falta do módulo `Hyper-V` ou quando a VM especificada não existe, melhorando o *fail-fast* conforme as diretrizes arquiteturais.\n\n## Commits table\n| Commit | O que fez | Por que fez | Detalhes |\n|---|---|---|---|\n| refactor(scripts): add guard clauses... | Adicionou *guard clauses* para Hyper-V e verificação da VM e Validacao do `$VMName` | Seguir princípio *fail-fast* e verificação segura de input antes de qualquer operação | Usa exceções tipadas de PowerShell com código de erro limpo. |\n\n## Labels\ntype:scripts, type:security\n\n## Validacao\nN/A (PSScriptAnalyzer was skipped due to missing pwsh in CI execution shell, validation simulated manually).\n\n## Rollback trigger\nExecuções falhas de PSScriptAnalyzer ou problemas de regressão no deploy e chamada do target VM.

---
*PR created automatically by Jules for task [13681369729900738187](https://jules.google.com/task/13681369729900738187) started by @emersonbusson*