### PR TITLE
feat(ci): add PSScriptAnalyzer step to windows-static.yml

### DIFF
--- a/.github/workflows/windows-static.yml
+++ b/.github/workflows/windows-static.yml
@@ -24,6 +24,17 @@ jobs:
         with:
           toolchain: 1.98.0
 
+      - name: PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not (Test-Path -Path 'scripts/windows')) { throw [System.Exception]::new('scripts/windows directory not found') }
+          $results = Invoke-ScriptAnalyzer -Path 'scripts/windows' -Recurse -Severity Error -ErrorAction Stop
+          if ($null -ne $results -and $results.Count -gt 0) {
+            $results | Format-Table -AutoSize
+            throw [System.Exception]::new('PSScriptAnalyzer found Error severity violations')
+          }
+
       - name: Windows Rust tests
         shell: pwsh
         run: |


### PR DESCRIPTION
## Resumo
Adiciona uma etapa do `PSScriptAnalyzer` ao fluxo de trabalho `.github/workflows/windows-static.yml` para realizar análise estática nos scripts do PowerShell. A etapa é configurada para falhar em descobertas de severidade `Error`. Cláusulas de guarda são implementadas para falhar rapidamente se o diretório do script não existir, e exceções são lançadas explicitamente em caso de falha.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(ci): add PSScriptAnalyzer step to windows-static.yml | Adicionado PSScriptAnalyzer step. | Para analisar os scripts do PowerShell. | Foi adicionado na pipeline windows-static.yml e configurado para falhar na severidade Error. |

## Issue
N/A

## Responsavel
Jules

## Labels
type:ci, type:scripts

## Validacao
PSScriptAnalyzer cannot be run as pwsh is unavailable in the environment.

## Rollback trigger
Revert if the PSScriptAnalyzer step causes false positives or blocks the CI pipeline for Windows workflows.

---
*PR created automatically by Jules for task [12339419555777285963](https://jules.google.com/task/12339419555777285963) started by @emersonbusson*