### PR TITLE
ci: enforce release tag format and changelog guard clauses

### DIFF
--- a/.github/workflows/release-publication.yml
+++ b/.github/workflows/release-publication.yml
@@ -77,6 +77,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if ! [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "Error: Tag '$RELEASE_TAG' does not match format vX.Y.Z[-prerelease]" >&2
+            exit 64
+          fi
+          version="${RELEASE_TAG#v}"
+          if ! grep -q "\[${version}\]" CHANGELOG.md; then
+            echo "Error: Missing entry for version $version in CHANGELOG.md" >&2
+            exit 64
+          fi
           node tools/ci/check-release-publication.mjs \
             --policy docs/governance/release-promotion.json \
             --tag "$RELEASE_TAG" \
@@ -143,6 +152,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if ! [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "Error: Tag '$RELEASE_TAG' does not match format vX.Y.Z[-prerelease]" >&2
+            exit 64
+          fi
+          version="${RELEASE_TAG#v}"
+          if ! grep -q "\[${version}\]" CHANGELOG.md; then
+            echo "Error: Missing entry for version $version in CHANGELOG.md" >&2
+            exit 64
+          fi
           node tools/ci/check-release-publication.mjs \
             --policy docs/governance/release-promotion.json \
             --tag "$RELEASE_TAG" \


### PR DESCRIPTION
## Resumo
Adiciona condições de guarda (guard clauses) no workflow de publicação de release (`.github/workflows/release-publication.yml`) para validar se a tag de release segue o formato semântico rigoroso (`vX.Y.Z[-prerelease]`) e se existe uma entrada correspondente no arquivo `CHANGELOG.md`.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| ci: enforce release tag format and changelog guard clauses | Adicionou validação de formato de tag (Regex) e de entrada no CHANGELOG.md | Para garantir que apenas releases com tags válidas (vX.Y.Z) e devidamente documentadas no changelog avancem para publicação | Os passos "Validate exact publication request identity" e "Validate exact protected dispatch identity" agora possuem `if` blocks que fazem fail-fast com o código de erro EX_USAGE (64). |

## Issue
N/A

## Responsavel
@emersonbusson

## Labels
type:ci, type:scripts

## Validacao
actionlint cannot be run as it is unavailable in the environment.

## Rollback trigger
Falhas imprevistas em execuções válidas de release que sigam corretamente o padrão semântico, causando o bloqueio indevido da pipeline de CI.

---
*PR created automatically by Jules for task [4910210162230784067](https://jules.google.com/task/4910210162230784067) started by @emersonbusson*