### PR TITLE
docs: generate finding report for ci.yml action pinning

### DIFF
--- a/docs/jules/findings/FINDING_ONLY.txt
+++ b/docs/jules/findings/FINDING_ONLY.txt
@@ -1,0 +1,1 @@
+No unpinned action tags found in .github/workflows/ci.yml. All third-party actions are already pinned to full 40-character SHA hashes.


### PR DESCRIPTION
## Resumo
The target file .github/workflows/ci.yml already has all third-party action tags pinned to full 40-character SHA hashes. A FINDING_ONLY.txt report is generated as no code changes were possible.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: generate finding report for ci.yml action pinning | Added FINDING_ONLY.txt report | No unpinned actions were found in the target file | Confirmed that .github/workflows/ci.yml already uses full SHA hashes for all actions. |

## Labels
type:ci, type:scripts, type:security

## Validacao
N/A (no code changes)

## Rollback trigger
Not applicable (no code changes).

---
*PR created automatically by Jules for task [11707745495054775115](https://jules.google.com/task/11707745495054775115) started by @emersonbusson*