### PR TITLE
ci: add PR concurrency cancellation to prevent duplicate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Resumo
Updated the concurrency group definition in `.github/workflows/ci.yml` to correctly use `${{ github.head_ref || github.ref }}`. This ensures that redundant in-progress CI runs for the same branch or pull request are cancelled, reducing wasted parallel compute resources.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| ci: add PR concurrency cancellation to prevent duplicate runs | Updated `concurrency.group` key | To cancel redundant in-progress CI runs on PR updates | Changed `${{ github.ref }}` to `${{ github.head_ref \|\| github.ref }}` |

## Labels
type:ci

## Validacao
Executed `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml` to ensure YAML schema and syntax are correct.

## Rollback trigger
Revert this change if CI jobs begin cancelling unexpectedly for unrelated branches or if workflow dispatch events are dropped incorrectly.

---
*PR created automatically by Jules for task [7930984167735121231](https://jules.google.com/task/7930984167735121231) started by @emersonbusson*