### PR TITLE
chore(scripts): add guard clauses for Admin and Hyper-V in Wait-Win11LabReady

### DIFF
--- a/scripts/windows/Wait-Win11LabReady.ps1
+++ b/scripts/windows/Wait-Win11LabReady.ps1
@@ -55,6 +55,15 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+$currentPrincipal = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw [System.UnauthorizedAccessException]::new("Administrative privileges are required.")
+}
+
+if (-not (Get-Module -ListAvailable -Name Hyper-V)) {
+    throw "Hyper-V PowerShell module is not available."
+}
+
 . (Join-Path $PSScriptRoot "Invoke-GuestPsDirectBounded.ps1")
 
 function Normalize-Win11LabReadyThumbprint {


### PR DESCRIPTION
## Resumo
Added strict guard clauses at the top of `Wait-Win11LabReady.ps1` to ensure it fails fast when required infrastructure dependencies are missing. It now validates if the current user has Administrator privileges and if the `Hyper-V` PowerShell module is available on the system, throwing a typed exception or descriptive error message respectively.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| chore(scripts): add guard clauses for Admin and Hyper-V | Added early exit guard clauses for Admin privileges and Hyper-V module. | Enforce infrastructure hardening by failing fast on missing prerequisites before script execution. | Used `[Security.Principal.WindowsPrincipal]` to check Administrator role and `Get-Module -ListAvailable` for Hyper-V. |

## Labels
type:scripts, type:ci, type:security

## Validacao
`Invoke-ScriptAnalyzer -Path scripts/windows/Wait-Win11LabReady.ps1` executed via PowerShell to ensure no new errors or warnings were introduced by the changes.

## Rollback trigger
Revert if `Wait-Win11LabReady.ps1` fails execution on valid Hyper-V host environments due to false positive validation checks on privileges or module availability.

---
*PR created automatically by Jules for task [18254509983810452764](https://jules.google.com/task/18254509983810452764) started by @emersonbusson*