### PR TITLE
feat(packaging): validate DEBIAN/control mandatory fields before build

### DIFF
--- a/scripts/package/build-deb-package.sh
+++ b/scripts/package/build-deb-package.sh
@@ -104,6 +104,33 @@ printf " RamShared is an R&D system that utilizes idle GPU Video RAM (VRAM)\n" >
 printf " over PCIe as an accelerated, high-throughput memory tier for Linux and WSL2.\n" >> "$STAGE_DIR/DEBIAN/control"
 printf " Absorbs memory pressure spikes and prevents desktop/WSL2 swap freezes.\n" >> "$STAGE_DIR/DEBIAN/control"
 
+echo "==> Validating DEBIAN/control mandatory fields..."
+CTRL_FILE="$STAGE_DIR/DEBIAN/control"
+if [[ ! -f "$CTRL_FILE" ]]; then
+  echo "ERROR: DEBIAN/control file missing." >&2
+  exit 78
+fi
+
+pkg_val=$(grep '^Package:' "$CTRL_FILE" | sed 's/^Package:[[:space:]]*//' || true)
+ver_val=$(grep '^Version:' "$CTRL_FILE" | sed 's/^Version:[[:space:]]*//' || true)
+arch_val=$(grep '^Architecture:' "$CTRL_FILE" | sed 's/^Architecture:[[:space:]]*//' || true)
+dep_val=$(grep '^Depends:' "$CTRL_FILE" | sed 's/^Depends:[[:space:]]*//' || true)
+
+if [[ -z "$pkg_val" || -z "$ver_val" || -z "$arch_val" || -z "$dep_val" ]]; then
+  echo "ERROR: Missing mandatory fields in DEBIAN/control (Package, Version, Architecture, Depends)" >&2
+  exit 78
+fi
+
+if [[ ! "$ver_val" =~ ^[0-9][a-zA-Z0-9.+~-]*$ ]]; then
+  echo "ERROR: Invalid Version format in DEBIAN/control: '$ver_val'" >&2
+  exit 78
+fi
+
+if [[ ! "$pkg_val" =~ ^[a-z0-9.+-]+$ ]]; then
+  echo "ERROR: Invalid Package format in DEBIAN/control: '$pkg_val'" >&2
+  exit 78
+fi
+
 # Generate DEBIAN/postinst (post-installation script)
 cat << 'POSTINST_EOF' > "$STAGE_DIR/DEBIAN/postinst"
 #!/bin/sh


### PR DESCRIPTION
## Resumo
Added strict validation for the `DEBIAN/control` file mandatory fields (`Package`, `Version`, `Architecture`, `Depends`) and verified their formats using guard clauses prior to building the Debian package. The script now fails fast with sysexits `EX_CONFIG` (78) upon detecting missing or invalid field values, enforcing operational script reliability.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(packaging): validate DEBIAN/control... | Added mandatory fields and format validation for DEBIAN/control. | To prevent generating malformed Debian packages and failing fast on configuration issues. | Uses regex to validate Package and Version formats, and exits with sysexit 78. |

## Labels
type:packaging, type:scripts, type:security

## Validacao
shellcheck cannot be run as it is unavailable in the environment. Manual test executed via `bash -n scripts/package/build-deb-package.sh`.

## Rollback trigger
If the Debian packaging pipeline fails due to overly strict regex validations on standard or legacy package versions, revert this commit.

---
*PR created automatically by Jules for task [5151663695581979446](https://jules.google.com/task/5151663695581979446) started by @emersonbusson*