### PR TITLE
build(scripts): harden measure-vram-headroom.sh with GPU device validation

### DIFF
--- a/scripts/p0/measure-vram-headroom.sh
+++ b/scripts/p0/measure-vram-headroom.sh
@@ -8,8 +8,40 @@
 # output: CSV on stdout plus a summary (free min/max/mean plus volatility).
 set -euo pipefail
 
+# sysexits.h codes
+readonly EX_USAGE=64
+readonly EX_UNAVAILABLE=69
+
 DUR="${1:-30}"
 STEP="${2:-2}"
+
+if ! [[ "$DUR" =~ ^[0-9]+$ ]] || ! [[ "$STEP" =~ ^[0-9]+$ ]]; then
+  echo "Error: Duration and step must be positive integers." >&2
+  exit "$EX_USAGE"
+fi
+
+if (( DUR <= 0 || STEP <= 0 || STEP > DUR )); then
+  echo "Error: Invalid duration or step values." >&2
+  exit "$EX_USAGE"
+fi
+
+if (( DUR > 86400 )); then
+  echo "Error: Duration exceeds maximum allowed (86400s)." >&2
+  exit "$EX_USAGE"
+fi
+
+gpu_detected=0
+if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
+  gpu_detected=1
+elif command -v vulkaninfo >/dev/null 2>&1 && vulkaninfo >/dev/null 2>&1; then
+  gpu_detected=1
+fi
+
+if (( gpu_detected == 0 )); then
+  echo "Error: Neither nvidia-smi nor vulkaninfo detected a working GPU." >&2
+  exit "$EX_UNAVAILABLE"
+fi
+
 N=$(( DUR / STEP ))
 
 echo "ts_s,vram_free_mib,vram_used_mib,ram_avail_mib,ram_free_mib,swap_used_mib"


### PR DESCRIPTION
## Resumo
Hardened `scripts/p0/measure-vram-headroom.sh` to validate GPU device detection and arguments before executing VRAM measurement loop, to ensure script fails fast when run on unsupported environments or with invalid inputs.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | build(scripts): harden measure-vram-headroom.sh with GPU device validation | To prevent script failure loops on machines without a working GPU and reject out-of-bounds metrics. | Added sysexits.h return codes (64, 69). Validated inputs are integers, positive, and DUR <= 86400. Added `command -v` guard for `nvidia-smi` and `vulkaninfo`. |

## Labels
type:scripts, type:security, type:infrastructure

## Validacao
`shellcheck cannot be run as it is unavailable in the environment.`

## Rollback trigger
Script improperly rejects valid GPU environments (e.g., specific vulkaninfo outputs) or standard benchmarking duration inputs.

---
*PR created automatically by Jules for task [10694173540876288964](https://jules.google.com/task/10694173540876288964) started by @emersonbusson*