### PR TITLE
feat(scripts): add guard clauses and signature validation for launchers

### DIFF
--- a/scripts/windows/Manage-RamSharedLaunchers.ps1
+++ b/scripts/windows/Manage-RamSharedLaunchers.ps1
@@ -5,7 +5,8 @@ param(
     [string]$Action = "plan",
     [switch]$Run,
     [ValidatePattern('^[A-Za-z0-9._-]+$')]
-    [string]$Distro = "Ubuntu-24.04"
+    [string]$Distro = "Ubuntu-24.04",
+    [switch]$ValidateSignature
 )
 
 Set-StrictMode -Version Latest
@@ -14,6 +15,23 @@ $Root = Join-Path $env:LOCALAPPDATA "RamShared\launchers"
 $Backup = Join-Path $env:LOCALAPPDATA "RamShared\launcher-backup"
 $BackupManifest = Join-Path $Backup "launcher-backup-manifest.json"
 $Files = @("ramshared-shell.cmd", "ramshared-terminal.cmd", "ramshared-vscode.cmd")
+
+$executables = @("wsl.exe", "wt.exe", "code.cmd", "code")
+foreach ($exe in $executables) {
+    $cmd = Get-Command $exe -ErrorAction SilentlyContinue
+    if (-not $cmd -or -not (Test-Path -LiteralPath $cmd.Path -PathType Leaf)) {
+        if ($exe -eq "code.cmd" -or $exe -eq "code") {
+            continue # VS Code is optional depending on environment
+        }
+        throw [System.IO.FileNotFoundException]::new("launcher_executable_not_found: $exe")
+    }
+    if ($ValidateSignature) {
+        $sig = Get-AuthenticodeSignature -FilePath $cmd.Path -ErrorAction Stop
+        if ($sig.Status -ne 'Valid') {
+            throw [System.Security.SecurityException]::new("launcher_signature_invalid: $exe")
+        }
+    }
+}
 
 function Get-LauncherSha256 {
     param([string]$Path)


### PR DESCRIPTION
## Resumo
Added `-ValidateSignature` switch and execution guard clauses to `Manage-RamSharedLaunchers.ps1`. The script now explicitly validates that external dependencies (`wsl.exe`, `wt.exe`, and optionally VS Code) are present on the system before attempting installation operations, failing fast with specific typed exceptions if requirements are not met or if signatures are invalid.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): add guard clauses and signature validation for launchers | Added `$ValidateSignature` switch and execution dependency checks. | To meet infrastructure hardening principles (fail-fast, guard clauses, specific errors). | Used `Get-Command` to resolve `.Path`, `Test-Path` to ensure it is a Leaf file, and optionally `Get-AuthenticodeSignature` to check validity. Throws `FileNotFoundException` and `SecurityException`. |

## Labels
type:scripts, type:security

## Validacao
`pwsh -Command "Invoke-ScriptAnalyzer -Path scripts/windows/Manage-RamSharedLaunchers.ps1"` (placeholder logic executed as `pwsh` was not natively available).

## Rollback trigger
Revert if the launcher script starts failing unconditionally on valid user systems (e.g., throwing `FileNotFoundException` for VS Code when it shouldn't, or due to Path resolution errors).

---
*PR created automatically by Jules for task [5228018543491395989](https://jules.google.com/task/5228018543491395989) started by @emersonbusson*