### PR TITLE
fix(ci): reorder contract verification to end of job

### DIFF
--- a/.github/workflows/ci-contract.yml
+++ b/.github/workflows/ci-contract.yml
@@ -39,8 +39,6 @@ jobs:
           tools/ci/check-ci-contract.test.mjs
           tools/ci/check-ci-aggregate.test.mjs
 
-      - name: Verify local contract admission
-        run: node tools/ci/check-ci-contract.mjs --check-local
 
       - name: Release promotion checker coverage
         run: |
@@ -75,6 +73,9 @@ jobs:
 
       - name: Validate exact SPEC coverage map
         run: node tools/ci/plan-rust-slice-coverage.mjs --all
+
+      - name: Verify local contract admission
+        run: node tools/ci/check-ci-contract.mjs --check-local
 
   ci-core:
     name: ci-core


### PR DESCRIPTION
## Resumo
Move the `Verify local contract admission` step to the end of the `contract` job in `.github/workflows/ci-contract.yml`. This ensures that all contract prerequisites are met before local verification.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Move verify local contract admission step | Ensure correct execution order | Moved to end of contract job |

## Labels
type:ci

## Validacao
node tools/ci/check-ci-contract.mjs --check-local

## Rollback trigger
Check failure on PR.

---
*PR created automatically by Jules for task [12066237066776257844](https://jules.google.com/task/12066237066776257844) started by @emersonbusson*