### PR TITLE
ci: harden comment-language workflow concurrency and inputs

### DIFF
--- a/.github/workflows/comment-language.yml
+++ b/.github/workflows/comment-language.yml
@@ -6,7 +6,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: comment-language-${{ github.workflow }}-${{ github.ref }}
+  group: comment-language-${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -21,10 +21,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fail if script is missing
+        if: hashFiles('tools/ci/check-comment-language.mjs') == ''
+        run: |
+          echo "Error: Required script tools/ci/check-comment-language.mjs is missing."
+          exit 69
+
       - name: Check added repository text uses canonical English
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: >-
           node tools/ci/check-comment-language.mjs
-          --diff "origin/${{ github.base_ref }}"
+          --diff "origin/${BASE_REF}"
 
 
   comment-language-summary:


### PR DESCRIPTION
## Resumo
Update comment-language workflow to fix PR concurrency grouping, add file guard clauses, and resolve a potential command injection vector.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | fix concurrency grouping | To ensure redundant in-progress runs for the same PR head branch are properly canceled. | Group uses github.head_ref \|\| github.ref. |
| 2 | add script guard clause | To prevent script execution failure when the required script is missing. | Validates hashFiles('tools/ci/check-comment-language.mjs') != '' and exits with 69. |
| 3 | sanitize input | To prevent command injection vulnerabilities. | Binds github.base_ref to an environment variable instead of inline interpolation. |

## Issue
Prompt OpsInfra-100 (day 2026-09-01) - comment-language.yml

## Responsavel
jules

## Labels
type:ci, type:security

## Validacao
actionlint .github/workflows/comment-language.yml

## Rollback trigger
Revert if the CI pipeline fails due to the concurrency change or if the script validation fails.

---
*PR created automatically by Jules for task [2714145975545286755](https://jules.google.com/task/2714145975545286755) started by @emersonbusson*