### PR TITLE
chore: document install.sh modification block

### DIFF
--- a/docs/jules/findings/install-idempotent.md
+++ b/docs/jules/findings/install-idempotent.md
@@ -1,0 +1,8 @@
+FINDING_ONLY: Safe modification of scripts/safety/install.sh is impossible.
+Evidence: The script is intentionally retained as an explicit disabled-staging boundary.
+It contains the following comments:
+# Legacy installer retained only as an explicit disabled-staging boundary.
+# It must not write system paths, load modules, reload a manager, or arrange
+# boot/service activation. A future attended transaction needs its own sealed
+# implementation and approval; it is deliberately not provided here.
+Any modification to enable version comparison and clean upgrades would violate its primary objective of being explicitly disabled and refusing installation.


### PR DESCRIPTION
## Resumo
Produced a FINDING_ONLY document in `docs/jules/findings/install-idempotent.md` explaining why `scripts/safety/install.sh` cannot be safely modified. The script is explicitly marked as a "legacy installer retained only as an explicit disabled-staging boundary" and instructs against modifying it for safe operations. As per the IMMUTABLE CONTRACT rule #4, a FINDING_ONLY report was created.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `<hash>` | Documented inability to modify install.sh | The target file `scripts/safety/install.sh` is an explicit disabled-staging boundary and explicitly states it must not be modified to enable installations. | `<details><summary>Detalhes</summary>Created docs/jules/findings/install-idempotent.md to capture the safety refusal. No code changes were made.</details>` |

## Labels
type:scripts, area:packaging, type:security

## Validacao
echo "shellcheck cannot be run as it is unavailable in the environment."

## Rollback trigger
Not applicable (FINDING_ONLY).

---
*PR created automatically by Jules for task [14947048564731501363](https://jules.google.com/task/14947048564731501363) started by @emersonbusson*