### PR TITLE
feat(scripts): validate perf counter availability

### DIFF
--- a/scripts/windows/Measure-RamSharedDiskIo.ps1
+++ b/scripts/windows/Measure-RamSharedDiskIo.ps1
@@ -36,6 +36,45 @@ param(
 $ErrorActionPreference = "Stop"
 function L($m) { Write-Host ("[{0}] {1}" -f (Get-Date -Format "HH:mm:ss"), $m) }
 
+function Assert-RamSharedPerformanceCountersAvailable {
+    $physicalDiskCount = 0
+    $logicalDiskCount = 0
+
+    try {
+        $physicalDiskCounters = Get-CimInstance -ClassName Win32_PerfFormattedData_PerfDisk_PhysicalDisk -ErrorAction Stop
+        if ($physicalDiskCounters) {
+            $physicalDiskCount = @($physicalDiskCounters).Count
+        }
+    } catch {
+        try {
+            $physicalDiskCounters = Get-WmiObject -Class Win32_PerfFormattedData_PerfDisk_PhysicalDisk -ErrorAction Stop
+            if ($physicalDiskCounters) {
+                $physicalDiskCount = @($physicalDiskCounters).Count
+            }
+        } catch { }
+    }
+
+    try {
+        $logicalDiskCounters = Get-CimInstance -ClassName Win32_PerfFormattedData_PerfDisk_LogicalDisk -ErrorAction Stop
+        if ($logicalDiskCounters) {
+            $logicalDiskCount = @($logicalDiskCounters).Count
+        }
+    } catch {
+        try {
+            $logicalDiskCounters = Get-WmiObject -Class Win32_PerfFormattedData_PerfDisk_LogicalDisk -ErrorAction Stop
+            if ($logicalDiskCounters) {
+                $logicalDiskCount = @($logicalDiskCounters).Count
+            }
+        } catch { }
+    }
+
+    if ($physicalDiskCount -eq 0 -or $logicalDiskCount -eq 0) {
+        throw [System.InvalidOperationException]::new("Performance counters are unavailable or zero. PhysicalDisk count: $physicalDiskCount, LogicalDisk count: $logicalDiskCount. Enable disk performance counters using 'diskperf -Y'.")
+    }
+}
+
+Assert-RamSharedPerformanceCountersAvailable
+
 function Get-Sha256Hex {
     param([byte[]]$Bytes)
     $sha256 = [System.Security.Cryptography.SHA256]::Create()


### PR DESCRIPTION
## Resumo
Adicionado um 'guard clause' para validar a disponibilidade e presença de instâncias não nulas dos contadores de desempenho PhysicalDisk e LogicalDisk usando classes WMI/CIM locale-safe. Se os contadores não estiverem disponíveis, o script falha rapidamente lançando um `System.InvalidOperationException` detalhado. Isso adere aos princípios de hardening de infraestrutura.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): validate perf counter availability | Adicionou a função `Assert-RamSharedPerformanceCountersAvailable` e a chamou no script. | Para validar de forma preventiva que os contadores de desempenho físicos e lógicos de disco estejam disponíveis e evitar falhas silenciosas ou dados incorretos mais tarde no script. | Usa `Get-CimInstance` com fallback para `Get-WmiObject` em classes `Win32_PerfFormattedData_PerfDisk_*`. Lança `InvalidOperationException` caso os contadores sejam zero. |

## Labels
type:scripts

## Validacao
`pwsh -Command "Invoke-ScriptAnalyzer -Path scripts/windows/Measure-RamSharedDiskIo.ps1"`

## Rollback trigger
Se o script falhar de forma espúria e parar a execução em ambientes onde os contadores de desempenho do disco estejam ativos e disponíveis, a alteração deve ser revertida.

---
*PR created automatically by Jules for task [2548461986874691022](https://jules.google.com/task/2548461986874691022) started by @emersonbusson*