### PR TITLE
feat(safety): use semantic exit codes for nbd-product-preflight

### DIFF
--- a/scripts/safety/nbd-product-preflight.sh
+++ b/scripts/safety/nbd-product-preflight.sh
@@ -37,7 +37,20 @@ declare -A MANIFEST_HASHES=()
 block() {
   printf 'NBD_PRODUCT_STATE=BLOCKED\n'
   printf 'NBD_READINESS_REASON=%s\n' "$1"
-  exit 1
+  case "$1" in
+    UNSUPPORTED_ARGUMENT)
+      exit 64
+      ;;
+    UBLK_MODULE_MISSING)
+      exit 69
+      ;;
+    *UNBOUND|*TYPE_INVALID|*ALIGNMENT_INVALID|*ENV_OVERRIDE_FORBIDDEN|*CAPACITY_UNKNOWN|*CAPACITY_AMBIGUOUS|*SINK_UNKNOWN|*SINK_IDENTITY_INVALID|VRAM_SIZE_INVALID)
+      exit 78
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
 }
 
 usage() {
@@ -411,6 +424,8 @@ check_legacy_ublk() {
   module_state=ABSENT
   if [[ -r $MODULES_FILE ]] && awk '$1 == "ublk_drv" { found = 1 } END { exit !found }' "$MODULES_FILE"; then
     module_state=LOADED_INERT
+  else
+    block UBLK_MODULE_MISSING
   fi
   UBLK_MODULE_STATE=$module_state
 }


### PR DESCRIPTION
## Resumo
This change applies semantic exit codes (EX_USAGE, EX_UNAVAILABLE, EX_CONFIG) from sysexits.h to the Bash product preflight script. It intercepts specific failure reasons within the `block()` function to return standard operational infrastructure codes instead of a generic exit 1. It also introduces a fail-fast behavior on the `ublk_drv` kernel module check to satisfy the missing kernel module constraint.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(safety): use semantic exit codes for nbd-product-preflight | Added sysexits.h exit codes mapping to `block` and fail-fast for missing kernel module. | To comply with infrastructure hardening standards requiring specific exit codes for operational triage. | Replaced `exit 1` in `block()` with a switch case evaluating the error reason. Refactored `check_legacy_ublk()` to abort when `ublk_drv` is absent instead of leaving state as `ABSENT`. |

## Labels
type:scripts, type:safety

## Validacao
shellcheck scripts/safety/nbd-product-preflight.sh

## Rollback trigger
Any failure in `nbd-product-preflight.sh` during automated checks or CI pipeline regressions.

---
*PR created automatically by Jules for task [2107736646571042604](https://jules.google.com/task/2107736646571042604) started by @emersonbusson*