### PR TITLE
feat(packaging): add dry-run mode to LKML patchset dispatcher

### DIFF
--- a/scripts/package/send-lkml-patchset.sh
+++ b/scripts/package/send-lkml-patchset.sh
@@ -16,6 +16,15 @@ LKML_TO="linux-block${EMAIL_AT}${VGER_DOMAIN}"
 AXBOE_CC="axboe${EMAIL_AT}${KERNEL_DOMAIN}"
 LKML_CC="linux-kernel${EMAIL_AT}${VGER_DOMAIN}"
 
+DRY_RUN=0
+if [ "${1:-}" = "--dry-run" ]; then
+    DRY_RUN=1
+elif [ $# -gt 0 ]; then
+    echo "❌ Error: Invalid argument: $1" >&2
+    echo "Usage: $0 [--dry-run]" >&2
+    exit 64
+fi
+
 echo "============================================================"
 echo "  🐧 RamShared — Linux Kernel LKML Patch Dispatcher"
 echo "============================================================"
@@ -36,6 +45,23 @@ echo "Sender: $SENDER_NAME <$SENDER_EMAIL>"
 echo "Destination: $LKML_TO (Jens Axboe)"
 echo "CC: $LKML_CC"
 echo ""
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo "==> [DRY RUN] Patch summary:"
+    for patch in "$OUT_DIR"/*.patch; do
+        if [ -f "$patch" ]; then
+            echo "  • $(basename "$patch")"
+        fi
+    done
+    echo ""
+    echo "==> [DRY RUN] Exact recipients:"
+    echo "  • To: $LKML_TO"
+    echo "  • Cc: $AXBOE_CC"
+    echo "  • Cc: $LKML_CC"
+    echo ""
+    echo "==> [DRY RUN] Execution complete. No emails were sent."
+    exit 0
+fi
 
 # Safely prompt for Gmail App Password (hidden input, no echo)
 read -r -s -p "Enter Gmail App Password (16 characters): " SMTP_PASS


### PR DESCRIPTION
## Resumo
Adicionado o parâmetro `--dry-run` ao script `send-lkml-patchset.sh` para exibir o resumo dos patches e os destinatários exatos sem enviar os e-mails, melhorando a segurança e o teste operacional (prevenindo envios acidentais para LKML). Adicionada também verificação para argumentos inválidos retornando erro semântico (64).

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(packaging): add dry-run mode to LKML patchset dispatcher | Adicionou flag `--dry-run` | Permitir verificação segura de destinatários antes do envio real | Retorna 64 para flags inválidas, intercepta o envio após mostrar a lista e sai com código 0. |

## Labels
type:scripts, type:packaging

## Validacao
`shellcheck` cannot be run as it is unavailable in the environment. Manual validation executed via `run_in_bash_session` to test both regular runs (with prompt) and `--dry-run` executions.

## Rollback trigger
Se o script falhar ao processar os argumentos corretamente ou se `--dry-run` acidentalmente invocar `git send-email` ou solicitar senha em ambientes CI automatizados, reverter imediatamente.

---
*PR created automatically by Jules for task [15844256601890264501](https://jules.google.com/task/15844256601890264501) started by @emersonbusson*