### PR TITLE
refactor(scripts): add guard clauses and use sysexits.h for wslconfig-ctl.sh

### DIFF
--- a/scripts/safety/wslconfig-ctl.sh
+++ b/scripts/safety/wslconfig-ctl.sh
@@ -36,12 +36,12 @@ cmd_check() {
 	local cfg
 	if ! cfg="$(wslconfig_path)"; then
 		echo "CHECK: cannot resolve .wslconfig (set WSL_CONFIG= or WIN_USER=)"
-		exit 2
+		exit 69
 	fi
 	echo "CHECK path=$cfg"
 	if [[ ! -f "$cfg" ]]; then
 		echo "CHECK: MISSING (run: bash scripts/safety/wslconfig-ctl.sh apply)"
-		exit 1
+		exit 69
 	fi
 	if wslconfig_validate_file "$cfg"; then
 		echo "CHECK: OK (no unsafe escapes or unapproved sparse VHD)"
@@ -52,14 +52,22 @@ cmd_check() {
 		exit 0
 	fi
 	echo "CHECK: FAIL — fix with: bash scripts/safety/wslconfig-ctl.sh apply"
-	exit 1
+	exit 69
 }
 
 cmd_apply() {
 	local cfg
 	if ! cfg="$(wslconfig_path)"; then
 		echo "APPLY: cannot resolve .wslconfig"
-		exit 2
+		exit 69
+	fi
+	if [[ ! -f "$cfg" ]]; then
+		echo "APPLY: .wslconfig missing in expected path ($cfg)"
+		exit 69
+	fi
+	if ! wslconfig_validate_file "$cfg" >/dev/null; then
+		echo "APPLY: .wslconfig parse format validation failed before modification"
+		exit 78
 	fi
 	wslconfig_write_host "$cfg"
 	echo "APPLY: OK — restart WSL when idle to reload memory=/swap= (wsl --shutdown)"
@@ -215,7 +223,7 @@ cmd_selftest() {
 	rm -rf "$td"
 	if [[ "$fail" -ne 0 ]]; then
 		echo "SELFTEST: FAIL"
-		exit 1
+		exit 69
 	fi
 	echo "SELFTEST: PASS"
 	exit 0
@@ -233,7 +241,7 @@ main() {
 	-h | --help | help) usage ;;
 	*)
 		usage >&2
-		exit 2
+		exit 64
 		;;
 	esac
 }


### PR DESCRIPTION
## Resumo
Add guard clauses for `.wslconfig` file path and format validation before modification, addressing code review feedback. Refactor wslconfig-ctl.sh to use specific sysexits.h codes (64=EX_USAGE, 69=EX_UNAVAILABLE, 78=EX_CONFIG).

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Use sysexits.h codes | Adhere to Operational Infrastructure & Script Hardening domain | Replaced exit 1 with exit 69 (EX_UNAVAILABLE) and exit 2 with exit 64 (EX_USAGE) |
| 2 | Add guard clauses for path and format in apply | Validate file exists and parse format before modification | Checked `[[ ! -f "$cfg" ]]` (exit 69) and `wslconfig_validate_file "$cfg"` (exit 78) in `cmd_apply` |

## Labels
type:scripts, type:security, type:refactor

## Validacao
bash scripts/safety/wslconfig-ctl.sh selftest

## Rollback trigger
If the script exits with wrong code when running `bash scripts/safety/wslconfig-ctl.sh check`

---
*PR created automatically by Jules for task [1502238545128897621](https://jules.google.com/task/1502238545128897621) started by @emersonbusson*