### PR TITLE
feat(scripts): add timeout guard on WSL2 freeze operations

### DIFF
--- a/scripts/safety/wsl2-freeze-campaign.sh
+++ b/scripts/safety/wsl2-freeze-campaign.sh
@@ -375,15 +375,27 @@ if [[ "$RUN_ISOLATED" -eq 1 || "$RUN_SHARED" -eq 1 ]]; then
       fi
       if [[ -n "$action_pid" ]]; then
         watchdog_deadline=$((WATCHDOG_SEC + ACTION_CLEANUP_GRACE_SEC))
+
+        cleanup_handler() {
+          echo "action_cleanup_timeout after ${watchdog_deadline}s" >"$rdir/watchdog.txt"
+          if [[ -n "${action_pid:-}" ]]; then
+            kill -9 "$action_pid" 2>/dev/null || true
+          fi
+        }
+        trap cleanup_handler SIGALRM
+
         (
           sleep "$watchdog_deadline"
-          if kill -0 "$action_pid" 2>/dev/null; then
-            echo "action_cleanup_timeout after ${watchdog_deadline}s" >"$rdir/watchdog.txt"
-          fi
+          kill -ALRM $$ 2>/dev/null || true
         ) &
         wd_pid=$!
+
+        set +e
         wait "$action_pid"
         action_rc=$?
+        set -e
+
+        trap - SIGALRM
         kill "$wd_pid" 2>/dev/null || true
         wait "$wd_pid" 2>/dev/null || true
       fi


### PR DESCRIPTION
## Resumo
Adiciona um tratador de timeout baseado em alarme (`SIGALRM`) ao script `wsl2-freeze-campaign.sh`. Isso garante que operações de estresse prolongadas não causem travamentos permanentes do script (hang), interrompendo-as caso ultrapassem o limite especificado de tempo (watchdog).

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): add alarm-based timeout handler to wsl2-freeze-campaign | Implementou um `trap SIGALRM` envolvendo o comando `wait` para matar a probe de estresse. | Para evitar que a rotina de avaliação de congelamento do WSL2 fique suspensa indefinidamente se a ação falhar ou travar sem retornar controle. | Adiciona `set +e` ao redor do `wait` para prevenir que o exit status >128 quebre a execução do shell prematuramente. |

## Labels
type:scripts, type:safety

## Validacao
```bash
bash scripts/safety/wsl2-freeze-campaign.sh && bash scripts/safety/wsl2-freeze-campaign.sh
echo "shellcheck cannot be run as it is unavailable in the environment."
```

## Rollback trigger
Se o timeout (watchdog) for acionado falsamente e abortar ações de campanha válidas precocemente.

---
*PR created automatically by Jules for task [10345931657274076268](https://jules.google.com/task/10345931657274076268) started by @emersonbusson*