### PR TITLE
feat(scripts): add graceful SIGINT handling with GetNewClosure

### DIFF
--- a/scripts/windows/Watch-RamSharedWsl.ps1
+++ b/scripts/windows/Watch-RamSharedWsl.ps1
@@ -784,6 +784,16 @@ function Invoke-GuardianWatch {
     New-Item -ItemType Directory -Path $runDirectory | Out-Null
     $eventPath = Join-Path $runDirectory "guardian-events.jsonl"
     $telemetryPath = Join-Path $ArtifactRoot "windows-telemetry.jsonl"
+
+    [Console]::TreatControlCAsInput = $false
+    [Console]::add_CancelKeyPress({
+        param($sender, $e)
+        $e.Cancel = $true
+        Write-GuardianEvent -Path $eventPath -Event "guardian_stopped" -Data @{ reason = "sigint" }
+        Write-HostTelemetryRing -Path $telemetryPath
+        [Environment]::Exit(0)
+    }.GetNewClosure())
+
     Write-GuardianEvent -Path $eventPath -Event "guardian_started" -Data @{ heartbeat = $HeartbeatPath; stale_after_seconds = $StaleAfterSec }
     while ($true) {
         # A current heartbeat must be observed before any HEALTHY proof can be


### PR DESCRIPTION
## Resumo

Added a graceful `Ctrl+C` signal handler to `Watch-RamSharedWsl.ps1`. When interrupted via the console (SIGINT), the script now safely logs a `guardian_stopped` event, flushes the final `windows-telemetry.jsonl` host telemetry ring, and calls `[Environment]::Exit(0)`. Crucially, `.GetNewClosure()` is used on the event scriptblock to capture the local file paths for the background .NET thread.

## Commits table

| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(scripts): add graceful SIGINT handling with GetNewClosure | Registered `[Console]::add_CancelKeyPress` | To ensure file handles and state are cleanly resolved before exit on Ctrl+C. | Prevents silent data loss for telemetry during manual watchdog termination. |

## Labels

type:scripts

## Validacao

`./scripts/windows/Test-WindowsCiStatic.ps1` (PSScriptAnalyzer validation within isolated harness, verified locally).

## Rollback trigger

Any failure or unhandled exception during manual Ctrl+C termination.

---
*PR created automatically by Jules for task [16398632885316031828](https://jules.google.com/task/16398632885316031828) started by @emersonbusson*