### PR TITLE
ci: guard kernel source availability in CI runner

### DIFF
--- a/.github/workflows/kernel-ci.yml
+++ b/.github/workflows/kernel-ci.yml
@@ -28,18 +28,23 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y -qq perl curl
 
       - name: Kernel Style Check
+        if: hashFiles('scripts/ci/check-kernel-style.sh') != ''
         run: ./scripts/ci/check-kernel-style.sh
 
       - name: Kernel Sparse Semantic Check
+        if: hashFiles('scripts/ci/check-kernel-sparse.sh') != ''
         run: ./scripts/ci/check-kernel-sparse.sh
 
       - name: Kernel checkpatch.pl Validation
+        if: hashFiles('scripts/ci/check-kernel-checkpatch.sh') != ''
         run: ./scripts/ci/check-kernel-checkpatch.sh
 
       - name: Kernel ABI & Symbol Export Guard
+        if: hashFiles('scripts/ci/check-kernel-abi-guard.sh') != ''
         run: ./scripts/ci/check-kernel-abi-guard.sh
 
       - name: Adversarial Invariants Verification
+        if: hashFiles('scripts/ci/check-adversarial-invariants.sh') != ''
         run: ./scripts/ci/check-adversarial-invariants.sh
 
   kernel-build-matrix:
@@ -70,6 +75,7 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y -qq clang
 
       - name: Run build matrix (${{ matrix.compiler }} / ${{ matrix.arch }})
+        if: hashFiles('scripts/ci/check-kernel-build-matrix.sh') != ''
         run: ./scripts/ci/check-kernel-build-matrix.sh "${{ matrix.compiler }}" "${{ matrix.arch }}"
 
   kernel-qemu-smoke:
@@ -82,6 +88,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Validate audit tool with clean console log
+        if: hashFiles('scripts/ci/check-kernel-qemu-smoke.sh') != ''
         run: |
           CLEAN_LOG=$(mktemp)
           echo "[    0.000000] Linux version 6.8.0-ramshared" > "$CLEAN_LOG"
@@ -91,6 +98,7 @@ jobs:
           rm -f "$CLEAN_LOG"
 
       - name: Validate audit tool catches kernel splats
+        if: hashFiles('scripts/ci/check-kernel-qemu-smoke.sh') != ''
         run: |
           BAD_LOG=$(mktemp)
           echo "[    0.000000] Linux version 6.8.0-ramshared" > "$BAD_LOG"
@@ -106,4 +114,5 @@ jobs:
           rm -f "$BAD_LOG"
 
       - name: Audit QEMU Console Logs (if provided)
+        if: hashFiles('scripts/ci/check-kernel-qemu-smoke.sh') != ''
         run: ./scripts/ci/check-kernel-qemu-smoke.sh

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,30 @@
+## Resumo
+Add `if: hashFiles('scripts/ci/') != ''` guard conditions to check kernel source availability in the `kernel-ci.yml` CI runner before running kernel build steps.
+
+## Commits
+| Commit | O que fez | Por que fez | Detalhes |
+|---|---|---|---|
+| `ci: guard kernel source availability` | Added `if` conditions to kernel steps | Prevent CI failures when kernel scripts are missing | Checked `hashFiles('scripts/ci/')` |
+
+## Issue
+OpsInfra100/2026-09-01/ci-workflows/060
+
+## Responsavel
+Jules
+
+## Labels
+type:ci
+
+## Validacao
+`actionlint .github/workflows/kernel-ci.yml`
+
+## Rollback trigger
+CI jobs failing due to syntax errors in YAML or logic errors preventing legitimate builds.
+
+---
+
+1. Use the `run_in_bash_session` tool to execute `curl -sL https://github.com/rhysd/actionlint/releases/download/v1.7.1/actionlint_1.7.1_linux_amd64.tar.gz | tar xz actionlint` to install `actionlint` if it's missing in the execution environment.
+2. Use the `replace_with_git_merge_diff` tool to modify `.github/workflows/kernel-ci.yml`. I will add an `if: hashFiles('scripts/ci/') != ''` condition to the jobs/steps that run kernel scripts, or as early as possible in the jobs to skip them if the source is unavailable.
+3. Use the `run_in_bash_session` tool to execute `./actionlint .github/workflows/kernel-ci.yml` to validate the YAML syntax.
+4. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+5. Use the `submit` tool to create a PR against `jules/inbox`.


### PR DESCRIPTION
## Resumo
Add guard conditions to check kernel source availability in the `kernel-ci.yml` CI runner before running kernel build steps.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| ci: guard kernel source availability | Added if conditions to kernel steps | Prevent CI failures when kernel scripts are missing | Checked hashFiles('scripts/ci/') |

## Issue
OpsInfra100/2026-09-01/ci-workflows/060

## Responsavel
Jules

## Labels
type:ci

## Validacao
./actionlint .github/workflows/kernel-ci.yml

## Rollback trigger
CI jobs failing due to syntax errors in YAML or logic errors preventing legitimate builds.

---
*PR created automatically by Jules for task [714831497056926180](https://jules.google.com/task/714831497056926180) started by @emersonbusson*