### PR TITLE
refactor(scripts): enforce early guard clauses and cgroup isolation validation in test cell

### DIFF
--- a/scripts/safety/test-nbd-benchmark-cell.sh
+++ b/scripts/safety/test-nbd-benchmark-cell.sh
@@ -5,6 +5,29 @@ ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
 CELL="$ROOT/scripts/safety/nbd-benchmark-cell.sh"
 CGROUP_LAUNCH="$ROOT/scripts/safety/nbd-benchmark-cgroup-launch.sh"
 BENCHMARK_LIB="$ROOT/scripts/safety/nbd-benchmark-lib.sh"
+
+[[ -x $CELL ]] || {
+  printf 'FAIL benchmark cell harness missing or not executable: %s\n' "$CELL" >&2
+  exit 69
+}
+[[ -x $CGROUP_LAUNCH ]] || {
+  printf 'FAIL benchmark cgroup launcher missing or not executable: %s\n' "$CGROUP_LAUNCH" >&2
+  exit 69
+}
+[[ -f $BENCHMARK_LIB && ! -L $BENCHMARK_LIB ]] || {
+  printf 'FAIL benchmark library missing or symlinked: %s\n' "$BENCHMARK_LIB" >&2
+  exit 69
+}
+
+command -v unshare >/dev/null || {
+  printf 'FAIL unshare command is required but missing\n' >&2
+  exit 69
+}
+unshare -Cm true >/dev/null 2>&1 || {
+  printf 'FAIL cgroup namespace isolation is not available\n' >&2
+  exit 69
+}
+
 TMP=$(mktemp -d)
 declare -a TEST_CHILD_PIDS=()
 cleanup_test_children() {
@@ -22,19 +45,6 @@ pass_count=0
 pass() {
   pass_count=$((pass_count + 1))
   printf 'PASS %s\n' "$1"
-}
-
-[[ -x $CELL ]] || {
-  printf 'FAIL benchmark cell harness missing or not executable: %s\n' "$CELL" >&2
-  exit 1
-}
-[[ -x $CGROUP_LAUNCH ]] || {
-  printf 'FAIL benchmark cgroup launcher missing or not executable: %s\n' "$CGROUP_LAUNCH" >&2
-  exit 1
-}
-[[ -f $BENCHMARK_LIB && ! -L $BENCHMARK_LIB ]] || {
-  printf 'FAIL benchmark library missing or symlinked: %s\n' "$BENCHMARK_LIB" >&2
-  exit 1
 }
 # shellcheck source=nbd-benchmark-lib.sh
 source "$BENCHMARK_LIB"


### PR DESCRIPTION
## Resumo
Moved guard clauses for dependency checks (`CELL`, `CGROUP_LAUNCH`, `BENCHMARK_LIB`) to the very beginning of the script to adhere to the fail-fast principle. These checks now run before any temporary directories are created or `trap EXIT` handlers are registered, ensuring no cleanup artifacts are left behind when dependencies fail. Furthermore, the script now validates the presence of cgroup namespace isolation by explicitly checking for the `unshare` command and its functionality, exiting with `EX_UNAVAILABLE` (69) if isolation is unsupported.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(scripts): move guard clauses and validate cgroup namespace isolation | Moved prereq checks to top, changed exits to 69, added unshare validation. | To guarantee fail-fast behavior before allocating resources and ensure cgroup namespace isolation is available for the test cell. | Modified `scripts/safety/test-nbd-benchmark-cell.sh`. |

## Labels
type:scripts, type:safety

## Validacao
Ran `shellcheck scripts/safety/test-nbd-benchmark-cell.sh`.
Ran `sudo bash scripts/safety/test-nbd-benchmark-cell.sh` and observed 48 passing tests.

## Rollback trigger
Revert if the benchmark cell script exits immediately with code 69 on environments where cgroup namespace isolation is mistakenly flagged as unavailable.

---
*PR created automatically by Jules for task [17795871356816026662](https://jules.google.com/task/17795871356816026662) started by @emersonbusson*