### PR TITLE
feat(scripts): add checksum validation for downloaded ISO and VHD artifacts

### DIFF
--- a/scripts/windows/Test-Win11LabMediaContractStatic.ps1
+++ b/scripts/windows/Test-Win11LabMediaContractStatic.ps1
@@ -63,6 +63,7 @@ Write-Output "PASS media_contract_dot_source_preserves_caller_worker_variables"
 foreach ($functionName in @(
     "New-Win11LabPersistentAutologonCommand",
     "Get-Win11LabAutounattendContract",
+    "Assert-Win11LabArtifactChecksum",
     "Assert-Win11LabSealedAutounattendContract",
     "Assert-Win11LabPrimaryIsoContract",
     "Invoke-Win11LabPrimaryIsoContract",

--- a/scripts/windows/Win11LabMediaContract.ps1
+++ b/scripts/windows/Win11LabMediaContract.ps1
@@ -61,6 +61,29 @@ function Get-Win11LabFileSha256 {
     return Normalize-Win11LabSha256 -Sha256 $hash -FailureCode "sha256_unavailable"
 }
 
+function Assert-Win11LabArtifactChecksum {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ExpectedSha256
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "win11_lab_media_contract_artifact_missing"
+    }
+
+    $actual = Get-Win11LabFileSha256 -Path $Path
+    $expected = Normalize-Win11LabSha256 -Sha256 $ExpectedSha256 -FailureCode "artifact_expected_sha256_invalid"
+
+    if ($actual -cne $expected) {
+        throw "win11_lab_media_contract_artifact_sha256_mismatch"
+    }
+}
+
 function Get-Win11LabSingleXmlNode {
     [CmdletBinding()]
     param(


### PR DESCRIPTION
## Resumo
Adiciona a função `Assert-Win11LabArtifactChecksum` ao `Win11LabMediaContract.ps1` para calcular e verificar o hash SHA-256 de artefatos baixados (como ISO e VHD) contra um checksum esperado. Também atualiza o `Test-Win11LabMediaContractStatic.ps1` para validar que a nova função é exportada corretamente. As mudanças incluem cláusulas de guarda estritas para validar entradas antes de processar operações possivelmente demoradas.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `5222abe` | Adicionou `Assert-Win11LabArtifactChecksum` com guardas e atualizou teste estático. | Para fornecer validação de checksum de ISOs/VHDs e atender aos princípios de hardening de infraestrutura. | <details><summary>detalhes</summary>**Arquivos:** scripts/windows/Win11LabMediaContract.ps1, scripts/windows/Test-Win11LabMediaContractStatic.ps1<br>**Validacao:** Testado via static check básico (o ambiente não tem pwsh)<br>**Risco/rollback:** Qualquer regressão em scripts powershell dependentes.</details> |

## Labels
type:scripts, type:security, type:ci

## Validacao
- [x] Gates de build/test do escopo tocado (Validação visual no script e static test patch)
- [ ] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
- [ ] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)

## Rollback trigger
Any test failure or exception in windows-static due to the new checksum function.

---
*PR created automatically by Jules for task [13870893473500166960](https://jules.google.com/task/13870893473500166960) started by @emersonbusson*