### PR TITLE
build(scripts): add guard clauses and semantic exit codes to Build-Drivers.ps1

### DIFF
--- a/scripts/windows/Build-Drivers.ps1
+++ b/scripts/windows/Build-Drivers.ps1
@@ -8,16 +8,28 @@
 #>
 [CmdletBinding()]
 param(
+    [ValidateNotNullOrEmpty()]
     [string]$RepoRoot = "C:\ramshared\src",
+
+    [ValidateNotNullOrEmpty()]
     [string]$KitVersion = "10.0.26100.0",
+
     [switch]$CodeAnalysis
 )
 
 $ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $RepoRoot)) {
+    Write-Error -ErrorId "RepoRootNotFound" -Message "Repository root path not found: $RepoRoot"
+    exit 74
+}
+
 Set-Location $RepoRoot
 $log = Join-Path $RepoRoot "artifacts\build-drivers.log"
 New-Item -ItemType Directory -Force -Path (Split-Path $log) | Out-Null
 Start-Transcript -Path $log -Force
+
+try {
 
 function Find-VcVars {
     $p = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
@@ -96,4 +108,10 @@ Write-Output "BUILT $psSys"
 Get-Item $psSys | Format-List FullName, Length, LastWriteTime | Out-String | Write-Output
 
 Write-Output "BUILD_DRIVERS_OK"
-Stop-Transcript
+
+} catch {
+    Write-Error -ErrorId "BuildFailed" -Exception $_.Exception -Message "Build failed: $($_.Exception.Message)"
+    exit 74
+} finally {
+    Stop-Transcript
+}


### PR DESCRIPTION
## Resumo
Adicionada validação rigorosa de parâmetros, fail-fast em pré-requisitos não atendidos e código de saída semântico (74) para falhas na build de drivers, de acordo com os princípios de OpsInfra-100. O artefato de log é garantido via bloco finally.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| build(scripts): add guard clauses and semantic exit codes to Build-Drivers.ps1 | Adicionou atributos `ValidateNotNullOrEmpty` nos parâmetros, um guard clause para validar `$RepoRoot` físico e um block `try/catch/finally` que faz o exit code emitir erro semântico 74 se algo falhar, fechando também a transcript. | Para aplicar os princípios de infraestrutura para scripts operacionais, mitigando inputs falhos, falhando de maneira rápida caso as dependências não sejam fisicamente locais e garantindo a devolução de ExitCodes legíveis por CIs caso as builds quebrem. | `Stop-Transcript` migrado para o block `finally` garantindo a preservação pós-mortem. |

## Labels
type:scripts, type:ci, type:infrastructure

## Validacao
echo "Skipping PSScriptAnalyzer as pwsh is not installed"

## Rollback trigger
Se as pipelines de compilação ou runners de VM do Windows que rodam esse script apresentarem regressões (exit code inesperado impedindo continuação limpa devido ao bloco try/catch e o ErrorActionPreference em interações COM/WMI externas em novos ambientes não previstos).

---
*PR created automatically by Jules for task [11282835416757998517](https://jules.google.com/task/11282835416757998517) started by @emersonbusson*