### PR TITLE
feat: guard clauses for socket state in control plane script

### DIFF
--- a/scripts/safety/manage-control-plane.sh
+++ b/scripts/safety/manage-control-plane.sh
@@ -272,8 +272,26 @@ stage_uninstall_recovery() {
   validate_receipt_structure "$receipt"
 }
 
+validate_socket_state() {
+  local dropin service_dir sock
+  for dropin in "${dropins[@]}"; do
+    service_dir="${dropin%%/*}"
+    sock="${service_dir%.service.d}.socket"
+    if systemctl is-active --quiet "$sock" 2>/dev/null; then
+      echo "control plane socket $sock is active; stop it before management operations" >&2
+      return 64
+    fi
+    if systemctl is-enabled --quiet "$sock" 2>/dev/null; then
+      echo "control plane socket $sock is enabled; disable it before management operations" >&2
+      return 64
+    fi
+  done
+  return 0
+}
+
 install_control_plane() {
   local relative limits_temporary
+  validate_socket_state || return 64
   compute_workload_limits || { echo 'guest memory cannot safely reserve the control plane' >&2; return 1; }
   [[ ! -e $manifest && ! -L $manifest && ! -e $transaction && ! -L $transaction ]] || { echo 'control plane installation state already exists; recover it explicitly' >&2; return 1; }
   install -d -m 0700 "$state_dir" "$backup_dir"; [[ -d $state_dir && ! -L $state_dir && -d $backup_dir && ! -L $backup_dir ]] || return 1
@@ -290,6 +308,7 @@ install_control_plane() {
 
 uninstall_control_plane() {
   local installation_id
+  validate_socket_state || return 64
   [[ -f $manifest && ! -L $manifest ]] || { echo 'owned install receipt is missing' >&2; return 1; }
   validate_active_manifest || { echo 'control-plane rollback refused; preserve operator changes and resolve them explicitly' >&2; return 1; }
   installation_id=$(read_receipt_header "$manifest") || return 1


### PR DESCRIPTION
## Resumo
Added guard clauses to validate control plane socket state (is-active, is-enabled) before allowing management operations.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: guard clauses for socket state in control plane script | Added `validate_socket_state` guard clause in `manage-control-plane.sh` | Prevent mutations while sockets are active or enabled | Checks `is-active` and `is-enabled` for docker, containerd, and cron sockets before `install_control_plane` and `uninstall_control_plane`, returning EX_USAGE (64) if so. |

## Issue
OpsInfra100

## Responsavel
Jules

## Labels
type:scripts

## Validacao
`shellcheck scripts/safety/manage-control-plane.sh`
(Manually validated socket states logic via tests due to shellcheck missing in env)

## Rollback trigger
Revert if script refuses to run in environments without systemd or encounters unexpected parsing issues with dropins.

---
*PR created automatically by Jules for task [894298944916369727](https://jules.google.com/task/894298944916369727) started by @emersonbusson*