### PR TITLE
refactor(scripts): apply guard clause for checkpatch.pl availability

### DIFF
--- a/scripts/ci/check-kernel-checkpatch.sh
+++ b/scripts/ci/check-kernel-checkpatch.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-2.0-only
-# Download checkpatch.pl from torvalds/linux and validate kernel driver files.
+# Validate kernel driver files using checkpatch.pl from kernel source tree.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -9,22 +9,17 @@ cd "$ROOT"
 echo "==> Running checkpatch.pl validation on kernel driver files..."
 
 DRIVER_DIR="drivers/block/ramshared"
-CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/ramshared-ci"
-CHECKPATCH="$CACHE_DIR/checkpatch.pl"
-SPELLING="$CACHE_DIR/spelling.txt"
-CONST_STRUCTS="$CACHE_DIR/const_structs.checkpatch"
+KERNEL_DIR="${KERNEL_DIR:-/lib/modules/$(uname -r)/build}"
 
-# Download checkpatch.pl from torvalds/linux if not cached
+if [[ ! -d "$KERNEL_DIR" ]]; then
+  echo "FAIL: Kernel source path not found at $KERNEL_DIR" >&2
+  exit 69
+fi
+
+CHECKPATCH="$KERNEL_DIR/scripts/checkpatch.pl"
 if [[ ! -x "$CHECKPATCH" ]]; then
-  mkdir -p "$CACHE_DIR"
-  echo "  Downloading checkpatch.pl from torvalds/linux..."
-  curl -sSfL "https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl" -o "$CHECKPATCH" || {
-    echo "  [SKIP] Could not download checkpatch.pl (network unavailable). PASS by grace."
-    exit 0
-  }
-  chmod +x "$CHECKPATCH"
-  curl -sSfL "https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt" -o "$SPELLING" 2>/dev/null || touch "$SPELLING"
-  curl -sSfL "https://raw.githubusercontent.com/torvalds/linux/master/scripts/const_structs.checkpatch" -o "$CONST_STRUCTS" 2>/dev/null || touch "$CONST_STRUCTS"
+  echo "FAIL: checkpatch.pl not found or not executable at $CHECKPATCH" >&2
+  exit 69
 fi
 
 TARGET_FILES=()


### PR DESCRIPTION
## Resumo
Modified `scripts/ci/check-kernel-checkpatch.sh` to enforce infrastructure hardening principles. Removed the remote curl downloads and instead check that a `KERNEL_DIR` exists and that `checkpatch.pl` is executable within it. If checks fail, it now exits with sysexits 69 instead of failing silently or proceeding with network-downloaded scripts.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(scripts): apply guard clause for checkpatch.pl availability | Replaced remote checkpatch download logic with local kernel tree verification and strict error exits. | To prevent network reliance, avoid unverified script execution, and adhere to fail-fast guard clauses with explicit semantic error 69. | Removed `CACHE_DIR` logic and curl downloads; added `-d $KERNEL_DIR` and `-x $CHECKPATCH` guard checks. |

## Labels
type:scripts, type:security, type:ci

## Validacao
```bash
shellcheck cannot be run as it is unavailable in the environment.
```

## Rollback trigger
Revert if `KERNEL_DIR` fallback logic is incompatible with existing CI runners or kernel module build pipelines, leading to widespread checkpatch skipping/failure.

---
*PR created automatically by Jules for task [3159607309036821391](https://jules.google.com/task/3159607309036821391) started by @emersonbusson*