### PR TITLE
chore(scripts): harden Invoke-RevokeDrill with target lock validation

### DIFF
--- a/scripts/windows/Invoke-RevokeDrill.ps1
+++ b/scripts/windows/Invoke-RevokeDrill.ps1
@@ -13,12 +13,28 @@
 #>
 [CmdletBinding()]
 param(
+    [ValidateNotNullOrEmpty()]
     [string]$ServiceName = "ramshared-winsvc",
+    [ValidateNotNullOrEmpty()]
     [string]$BrokerStatusCmd = "",
+    [ValidateNotNullOrEmpty()]
     [string]$ArtifactDir = ".\artifacts\revoke-drill"
 )
 
 $ErrorActionPreference = "Stop"
+
+try {
+    $svc = Get-Service -Name $ServiceName -ErrorAction Stop
+} catch {
+    Write-Error -ErrorId "ServiceNotFound" -Message "Service $ServiceName does not exist"
+    throw [System.Exception]::new("Service $ServiceName does not exist")
+}
+
+if (Get-Process -Name $ServiceName -ErrorAction SilentlyContinue) {
+    Write-Error -ErrorId "TargetLocked" -Message "Revocation target $ServiceName is locked by another process"
+    throw [System.Exception]::new("Revocation target $ServiceName is locked by another process")
+}
+
 New-Item -ItemType Directory -Force -Path $ArtifactDir | Out-Null
 $runId = "revoke-{0:yyyyMMdd-HHmmss}" -f (Get-Date)
 $log = Join-Path $ArtifactDir "$runId.log"


### PR DESCRIPTION
## Resumo

Implemented infrastructure hardening guard clauses in `Invoke-RevokeDrill.ps1` to validate the revocation target exists and is not locked by another process before executing the drill, preventing blind execution and improving reliability.

## Commits table

| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Hardened `Invoke-RevokeDrill.ps1` with service existence and lock checks | To adhere to OpsInfra-100 guard clause and fail-fast principles | Added explicit `Get-Service` checks and process lock validations before attempting SCM stops to prevent unhandled terminating errors and deadlocks during teardown. |

## Labels

type:scripts, type:security, type:reliability

## Validacao

```powershell
pwsh -Command "Invoke-ScriptAnalyzer -Path scripts/windows/Invoke-RevokeDrill.ps1"
```

## Rollback trigger

If the script fails to detect a legitimately running service or incorrectly blocks teardown due to false-positive lock detection, causing CI timeouts or drill failures, revert the commit.

---
*PR created automatically by Jules for task [4260765375477306280](https://jules.google.com/task/4260765375477306280) started by @emersonbusson*