### PR TITLE
ci: add wsl2 prerequisite check to wsl2-lab workflow

### DIFF
--- a/.github/workflows/wsl2-lab.yml
+++ b/.github/workflows/wsl2-lab.yml
@@ -19,7 +19,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: wsl2-lab-plan-${{ github.ref }}
+  group: wsl2-lab-plan-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -36,6 +36,22 @@ jobs:
       LAB_REVISION: ${{ github.sha }}
       LAB_ENVIRONMENT: protected-isolated-lab
     steps:
+      - name: Validate WSL2 prerequisites
+        run: |
+          set -euo pipefail
+          if ! uname -r | grep -qi "microsoft"; then
+            echo "Error: WSL2 kernel not detected."
+            exit 69
+          fi
+          if ! command -v wsl.exe >/dev/null 2>&1; then
+            echo "Error: wsl.exe not found in PATH."
+            exit 69
+          fi
+          if ! wsl.exe --list --quiet >/dev/null 2>&1; then
+            echo "Error: WSL distro availability check failed."
+            exit 69
+          fi
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 


### PR DESCRIPTION
## Resumo
Added a fail-fast prerequisite check for WSL2 kernel and distro availability in the wsl2-lab workflow. It exits with code 69 if `uname -r` doesn't match 'microsoft', `wsl.exe` is missing, or `wsl.exe --list` fails. It also fixes the concurrency group to use `github.head_ref || github.ref` to properly cancel runs on PRs.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| (hash) | `<details><summary>ci: add wsl2 prerequisite check to wsl2-lab workflow</summary>Added a bash script guard clause step to the wsl2-lab-plan job to check if the runner is running a WSL2 kernel and has access to WSL distributions. Exits with sysexits.h code 69 (EX_UNAVAILABLE) if not.</details>` | `<details><summary>Fail fast on invalid runners</summary>Prevents the CI workflow from proceeding and failing further down when run on a non-WSL2 environment, saving CI minutes and giving clearer error messages.</details>` | `<details><summary>Added step Validate WSL2 prerequisites</summary>The step runs before Checkout, validating `uname -r`, `command -v wsl.exe`, and `wsl.exe --list`. Included `set -euo pipefail`.</details>` |

## Issue
None

## Responsavel
@jules

## Labels
type:ci, type:scripts

## Validacao
Echoing that shellcheck and actionlint cannot be run.

## Rollback trigger
Workflow incorrectly fails on valid WSL2 runners.

---
*PR created automatically by Jules for task [1345372186453360172](https://jules.google.com/task/1345372186453360172) started by @emersonbusson*