### PR TITLE
feat(scripts): add guard clauses for fio, nbd, and cgroup to benchmark cell

### DIFF
--- a/scripts/safety/nbd-benchmark-cell.sh
+++ b/scripts/safety/nbd-benchmark-cell.sh
@@ -5,6 +5,21 @@ set -euo pipefail
 PATH=/usr/sbin:/usr/bin:/sbin:/bin
 export PATH
 
+if ! command -v fio >/dev/null 2>&1; then
+  printf 'NBD_BENCHMARK_STATE=REFUSED\nNBD_BENCHMARK_REASON=FIO_MISSING\n' >&2
+  exit 69
+fi
+
+if ! ls /dev/nbd* >/dev/null 2>&1; then
+  printf 'NBD_BENCHMARK_STATE=REFUSED\nNBD_BENCHMARK_REASON=NBD_DEVICE_MISSING\n' >&2
+  exit 69
+fi
+
+if [[ ! -d /sys/fs/cgroup || ! -f /sys/fs/cgroup/cgroup.controllers ]] || ! grep -q memory /sys/fs/cgroup/cgroup.controllers; then
+  printf 'NBD_BENCHMARK_STATE=REFUSED\nNBD_BENCHMARK_REASON=CGROUP_V2_MEMORY_CONTROLLER_MISSING\n' >&2
+  exit 69
+fi
+
 ACTION=""
 MODE=""
 CONDITION=""


### PR DESCRIPTION
## Resumo
Added necessary guard clauses to `scripts/safety/nbd-benchmark-cell.sh` to validate the environment before proceeding with benchmark operations. This ensures the script fails fast if `fio`, NBD block devices, or the cgroup v2 memory controller are missing, using semantic exit codes (`EX_UNAVAILABLE` = 69).

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): add guard clauses for fio, nbd, and cgroup to benchmark cell | Added validation logic at the start of the script. | To satisfy infrastructure hardening principles (Guard Clauses, Fail-Fast) and ensure the environment is correctly set up. | Used `command -v` for `fio`, `ls` for `/dev/nbd*`, and checked `cgroup.controllers` for `memory`. Used `exit 69` for semantic errors. |

## Labels
type:scripts

## Validacao
Ran `shellcheck scripts/safety/nbd-benchmark-cell.sh` locally.

## Rollback trigger
If the script starts failing in known-good CI/CD or operational environments where one of the checks is too strict (e.g. custom cgroup setup, or a different I/O benchmarking tool substituted for `fio`).

---
*PR created automatically by Jules for task [17380795173272468690](https://jules.google.com/task/17380795173272468690) started by @emersonbusson*