### PR TITLE
fix(scripts/windows): add guard clauses for service state transitions

### DIFF
--- a/scripts/windows/Manage-RamSharedOrigin.ps1
+++ b/scripts/windows/Manage-RamSharedOrigin.ps1
@@ -401,6 +401,11 @@ if ($Action -eq "install" -and $PARTUUID -cne "00000000-0000-0000-0000-000000000
 
 switch ($Action) {
     "install" {
+        $consumer = Get-Service -Name RamSharedWinSvc -ErrorAction SilentlyContinue
+        $broker = Get-Service -Name RamSharedBroker -ErrorAction SilentlyContinue
+        if (($null -ne $consumer -and $consumer.Status -ne "Stopped") -or ($null -ne $broker -and $broker.Status -ne "Stopped")) {
+            throw "origin install requires RamShared services to be stopped"
+        }
         $transaction = New-OriginInstallTransaction
         try {
             if (Test-Path -LiteralPath $ExistingSwapVhdx) { Write-Verbose "existing WSL swap VHDX remains untouched" }
@@ -445,6 +450,11 @@ switch ($Action) {
         [ordered]@{ state = "VERIFIED"; action = $Action; partuuid = $proof.partuuid; disk_guid = $proof.disk_guid; host_mutation = $false } | ConvertTo-Json -Depth 4
     }
     "uninstall" {
+        $consumer = Get-Service -Name RamSharedWinSvc -ErrorAction SilentlyContinue
+        $broker = Get-Service -Name RamSharedBroker -ErrorAction SilentlyContinue
+        if (($null -ne $consumer -and $consumer.Status -ne "Stopped") -or ($null -ne $broker -and $broker.Status -ne "Stopped")) {
+            throw "origin uninstall requires RamShared services to be stopped"
+        }
         if ($PartUuidWasSupplied -or $LogicalCapacityWasSupplied -or $PhysicalCacheCapWasSupplied) { throw "origin uninstall does not accept caller identity or policy values" }
         $manifest = Read-SealedOriginManifest
         $proof = Get-OriginVhdxOwnershipProof -VhdxPath $OriginVhdx

--- a/update_pr.md
+++ b/update_pr.md
@@ -1,0 +1,22 @@
+## Resumo
+Add guard clauses to ensure product services are stopped before mutating storage identity or origin manifests.
+
+## Commits
+| Commit | O que fez | Por que fez | Detalhes |
+| --- | --- | --- | --- |
+| 1 | Adicionadas validações de estado para `RamSharedWinSvc` e `RamSharedBroker` durante operações de `install` e `uninstall`. | Prevenir corrupção de estado falhando rapidamente se os serviços do produto ainda estiverem ativos. | Modificado `scripts/windows/Manage-RamSharedOrigin.ps1` com verificações `-ErrorAction SilentlyContinue` e lançamentos de exceções. |
+
+## Issue
+N/A
+
+## Responsavel
+jules
+
+## Labels
+type:scripts, type:security, type:ci
+
+## Validacao
+`echo "Skipping PSScriptAnalyzer as pwsh is not installed"`
+
+## Rollback trigger
+Se as transações de instalação ou desinstalação começarem a falhar devido a exceções de estado inesperadas (e.g., validações pendentes ou travamentos na SCM) originadas do `$Action` switch block.


### PR DESCRIPTION
## Resumo
Add guard clauses to ensure product services are stopped before mutating storage identity or origin manifests.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Adicionadas validações de estado para `RamSharedWinSvc` e `RamSharedBroker` durante operações de `install` e `uninstall`. | Prevenir corrupção de estado falhando rapidamente se os serviços do produto ainda estiverem ativos. | Modificado `scripts/windows/Manage-RamSharedOrigin.ps1` com verificações `-ErrorAction SilentlyContinue` e lançamentos de exceções. |

## Labels
type:scripts, type:security, type:ci

## Validacao
`echo "Skipping PSScriptAnalyzer as pwsh is not installed"`

## Rollback trigger
Se as transações de instalação ou desinstalação começarem a falhar devido a exceções de estado inesperadas (e.g., validações pendentes ou travamentos na SCM) originadas do `$Action` switch block.

---
*PR created automatically by Jules for task [1163396077332206378](https://jules.google.com/task/1163396077332206378) started by @emersonbusson*