### PR TITLE
feat(safety): add active swap draining guard to cascade teardown

### DIFF
--- a/scripts/safety/cascade-down.sh
+++ b/scripts/safety/cascade-down.sh
@@ -7,17 +7,23 @@ PRODUCT_ROOT=/opt/ramshared
 SELECTOR="$PRODUCT_ROOT/current"
 
 refuse() {
+  local reason=$1
+  local code=${2:-69}
   printf 'NBD_LIFECYCLE_STATE=REFUSED\n'
-  printf 'NBD_LIFECYCLE_REASON=%s\n' "$1"
-  exit 1
+  printf 'NBD_LIFECYCLE_REASON=%s\n' "$reason"
+  exit "$code"
 }
 
-[[ -L $SELECTOR ]] || refuse RELEASE_SELECTOR_MISSING
+# Guard clauses: Validate missing dependencies (EX_UNAVAILABLE = 69)
+command -v readlink >/dev/null || refuse DEPENDENCY_MISSING_READLINK 69
+command -v awk >/dev/null || refuse DEPENDENCY_MISSING_AWK 69
+
+[[ -L $SELECTOR ]] || refuse RELEASE_SELECTOR_MISSING 78
 RELEASE=$(readlink -f -- "$SELECTOR" 2>/dev/null || true)
-[[ $RELEASE == "$PRODUCT_ROOT"/releases/* && -d $RELEASE ]] || refuse RELEASE_SELECTOR_INVALID
+[[ $RELEASE == "$PRODUCT_ROOT"/releases/* && -d $RELEASE ]] || refuse RELEASE_SELECTOR_INVALID 78
 RELEASE_VERSION=${RELEASE##*/}
 CLI="$RELEASE/bin/ramshared"
-[[ -x $CLI ]] || refuse RELEASE_LAYOUT_INVALID
+[[ -x $CLI ]] || refuse RELEASE_LAYOUT_INVALID 78
 
 case $# in
   0)
@@ -28,12 +34,20 @@ case $# in
     exit 0
     ;;
   1)
-    [[ $1 == --execute ]] || refuse UNSUPPORTED_ARGUMENT
+    [[ $1 == --execute ]] || refuse UNSUPPORTED_ARGUMENT 64
     ;;
-  *) refuse UNSUPPORTED_ARGUMENT ;;
+  *) refuse UNSUPPORTED_ARGUMENT 64 ;;
 esac
 
-[[ ${RAMSHARED_NBD_LIFECYCLE_APPROVAL:-} == "deactivate:$RELEASE_VERSION" ]] || refuse APPROVAL_MISSING
+[[ ${RAMSHARED_NBD_LIFECYCLE_APPROVAL:-} == "deactivate:$RELEASE_VERSION" ]] || refuse APPROVAL_MISSING 78
+
+# Guard: Verify no processes are pinning swap pages before swapoff
+if test -f /proc/swaps; then
+  if ! awk 'NR>1 && $1 ~ /^\/dev\/nbd/ && $4 > 0 { exit 1 }' /proc/swaps; then
+    refuse "SWAP_PAGES_PINNED" 69
+  fi
+fi
+
 printf 'NBD_LIFECYCLE_STATE=EXECUTING\n'
 printf 'NBD_LIFECYCLE_ACTION=deactivate\n'
 printf 'NBD_LIFECYCLE_VERSION=%s\n' "$RELEASE_VERSION"


### PR DESCRIPTION
## Resumo
This PR hardens the `cascade-down.sh` deactivation script by adding an explicit guard clause that validates no swap pages are pinned on the active NBD device before proceeding. It also improves semantic error reporting using `sysexits.h` codes (e.g. 64, 69, 78) as part of infrastructure principles.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(safety): add active swap draining guard to cascade teardown | Added check on `/proc/swaps` with `awk` | Prevent data corruption by preventing teardown when swap pages are in use. | Enforced semantic exit codes with `refuse` function. |

## Labels
type:scripts, type:security

## Validacao
shellcheck scripts/safety/cascade-down.sh

## Rollback trigger
If the new guard blocks legitimate lifecycle actions when no NBD devices are genuinely active, or if awk dependency is missing on targeted environments.

---
*PR created automatically by Jules for task [14162198498540960207](https://jules.google.com/task/14162198498540960207) started by @emersonbusson*