### PR TITLE
feat(scripts): add GPU adapter guard clauses to Measure-PagefileVram

### DIFF
--- a/scripts/windows/Measure-PagefileVram.ps1
+++ b/scripts/windows/Measure-PagefileVram.ps1
@@ -20,6 +20,29 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+
+try {
+    $gpus = Get-CimInstance -ClassName Win32_VideoController -ErrorAction Stop
+} catch {
+    throw [System.InvalidOperationException]::new("Failed to query Win32_VideoController for GPU adapters.")
+}
+
+if (-not $gpus) {
+    throw [System.InvalidOperationException]::new("No GPU adapters detected via Win32_VideoController.")
+}
+
+$validVram = $false
+foreach ($gpu in @($gpus)) {
+    if ($null -ne $gpu.AdapterRAM -and $gpu.AdapterRAM -gt 0) {
+        $validVram = $true
+        break
+    }
+}
+
+if (-not $validVram) {
+    throw [System.NotSupportedException]::new("VRAM query availability not found: no GPU with valid AdapterRAM detected.")
+}
+
 New-Item -ItemType Directory -Force -Path $ArtifactDir | Out-Null
 
 function Measure-Once {


### PR DESCRIPTION
## Resumo
Added infrastructure hardening to `Measure-PagefileVram.ps1` by proactively validating the presence of a GPU adapter and its VRAM query availability. The script now fails fast using typed exceptions (`[System.InvalidOperationException]` and `[System.NotSupportedException]`) if a valid GPU or `AdapterRAM` cannot be queried via `Win32_VideoController`, avoiding later failures or skewed metrics.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): add GPU adapter guard clauses to Measure-PagefileVram | Added WMI/CIM checks via `Get-CimInstance` for `Win32_VideoController` at the script's entry. | To enforce the physical limits and guard clauses architectural principle (fail-fast on missing hardware dependencies before doing operations). | Wraps the query in a `try...catch` block. Iterates over `@($gpus)` to safely check if any GPU has `AdapterRAM > 0`. Throws typed exceptions for early semantic errors. |

## Labels
type:scripts, type:security, type:infrastructure

## Validacao
Cannot run `Invoke-ScriptAnalyzer` in the provided Linux environment as `pwsh` is missing. The script structure was verified by visual inspection to maintain correctness and align with `$ErrorActionPreference = "Stop"` and PowerShell exception patterns.

## Rollback trigger
If the WMI/CIM queries timeout or fail incorrectly on legacy/virtualized nodes causing the script to falsely abort despite having working pagefile/VRAM setups.

---
*PR created automatically by Jules for task [1290686179715247901](https://jules.google.com/task/1290686179715247901) started by @emersonbusson*