### PR TITLE
feat(ci): protect main and release branches from closed PR cancellation

### DIFF
--- a/.github/workflows/cancel-closed-pr.yml
+++ b/.github/workflows/cancel-closed-pr.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   cancel-closed-pr:
     name: closed-pr-cancellation
-    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.ref != 'main' && !startsWith(github.event.pull_request.base.ref, 'release/')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Resumo
Add guard condition in cancel-closed-pr.yml to prevent cancellation of workflows for PRs targeting protected branches (main, release/*).

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(ci): protect main and release branches from closed PR cancellation | Adicionada condicao no arquivo cancel-closed-pr.yml para evitar o cancelamento de PRs que tenham como destino as branchs main ou que comecem com release/. | Para evitar perda de dados em workflows associados a branchs protegidas quando um PR e fechado. | Foi adicionado `&& github.event.pull_request.base.ref != 'main' && !startsWith(github.event.pull_request.base.ref, 'release/')` ao `if` do job `cancel-closed-pr`. |

## Issue
N/A

## Responsavel
OpsInfra100

## Labels
type:ci

## Validacao
Usei `actionlint .github/workflows/cancel-closed-pr.yml` via go install para garantir sintaxe.

## Rollback trigger
Caso o job falhe em parsear a condição if no actions e falhar a esteira inteira.

---
*PR created automatically by Jules for task [4842835471428129805](https://jules.google.com/task/4842835471428129805) started by @emersonbusson*