### PR TITLE
feat(packaging): add guard clauses for git send-email config

### DIFF
--- a/scripts/package/send-lkml-patchset.sh
+++ b/scripts/package/send-lkml-patchset.sh
@@ -3,6 +3,21 @@
 # Interactive and secure LKML patchset dispatcher for RamShared
 set -euo pipefail
 
+if ! command -v git >/dev/null 2>&1; then
+    echo "❌ Error: git is not installed or not in PATH."
+    exit 69 # EX_UNAVAILABLE
+fi
+
+if ! git config --get sendemail.smtpserver >/dev/null 2>&1; then
+    echo "❌ Error: git sendemail.smtpserver is not configured."
+    exit 78 # EX_CONFIG
+fi
+
+if ! git config --get sendemail.smtpuser >/dev/null 2>&1; then
+    echo "❌ Error: git sendemail.smtpuser is not configured."
+    exit 78 # EX_CONFIG
+fi
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 


### PR DESCRIPTION
Resumo
Added guard clauses to `scripts/package/send-lkml-patchset.sh` to validate `git` presence and `git sendemail` configurations (smtpserver and smtpuser) before execution. This fail-fast mechanism prevents late failures during LKML patchset dispatch.

Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(packaging): add guard clauses for git send-email config | Added validations for `git`, `smtpserver`, and `smtpuser` at the top of the script. | To enforce the fail-fast principle and prevent interactive prompting/execution failures when git configurations are missing. | Used sysexits.h exit codes (69 for EX_UNAVAILABLE, 78 for EX_CONFIG). |

Labels
type:packaging, type:scripts, type:security

Validacao
shellcheck cannot be run as it is unavailable in the environment.

Rollback trigger
If validly configured `git send-email` setups fail to pass the newly introduced `git config --get` checks, revert the commit.

---
*PR created automatically by Jules for task [2673627284828657931](https://jules.google.com/task/2673627284828657931) started by @emersonbusson*