### PR TITLE
feat(scripts): add guard clauses and fail-fast to kmsg-recorder.sh

### DIFF
--- a/scripts/safety/kmsg-recorder.sh
+++ b/scripts/safety/kmsg-recorder.sh
@@ -6,19 +6,42 @@
 # held before persisting (as happened in #1 — journald only captured the 1st line).
 #
 # Runs as a systemd service (root). Does not touch GPU/ublk/swap.
-set -uo pipefail
+set -euo pipefail
+
+if ! command -v dmesg >/dev/null 2>&1; then
+  echo "Error: dmesg command not found." >&2
+  exit 69 # EX_UNAVAILABLE
+fi
+
+if ! command -v stdbuf >/dev/null 2>&1; then
+  echo "Error: stdbuf command not found." >&2
+  exit 69 # EX_UNAVAILABLE
+fi
+
+if [ ! -r /dev/kmsg ]; then
+  echo "Error: /dev/kmsg is not readable. Requires root privileges." >&2
+  exit 77 # EX_NOPERM
+fi
 
 FORENSICS_DIR="${RAMSHARED_FORENSICS_DIR:-/mnt/c/wsl-forensics}"
 mkdir -p "$FORENSICS_DIR" 2>/dev/null || FORENSICS_DIR="/var/log"  # fallback guest-local
+
+if [ ! -d "$FORENSICS_DIR" ] || [ ! -w "$FORENSICS_DIR" ]; then
+  echo "Error: Directory $FORENSICS_DIR is not writable or is not a directory." >&2
+  exit 73 # EX_CANTCREAT
+fi
+
 LOG="$FORENSICS_DIR/kernel-console.log"
 PREV="$FORENSICS_DIR/kernel-console.prev.log"
 
 # Preserva o log do boot anterior (pode conter o crash) antes de truncar pro boot atual.
-[ -f "$LOG" ] && cp -f "$LOG" "$PREV" 2>/dev/null
+if [ -f "$LOG" ]; then
+  cp -f "$LOG" "$PREV" 2>/dev/null || true
+fi
 
 {
   echo "===== kmsg-recorder boot: $(date '+%Y-%m-%d %H:%M:%S %z') | kernel $(uname -r) ====="
-} > "$LOG" 2>/dev/null
+} > "$LOG"
 
 # --follow: imprime o buffer atual e segue em tempo real. -T timestamps legiveis.
 # Escreve direto no arquivo host-side (flush por linha via stdbuf pra durabilidade).


### PR DESCRIPTION
## Resumo
Adiciona guard clauses e fail-fast (`set -euo pipefail`) ao script `scripts/safety/kmsg-recorder.sh` para garantir que as dependências (`dmesg`, `stdbuf`), o dispositivo `/dev/kmsg` (leitura) e o diretório de saída (escrita) estejam válidos antes da execução do script, aderindo aos princípios de confiabilidade e infraestrutura.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): add guard clauses and fail-fast to kmsg-recorder.sh | Adicionou validações de dependências e de leitura/escrita com error codes semânticos. | Para evitar falhas silenciosas e seguir princípios de segurança de infraestrutura. | Usa `sysexits.h` codes (69, 73, 77). |

## Labels
type:scripts, type:security, type:infrastructure

## Validacao
shellcheck was skipped as it is unavailable in the execution environment.

## Rollback trigger
Se o serviço do systemd falhar ao iniciar devido a falsos positivos nas verificações de leitura/escrita.

---
*PR created automatically by Jules for task [10481535187285400130](https://jules.google.com/task/10481535187285400130) started by @emersonbusson*