### PR TITLE
feat(scripts): add guard clauses and build validations to WSL kernel build script

### DIFF
--- a/scripts/kernel/build-wsl-kernel.sh
+++ b/scripts/kernel/build-wsl-kernel.sh
@@ -15,27 +15,63 @@ set -euo pipefail
 # SPEC wsl2-custom-kernel-p1: default 6.18.y; override with KTAG=
 KTAG="${KTAG:-linux-msft-wsl-6.18.y}"
 KSRC="${KSRC:-$HOME/src/WSL2-Linux-Kernel}"
-JOBS="${JOBS:-2}"; [ "$JOBS" -lt 1 ] && JOBS=1
+JOBS="${JOBS:-2}"
+
+if ! [[ "$JOBS" =~ ^[0-9]+$ ]]; then
+  echo "Error: JOBS must be a positive integer." >&2
+  exit 64 # EX_USAGE
+fi
+if [ "$JOBS" -lt 1 ]; then
+  JOBS=1
+fi
+MAX_JOBS=$(nproc 2>/dev/null || echo 128)
+if [ "$JOBS" -gt "$MAX_JOBS" ]; then
+  echo "Error: JOBS ($JOBS) exceeds available CPU cores ($MAX_JOBS)." >&2
+  exit 64 # EX_USAGE
+fi
+
 CONFIGS=("$@"); [ ${#CONFIGS[@]} -eq 0 ] && CONFIGS=(CONFIG_BLK_DEV_UBLK=m CONFIG_ZRAM_WRITEBACK=y CONFIG_IO_URING=y)
 
 echo "[build] deps..."
 sudo apt-get install -y -q build-essential flex bison libelf-dev libssl-dev bc dwarves cpio python3 >/dev/null
 
+for cmd in make gcc flex bison; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: Required build tool '$cmd' is missing." >&2
+    exit 69 # EX_UNAVAILABLE
+  fi
+done
+
 if [ ! -d "$KSRC/.git" ]; then
   echo "[build] cloning $KTAG -> $KSRC"
   git clone --depth 1 --branch "$KTAG" https://github.com/microsoft/WSL2-Linux-Kernel.git "$KSRC"
 fi
-cd "$KSRC"
+cd "$KSRC" || { echo "Error: Failed to enter $KSRC" >&2; exit 74; }
+
+if [ ! -f "Makefile" ] || [ ! -f "Kconfig" ]; then
+  echo "Error: '$KSRC' is not a valid kernel source tree." >&2
+  exit 74 # EX_IOERR
+fi
 
 echo "[build] base = Microsoft/config-wsl + extra configs"
+if [ ! -f "Microsoft/config-wsl" ]; then
+  echo "Error: Microsoft/config-wsl not found." >&2
+  exit 78 # EX_CONFIG
+fi
 cp Microsoft/config-wsl .config
+
+if [ ! -f ".config" ]; then
+  echo "Error: .config was not created." >&2
+  exit 78 # EX_CONFIG
+fi
+
 for kv in "${CONFIGS[@]}"; do
   name="${kv%%=*}"; val="${kv##*=}"
   case "$val" in
     y) ./scripts/config --file .config --enable  "$name" ;;
     m) ./scripts/config --file .config --module  "$name" ;;
     n) ./scripts/config --file .config --disable "$name" ;;
-    *) echo "[build] invalid value in $kv (use y|m|n)"; exit 2 ;;
+    *) echo "[build] invalid value in $kv (use y|m|n)"; exit 64 ;;
   esac
 done
 make olddefconfig >/dev/null
@@ -45,7 +81,6 @@ fail=0
 for kv in "${CONFIGS[@]}"; do
   name="${kv%%=*}"; val="${kv##*=}"
   got="$(grep -E "^${name}=" .config | cut -d= -f2 || true)"; [ -z "$got" ] && got="(unset)"
-  want="$val"; [ "$val" = "y" ] && want="y"; [ "$val" = "m" ] && want="m"
   if { [ "$val" = "y" ] && [ "$got" = "y" ]; } || { [ "$val" = "m" ] && [ "$got" = "m" ]; } || { [ "$val" = "n" ] && [ "$got" = "(unset)" ]; }; then
     echo "[build]  OK  $name=$got"
   else
@@ -53,7 +88,7 @@ for kv in "${CONFIGS[@]}"; do
     fail=1
   fi
 done
-[ "$fail" = 1 ] && { echo "[build] configs did not apply; aborting."; exit 1; }
+[ "$fail" = 1 ] && { echo "[build] configs did not apply; aborting."; exit 78; }
 
 echo "[build] make -j$JOBS (resource-intensive; limited -j avoids stalling WSL2)..."
 make -j"$JOBS"


### PR DESCRIPTION
## Resumo
Applied guard clauses and sanity checks to `scripts/kernel/build-wsl-kernel.sh` to validate input arguments, kernel source tree integrity, .config existence, and required build toolchain components (make, gcc, flex, bison), enforcing fail-fast principles with explicit semantic sysexits.h exit codes.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(scripts): add guard clauses and build validations to WSL kernel build script | Added checks for JOBS sanity, build tool availability, source tree integrity (Makefile/Kconfig), and config application success using explicit `sysexits.h` error codes | Prevent build failures deep in the execution pipeline due to missing prerequisites or malformed inputs, aligning with RamShared operational hardening | Validated JOBS against nproc; checked for make, gcc, flex, bison; verified Makefile/Kconfig/.config existence; return EX_USAGE, EX_UNAVAILABLE, EX_IOERR, EX_CONFIG. |

## Issue
None

## Responsavel
Jules

## Labels
type:scripts, type:security, type:infrastructure

## Validacao
`shellcheck scripts/kernel/build-wsl-kernel.sh` (executed successfully)

## Rollback trigger
Revert if kernel builds fail indiscriminately due to unexpected command checks, or if valid nproc configurations cause erroneous rejections.

---
*PR created automatically by Jules for task [6589156045082620124](https://jules.google.com/task/6589156045082620124) started by @emersonbusson*