### PR TITLE
feat(scripts): add guard clauses for ublk module and character device

### DIFF
--- a/scripts/kernel/qemu-ublk-daemon.sh
+++ b/scripts/kernel/qemu-ublk-daemon.sh
@@ -58,8 +58,25 @@ if $BB insmod /modules/ublk_drv.ko 2>/tmp/e; then
   echo "KTEST-INSMOD=ok"
 else
   echo "KTEST-INSMOD=fail: $($BB cat /tmp/e)"
+  $BB poweroff -f
+  exit 69
 fi
-[ -e /dev/ublk-control ] && echo "KTEST-UBLK-CONTROL=present" || echo "KTEST-UBLK-CONTROL=absent"
+
+if $BB grep -q "^ublk_drv" /proc/modules; then
+  echo "KTEST-MODULE-LOADED=ok"
+else
+  echo "KTEST-MODULE-LOADED=fail"
+  $BB poweroff -f
+  exit 69
+fi
+
+if [ -c /dev/ublk-control ] && [ -r /dev/ublk-control ] && [ -w /dev/ublk-control ]; then
+  echo "KTEST-UBLK-CONTROL=present"
+else
+  echo "KTEST-UBLK-CONTROL=absent"
+  $BB poweroff -f
+  exit 69
+fi
 
 # 2) starts the daemon in the isolated generic-Linux QEMU guest (--force for best-effort mlockall)
 /ramsharedd --transport ublk --backend ram \


### PR DESCRIPTION
## Resumo
Adiciona guard clauses no script de daemon do ublk para garantir que o módulo de kernel `ublk_drv` está carregado (`/proc/modules`) e que o device `/dev/ublk-control` está acessível como um character device com permissões de leitura e escrita.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): add guard clauses for ublk module and character device | Adicionada validação rigorosa de módulo e device no script. | Prevenir execução com estado inconsistente, falhando rápido conforme princípios de infraestrutura. | Usa `grep` em `/proc/modules` e flags `-c`, `-r`, `-w`. Retorna 69 (EX_UNAVAILABLE). |

## Labels
type:scripts, type:security, type:infrastructure

## Validacao
shellcheck cannot be run as it is unavailable in the environment. Validado visualmente e analisado estaticamente.

## Rollback trigger
Falhas prematuras no start do daemon dentro do QEMU devido à indisponibilidade momentânea do device (ex: race conditions de udev não coberto neste guest base).

---
*PR created automatically by Jules for task [14459058019059212720](https://jules.google.com/task/14459058019059212720) started by @emersonbusson*