### PR TITLE
update build-rpm-package.sh to use specific exit codes for rpmbuild failures

### DIFF
--- a/scripts/package/build-rpm-package.sh
+++ b/scripts/package/build-rpm-package.sh
@@ -81,7 +81,31 @@ SPEC_EOF
 
 if command -v rpmbuild >/dev/null 2>&1; then
   echo "==> Executing rpmbuild..."
-  rpmbuild --define "_topdir $RPM_ROOT" -bb "$SPEC_FILE"
+  RPM_LOG=$(mktemp)
+
+  if ! rpmbuild --define "_topdir $RPM_ROOT" -bb "$SPEC_FILE" > "$RPM_LOG" 2>&1; then
+    cat "$RPM_LOG"
+    if grep -q "Bad exit status from .* (%prep)" "$RPM_LOG"; then
+      echo "ERROR: rpmbuild prep stage failed" >&2
+      rm -f "$RPM_LOG"
+      exit 65
+    elif grep -q "Bad exit status from .* (%build)" "$RPM_LOG"; then
+      echo "ERROR: rpmbuild build stage failed" >&2
+      rm -f "$RPM_LOG"
+      exit 74
+    elif grep -q "Bad exit status from .* (%install)" "$RPM_LOG"; then
+      echo "ERROR: rpmbuild install stage failed" >&2
+      rm -f "$RPM_LOG"
+      exit 73
+    else
+      echo "ERROR: rpmbuild failed" >&2
+      rm -f "$RPM_LOG"
+      exit 1
+    fi
+  fi
+  cat "$RPM_LOG"
+  rm -f "$RPM_LOG"
+
   cp "$RPM_ROOT"/RPMS/*/*.rpm "$OUT_DIR/" 2>/dev/null || true
   echo "✓ RPM package built under $OUT_DIR/"
 else


### PR DESCRIPTION
Resumo: Update scripts/package/build-rpm-package.sh to use distinct sysexits.h exit codes for prep (65), build (74), and install (73) failures.
Commits table:
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | update build-rpm-package.sh to use specific exit codes for rpmbuild failures | to follow infrastructure hardening principles regarding semantic exit codes | Modified script to run full rpmbuild once and parse the output on failure to assign the correct exit code without destroying package viability. |
Labels: type:scripts, type:packaging
Validacao: Use run_in_bash_session to execute echo 'shellcheck cannot be run as it is unavailable in the environment.'.
Rollback trigger: If rpmbuild parsing logic fails or causes unintended failures during CI packaging stage.

---
*PR created automatically by Jules for task [13565617557632614785](https://jules.google.com/task/13565617557632614785) started by @emersonbusson*