### PR TITLE
feat(packaging): add strict checkpatch.pl validation for LKML patches

### DIFF
--- a/scripts/package/generate-kernel-patchset.sh
+++ b/scripts/package/generate-kernel-patchset.sh
@@ -40,4 +40,22 @@ Signed-off-by: Emerson Busson
 COVER_EOF
 
 echo "✓ Cover letter created: $OUT_DIR/0000-cover-letter.patch"
+CHECKPATCH="scripts/checkpatch.pl"
+if [[ ! -x "$CHECKPATCH" ]]; then
+    echo "Error: $CHECKPATCH is missing or not executable." >&2
+    exit 69
+fi
+
+echo "==> Validating generated patches with checkpatch.pl..."
+for patch in "$OUT_DIR"/*.patch; do
+    if [[ ! -f "$patch" ]]; then
+        continue
+    fi
+    echo "  -> Checking $patch..."
+    if ! "$CHECKPATCH" --strict "$patch"; then
+        echo "Error: checkpatch.pl found errors in $patch" >&2
+        exit 74
+    fi
+done
+
 echo "✓ LKML patchset generation complete."


### PR DESCRIPTION
## Resumo
Added strict LKML format validation to the patchset generation script using checkpatch.pl. The script now fails fast if checkpatch is missing or if any patch fails strict validation, using sysexits.h standard exit codes.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(packaging): add strict checkpatch.pl validation for LKML patches | Added validation logic | To guarantee only clean patches are exported | Used sysexits.h EX_UNAVAILABLE and EX_IOERR exit codes. |

## Labels
type:packaging, type:scripts

## Validacao
echo "shellcheck cannot be run as it is unavailable in the environment."
(Verified via bash syntax execution of the script itself).

## Rollback trigger
Revert if the script incorrectly rejects valid LKML patches.

---
*PR created automatically by Jules for task [4239714134919061503](https://jules.google.com/task/4239714134919061503) started by @emersonbusson*