### PR TITLE
feat(scripts): update PSI check exit code to EX_UNAVAILABLE

### DIFF
--- a/scripts/p0/measure-psi.sh
+++ b/scripts/p0/measure-psi.sh
@@ -15,7 +15,7 @@ log() { echo "$LOG_PREFIX $*" >&2; }
 # Preflight: without CONFIG_PSI the file does not exist — the broker depends on PSI (DT-15).
 [ -r "$PSI" ] || {
 	log "ERROR: $PSI is unreadable. Kernel without CONFIG_PSI/PSI_DEFAULT_DISABLED? PSI is required."
-	exit 1
+	exit 69
 }
 
 log "sampling $PSI for ${DURATION}s -> $OUT"


### PR DESCRIPTION
Resumo: Atualiza o código de erro para a verificação de disponibilidade do PSI (/proc/pressure/memory) no script measure-psi.sh para utilizar o código semântico (sysexits.h) adequado.
Commits table: | Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(scripts): update PSI check exit code to EX_UNAVAILABLE | Atualizou o exit code de 1 para 69 na validação de leitura do /proc/pressure/memory. | Aderir aos princípios de arquitetura que exigem códigos de erro semânticos (sysexits.h). | Utiliza exit 69 (EX_UNAVAILABLE) quando o PSI não está acessível. |
Labels: type:scripts, type:security
Validacao: echo "shellcheck cannot be run as it is unavailable in the environment."
Rollback trigger: Se houver problemas com o novo código de erro retornando falhas que quebrem os scripts chamadores, reverter a alteração.

---
*PR created automatically by Jules for task [11171147633544489](https://jules.google.com/task/11171147633544489) started by @emersonbusson*