### PR TITLE
feat(scripts): add guard clauses for build deps and arch

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -34,6 +34,21 @@ else
   echo "  [+] Environment detected: Native Linux"
 fi
 
+# Check required build dependencies
+for cmd in cargo rustc gcc; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: Required build dependency '$cmd' is missing." >&2
+    exit 69 # EX_UNAVAILABLE
+  fi
+done
+
+# Check target architecture
+ARCH="$(uname -m)"
+if [[ "$ARCH" != "x86_64" && "$ARCH" != "aarch64" ]]; then
+  echo "Error: Unsupported architecture '$ARCH'. Only x86_64 and aarch64 are supported." >&2
+  exit 64 # EX_USAGE
+fi
+
 # Check GPU / NVIDIA tools
 if command -v nvidia-smi >/dev/null 2>&1; then
   GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -n 1 || echo "NVIDIA GPU")


### PR DESCRIPTION
## Resumo
Add guard clauses in scripts/install.sh to validate cargo, rustc, gcc toolchain availability and check target architecture (x86_64 or aarch64) matching physical limits before execution.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): add guard clauses for build deps and arch | Added checks for `cargo`, `rustc`, `gcc` and target architecture in `install.sh`. | To fail fast if required build dependencies are missing or architecture is unsupported, according to ops infrastructure hardening principles. | Uses `sysexits.h` exit codes (EX_UNAVAILABLE, EX_USAGE) and fails fast on unsupported architectures. |

## Labels
type:scripts, type:security, type:infrastructure

## Validacao
echo "shellcheck cannot be run as it is unavailable in the environment."

## Rollback trigger
Revert if the install script fails on supported systems due to dependency checks.

---
*PR created automatically by Jules for task [11095800197032674980](https://jules.google.com/task/11095800197032674980) started by @emersonbusson*