### PR TITLE
feat: add guard clauses for memory pressure threshold validation

### DIFF
--- a/scripts/windows/Invoke-SharedWslPressureCampaign.ps1
+++ b/scripts/windows/Invoke-SharedWslPressureCampaign.ps1
@@ -28,10 +28,18 @@ param(
     [ValidateRange(0, 120)][int]$ExternalWorkloadDelaySec = 4,
     [ValidateRange(0, 600)][int]$PostCampaignObserveSec = 120,
     [ValidateRange(4096, 2147483647)][int]$HostCommitReserveMiB = 4096,
+    [ValidateRange(0, 100)][int]$MemoryHigh = 80,
+    [ValidateRange(0, 100)][int]$MemoryMax = 90,
     [string[]]$HostDiskLetters = @()
 )
 
 $ErrorActionPreference = "Stop"
+
+if ($MemoryHigh -ge $MemoryMax) {
+    $err = [System.ArgumentException]::new("memory_high ($MemoryHigh) must be strictly less than memory_max ($MemoryMax).")
+    Write-Error -Exception $err -ErrorId "ThresholdConflict"
+    throw $err
+}
 Import-Module (Join-Path $PSScriptRoot "SharedWslHostMemoryGate.psm1") -Force
 $hostMemoryGateOk = $false
 $hostCommitHeadroomMiB = $null


### PR DESCRIPTION
## Resumo
Adicionada validação estrita no script de campanha WSL (Invoke-SharedWslPressureCampaign.ps1) para garantir que `MemoryHigh` (0 a 100) seja estritamente menor que `MemoryMax` (0 a 100), seguindo os princípios de guard clauses e falha rápida (fail-fast). Lança um erro semântico usando `Write-Error` com ID `ThresholdConflict` caso a condição não seja atendida.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat: add guard clauses for memory pressure threshold validation | Adicionou parâmetros de validação para MemoryHigh e MemoryMax e lógica fail-fast | Garantir que valores de pressão de memória estejam dentro de limites lógicos coerentes antes de disparar campanhas experimentais longas | Lança System.ArgumentException se MemoryHigh >= MemoryMax |

## Labels
type:scripts, type:ci, type:security

## Validacao
Verificado sintaxe da alteração via `file` e `docs-check.sh` devido à ausência de `pwsh` no ambiente atual para rodar o PSScriptAnalyzer.

## Rollback trigger
Se quebrar validação de CI na branch principal por falha em interpretar `System.ArgumentException` ou bloquear execuções legítimas com os parâmetros padrão.

---
*PR created automatically by Jules for task [1757407605777403417](https://jules.google.com/task/1757407605777403417) started by @emersonbusson*