### PR TITLE
feat(scripts): add guard clauses for dpkg-deb and fakeroot in build-deb-package.sh

### DIFF
--- a/scripts/package/build-deb-package.sh
+++ b/scripts/package/build-deb-package.sh
@@ -4,6 +4,13 @@
 # Usage: scripts/package/build-deb-package.sh [version]
 set -euo pipefail
 
+for cmd in dpkg-deb fakeroot lintian; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: Required tool '$cmd' is not installed or not in PATH." >&2
+    exit 69
+  fi
+done
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 VERSION="${1:-${RAMSHARED_PACKAGE_VERSION:-v0.9.0-beta.2}}"
 VERSION_CLEAN="${VERSION#v}"


### PR DESCRIPTION
## Resumo
Added early guard clauses in `build-deb-package.sh` to validate the presence of `dpkg-deb`, `fakeroot`, and `lintian`. If any of the required tools are missing, the script will exit early with code 69 (EX_UNAVAILABLE) to prevent failures later in the script.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(scripts): add guard clauses for dpkg-deb and fakeroot | Added early tool validation in build-deb-package.sh | To fail fast if required packaging tools are missing | Exits with 69 (EX_UNAVAILABLE) if dpkg-deb, fakeroot, or lintian are absent |

## Issue
OpsInfra100/2026-09-01/packaging/076

## Responsavel
Jules

## Labels
type:scripts, type:packaging

## Validacao
`shellcheck cannot be run as shellcheck is unavailable in the environment.`

## Rollback trigger
Revert if package builds fail due to environment restrictions or valid tool paths being rejected.

---
*PR created automatically by Jules for task [8967755130291361837](https://jules.google.com/task/8967755130291361837) started by @emersonbusson*