### PR TITLE
build: enforce guard clauses for binary artifacts before bundling

### DIFF
--- a/scripts/package/build-linux-bundle.sh
+++ b/scripts/package/build-linux-bundle.sh
@@ -69,11 +69,18 @@ if [[ $SKIP_BUILD -eq 0 ]]; then
 fi
 
 for binary in ramshared ramsharedd; do
-  [[ -x $TARGET_DIR/$binary ]] || {
+  if [[ ! -x $TARGET_DIR/$binary ]]; then
     printf 'missing release binary: %s\n' "$TARGET_DIR/$binary" >&2
-    exit 1
-  }
+    exit 69
+  fi
 done
+
+while IFS= read -r -d '' lib; do
+  if [[ ! -f $lib || ! -r $lib ]]; then
+    printf 'missing or unreadable release shared library: %s\n' "$lib" >&2
+    exit 69
+  fi
+done < <(find "$TARGET_DIR" -maxdepth 1 -name "*.so" -print0 2>/dev/null || true)
 
 install -d -m 0755 "$STAGE_RELEASE/bin" "$STAGE_RELEASE/scripts/safety" "$STAGE_RELEASE/systemd" \
   "$STAGE_RELEASE/systemd/docker.service.d" "$STAGE_RELEASE/systemd/containerd.service.d" \


### PR DESCRIPTION
## Resumo
Enforce infrastructure hardening principles in the Linux packaging script by applying fail-fast guard clauses. Replaced hardcoded exit 1 with semantic `sysexits.h` code 69 (EX_UNAVAILABLE) for missing release binaries. Additionally, introduced dynamic validation to ensure that if any shared libraries (`.so`) are produced by the build, they are also verified to be present and readable before assembling the distribution bundle.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| build: enforce guard clauses for binary artifacts before bundling | Updated script to use EX_UNAVAILABLE (69) and dynamically check for `.so` libraries. | To meet operational script hardening requirements by failing fast on missing artifacts with specific semantic exit codes. | Modified `scripts/package/build-linux-bundle.sh` to enforce missing artifact guard clauses. |

## Labels
type:packaging, type:scripts, type:security

## Validacao
`shellcheck` cannot be run as it is unavailable in the environment. `bash scripts/package/build-linux-bundle.sh --skip-build` executed successfully in the workspace.

## Rollback trigger
If the bundling process fails on a clean CI build due to valid but unreadable shared objects, or if exit code 69 disrupts CI downstream packaging orchestration, revert this PR.

---
*PR created automatically by Jules for task [8433739030801634400](https://jules.google.com/task/8433739030801634400) started by @emersonbusson*