### PR TITLE
feat(scripts): add guard clauses for crash dump availability

### DIFF
--- a/scripts/windows/Recover-GuestVerifierExactRun.ps1
+++ b/scripts/windows/Recover-GuestVerifierExactRun.ps1
@@ -19,6 +19,8 @@ param(
     [Parameter(Mandatory = $true)][string]$ExpectedSignerCertSha256,
     [string]$ExpectedPartialPublishedInf = "",
     [ValidateRange(15, 30)][int]$GuestRestartDelaySeconds = 15,
+    [Parameter(Mandatory = $true)][string]$CrashDumpPath,
+    [Parameter(Mandatory = $true)][string]$WinDbgPath,
     [switch]$PlanOnly,
     [switch]$ApproveExactRecovery
 )
@@ -34,6 +36,14 @@ foreach ($path in @($SourcePath, $HelperPath, $PasswordFile)) {
         throw "required recovery input file is missing"
     }
 }
+
+if (-not (Test-Path -LiteralPath $CrashDumpPath -PathType Leaf)) {
+    throw [System.IO.FileNotFoundException]::new("crash dump file is missing")
+}
+if (-not (Test-Path -LiteralPath $WinDbgPath -PathType Leaf)) {
+    throw [System.IO.FileNotFoundException]::new("WinDbg analysis tools are missing")
+}
+
 . $HelperPath
 
 $source = Get-Content -LiteralPath $SourcePath -Raw -ErrorAction Stop

--- a/scripts/windows/Test-RecoverGuestVerifierExactRunStatic.ps1
+++ b/scripts/windows/Test-RecoverGuestVerifierExactRunStatic.ps1
@@ -58,7 +58,7 @@ foreach ($required in @(
         "FailedRunArtifactDirectory", "SealedPlanArtifactDirectory", "PartialActionArtifactDirectory", "PlanOnly",
         "ApproveExactRecovery", "ExpectedVMId", "ExpectedDriverSha256",
         "ExpectedInfSha256", "ExpectedCatalogSha256", "ExpectedPartialPublishedInf",
-        "GuestRestartDelaySeconds")) {
+        "GuestRestartDelaySeconds", "CrashDumpPath", "WinDbgPath")) {
     if ($parameters -notcontains $required) {
         throw "guest_verifier_recovery_static_contract_is_green failed: missing parameter $required"
     }


### PR DESCRIPTION
## Resumo
Added `CrashDumpPath` and `WinDbgPath` parameters to `Recover-GuestVerifierExactRun.ps1` with guard clauses to ensure the presence of crash dumps and WinDbg tools before running the recovery analysis. Updated the static contract test to enforce these parameters.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| Hash | Added crash dump and WinDbg guard clauses | To fail-fast on missing analysis prerequisites | <details>Added `CrashDumpPath` and `WinDbgPath` parameters to `Recover-GuestVerifierExactRun.ps1`. Added `Test-Path` checks throwing `System.IO.FileNotFoundException`. Updated `Test-RecoverGuestVerifierExactRunStatic.ps1`.</details> |

## Labels
type:scripts, area:windows

## Validacao
PSScriptAnalyzer and test scripts could not be run because `pwsh` is unavailable in the environment.

## Rollback trigger
Revert if the script incorrectly fails when valid paths are provided, blocking recovery operations.

---
*PR created automatically by Jules for task [5295277294432615380](https://jules.google.com/task/5295277294432615380) started by @emersonbusson*