### PR TITLE
feat(ci): add end-to-end artifact integrity verification pipeline

### DIFF
--- a/.github/workflows/release-integrity.yml
+++ b/.github/workflows/release-integrity.yml
@@ -28,6 +28,8 @@ jobs:
     name: release-integrity
     if: github.event_name == 'push' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    outputs:
+      revision: ${{ steps.identity.outputs.revision }}
     timeout-minutes: 45
     permissions:
       contents: read
@@ -194,3 +196,40 @@ jobs:
           path: tmp/release-integrity-candidate
           if-no-files-found: error
           retention-days: 14
+
+  verify-artifact-integrity:
+    name: verify-artifact-integrity
+    needs: [release-integrity]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+    steps:
+      - name: Download exact integrity candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-integrity-${{ env.RELEASE_TAG }}-${{ needs.release-integrity.outputs.revision }}
+          path: tmp/release-integrity-artifact
+
+      - name: Verify downloaded artifact checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          target_dir="tmp/release-integrity-artifact/artifacts/release"
+          if [ ! -d "$target_dir" ]; then
+            echo "Directory not found: $target_dir" >&2
+            exit 74
+          fi
+          cd "$target_dir"
+          archive="ramshared-linux-$RELEASE_TAG.tar.gz"
+          if [ ! -f "$archive" ]; then
+            echo "Archive not found: $archive" >&2
+            exit 74
+          fi
+          if [ ! -f "$archive.sha256" ]; then
+            echo "Checksum file not found: $archive.sha256" >&2
+            exit 74
+          fi
+          sha256sum --strict --check "$archive.sha256"


### PR DESCRIPTION
## Resumo
Adiciona o job `verify-artifact-integrity` no workflow `release-integrity.yml` para validar de forma isolada os checksums do artefato gerado.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(ci): add end-to-end artifact integrity verification pipeline | Adicionou o job verify-artifact-integrity | Para garantir a integridade fim-a-fim do artefato gerado validando o checksum num runner isolado | Utiliza download-artifact e executa script bash seguro com guard clauses e fail-fast |

## Issue
OpsInfra100/2026-09-01/ci-workflows/066

## Responsavel
jules

## Labels
type:ci

## Validacao
actionlint cannot be run as it is unavailable in the environment.

## Rollback trigger
Falha contínua no step de validação de checksum impedindo a aprovação de releases legítimos.

---
*PR created automatically by Jules for task [11121057313068468028](https://jules.google.com/task/11121057313068468028) started by @emersonbusson*