### PR TITLE
feat(ci): pin security scanning actions and add SARIF upload

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -26,6 +27,20 @@ jobs:
         uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+          GITLEAKS_ENABLE_SUMMARY: true
+
+      - name: Validate Gitleaks SARIF
+        run: |
+          set -euo pipefail
+          test -s results.sarif
+          jq -e '.version == "2.1.0" and (.runs | type == "array")' results.sarif >/dev/null
+
+      - name: Upload Gitleaks SARIF
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+        if: always() && hashFiles('results.sarif') != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        with:
+          sarif_file: results.sarif
 
   gitleaks-summary:
     name: gitleaks-summary

--- a/docs/governance/ci-contract.json
+++ b/docs/governance/ci-contract.json
@@ -115,7 +115,8 @@
       "policy": {
         "timeout_minutes": 30,
         "permissions": {
-          "contents": "read"
+          "contents": "read",
+          "security-events": "write"
         },
         "permissions_scope": "job",
         "action_pinning": "full-sha",
@@ -273,7 +274,10 @@
           "cancel_in_progress": true
         }
       },
-      "required_commands": [],
+      "required_commands": [
+        "test -s results.sarif",
+        "jq -e '.version == \"2.1.0\" and (.runs | type == \"array\")' results.sarif"
+      ],
       "open_gaps": []
     },
     {
@@ -294,7 +298,8 @@
       "policy": {
         "timeout_minutes": 30,
         "permissions": {
-          "contents": "read"
+          "contents": "read",
+          "security-events": "write"
         },
         "permissions_scope": "job",
         "action_pinning": "full-sha",
@@ -304,7 +309,10 @@
           "cancel_in_progress": true
         }
       },
-      "required_commands": [],
+      "required_commands": [
+        "test -s results.sarif",
+        "jq -e '.version == \"2.1.0\" and (.runs | type == \"array\")' results.sarif"
+      ],
       "open_gaps": []
     },
     {

--- a/tools/ci/check-ci-contract.test.mjs
+++ b/tools/ci/check-ci-contract.test.mjs
@@ -1104,6 +1104,19 @@ test('ci_contract_requires_fail_closed_trivy_sarif_publication', () => {
   assert.doesNotMatch(workflow, /name: Upload Trivy SARIF[\s\S]{0,300}continue-on-error:\s*true/)
 })
 
+test('ci_contract_requires_fail_closed_gitleaks_sarif_publication', () => {
+  const contract = JSON.parse(readFileSync(path.join(ROOT, 'docs', 'governance', 'ci-contract.json'), 'utf8'))
+  const gate = contract.gates.find((item) => item.id === 'gitleaks')
+  const workflow = readFileSync(path.join(ROOT, gate.workflow), 'utf8')
+
+  assert.deepEqual(gate.allowed_continue_on_error_steps ?? [], [])
+  assert.ok(gate.required_commands.includes('test -s results.sarif'))
+  assert.ok(gate.required_commands.includes("jq -e '.version == \"2.1.0\" and (.runs | type == \"array\")' results.sarif"))
+  assert.match(workflow, /name: Validate Gitleaks SARIF[\s\S]*test -s results\.sarif/)
+  assert.match(workflow, /uses: github\/codeql-action\/upload-sarif@[0-9a-f]{40}[\s\S]*sarif_file: results\.sarif/)
+  assert.doesNotMatch(workflow, /name: Upload Gitleaks SARIF[\s\S]{0,300}continue-on-error:\s*true/)
+})
+
 test('closed_pull_request_cancellation_has_minimum_permission', () => {
   const workflow = readFileSync(path.join(ROOT, '.github', 'workflows', 'cancel-closed-pr.yml'), 'utf8')
   assert.match(workflow, /pull_request:\n\s+types: \[closed\]/)


### PR DESCRIPTION
## Resumo
Add fail-closed SARIF publishing to the standalone Gitleaks workflow, matching the security contract for Trivy. Required CodeQL action was pinned to the explicitly required v4 SHA `db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|--------|-----------|-------------|----------|
| feat(ci): pin security scanning actions and add SARIF upload | Modified gitleaks workflow to output and validate `results.sarif` | Required CodeQL SARIF publishing matching Trivy | Enforced with `test -s` and strict `jq -e` JSON schema validation; added CI contract test cases. |

## Labels
type:ci, type:security

## Validacao
```bash
node tools/ci/check-ci-contract.test.mjs
node tools/ci/check-ci-contract.mjs --check-local
```

## Rollback trigger
Any Actionlint parsing failure or broken SARIF schema on Gitleaks results.

---
*PR created automatically by Jules for task [1599966051053028132](https://jules.google.com/task/1599966051053028132) started by @emersonbusson*