### PR TITLE
feat(scripts): validate disk volume paths and free space before tests

### DIFF
--- a/scripts/windows/Invoke-WindowsStorageMatrix.ps1
+++ b/scripts/windows/Invoke-WindowsStorageMatrix.ps1
@@ -1597,6 +1597,16 @@ function Invoke-Workload(
     [int]$QueueDepth,
     [UInt64]$AvailableBytes
 ) {
+    $drivePath = (Split-Path $Path -Qualifier) + "\"
+    if (-not (Test-Path $drivePath)) {
+        throw "target volume path does not exist: $drivePath"
+    }
+    $driveLetter = (Split-Path $Path -Qualifier) -replace ':$', ''
+    $drive = Get-PSDrive -Name $driveLetter -ErrorAction Stop
+    if ([UInt64]$drive.Free -lt 1GB) {
+        throw "target volume has insufficient free space: $($drive.Free) bytes"
+    }
+
     $workerFileBytes = [UInt64]([math]::Floor(
             ([double]$AvailableBytes * 0.25 / $QueueDepth) / 4096) * 4096)
     $workerFileBytes = [UInt64][math]::Max(1MB, [math]::Min(32MB, $workerFileBytes))


### PR DESCRIPTION
## Resumo
Adiciona validação em `Invoke-Workload` no script `Invoke-WindowsStorageMatrix.ps1` para verificar se o volume de destino existe e possui no mínimo 1 GB de espaço livre antes de iniciar os testes destrutivos de I/O. Isso atende ao requisito de falhar rapidamente e validar limites físicos.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): validate target volume free space before running workloads | Adicionou validação de 1 GB usando `Get-PSDrive` em `Invoke-Workload`. | Para garantir que o disco de destino existe e não ficará sem espaço durante testes intensivos de I/O, falhando imediatamente. | Extrai a letra do drive do `$Path`, invoca `Get-PSDrive` e verifica se `$drive.Free` é menor que 1GB. |

## Labels
type:scripts, type:ci

## Validacao
Executado `pwsh -c "Invoke-ScriptAnalyzer -Path scripts/windows/Invoke-WindowsStorageMatrix.ps1"`. O ambiente reportou que o PowerShell (`pwsh`) não está instalado, então o teste não pôde ser completamente validado localmente, porém a sintaxe adicionada é correta e compatível com as validações de script comuns.

## Rollback trigger
Se os testes de CI apresentarem falhas generalizadas relacionadas ao `Get-PSDrive` não conseguir resolver caminhos mapeados ou se o script rejeitar indevidamente matrizes de testes válidas devido ao erro "target volume has insufficient free space".

---
*PR created automatically by Jules for task [15808986160779633941](https://jules.google.com/task/15808986160779633941) started by @emersonbusson*