### PR TITLE
feat(scripts): implement graceful termination with timeout and force-kill escalation

### DIFF
--- a/scripts/windows/Invoke-SharedWslPressureCampaign.ps1
+++ b/scripts/windows/Invoke-SharedWslPressureCampaign.ps1
@@ -172,8 +172,11 @@ function Stop-CampaignProcessInstanceSafely {
         if ($Process.StartTime.ToUniversalTime().Ticks -ne $originalStart) {
             return [pscustomobject]@{ stopped = $false; reason = "$Operation`_process_instance_identity_changed" }
         }
-        $Process.Kill()
-        if (-not $Process.WaitForExit(5000)) { return [pscustomobject]@{ stopped = $false; reason = "$Operation`_process_instance_kill_unreaped" } }
+        $Process.CloseMainWindow() | Out-Null
+        if (-not $Process.WaitForExit(10000)) {
+            Stop-Process -Id $Process.Id -Force -ErrorAction Stop
+            if (-not $Process.WaitForExit(5000)) { return [pscustomobject]@{ stopped = $false; reason = "$Operation`_process_instance_kill_unreaped" } }
+        }
         return [pscustomobject]@{ stopped = $true; reason = "$Operation`_process_instance_handle_terminated" }
     } catch {
         return [pscustomobject]@{ stopped = $false; reason = "$Operation`_process_instance_identity_unproven" }


### PR DESCRIPTION
## Resumo
Modified `Stop-CampaignProcessInstanceSafely` in `Invoke-SharedWslPressureCampaign.ps1` to utilize a graceful `WM_CLOSE` signal via `.CloseMainWindow()` instead of immediately invoking `.Kill()`. Implemented a 10-second timeout, falling back safely to `Stop-Process -Force` if the target process hangs, satisfying the requested infrastructure hardening and termination escalation rules.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): implement graceful termination with 10s timeout and escalation | Replaced direct `.Kill()` with `.CloseMainWindow()` + 10s wait and forced fallback | To prevent zombies and gracefully shut down workload tasks before forcing termination | Updated `Invoke-SharedWslPressureCampaign.ps1` logic in the `Stop-CampaignProcessInstanceSafely` helper |

## Labels
type:scripts, type:security, type:ci

## Validacao
Code structure visually validated. PowerShell execution engine (PSScriptAnalyzer) was not available (`pwsh` missing from sandbox) but standard structural code review approved.

## Rollback trigger
Any failure in `Stop-CampaignProcessInstanceSafely` resulting in pipeline failures or unkillable processes.

---
*PR created automatically by Jules for task [10618682137681843647](https://jules.google.com/task/10618682137681843647) started by @emersonbusson*