### PR TITLE
feat(scripts): validate baseline and comparison swap configurations before measurement

### DIFF
--- a/scripts/p0/measure-swap-compare.sh
+++ b/scripts/p0/measure-swap-compare.sh
@@ -13,7 +13,33 @@ LABEL="${2:-$TARGET}"
 SIZE="${3:-256M}"
 RT="${4:-12}"
 
-command -v fio >/dev/null || { echo "fio ausente" >&2; exit 2; }
+# Guard check: fio exists
+command -v fio >/dev/null || { echo "Error: fio ausente" >&2; exit 69; }
+
+# Guard check: Validate inputs
+if [[ ! "$RT" =~ ^[0-9]+$ ]] || [[ "$RT" -eq 0 ]]; then
+  echo "Error: runtime_s ($RT) must be a positive integer." >&2
+  exit 64
+fi
+
+if [[ ! "$SIZE" =~ ^[0-9]+[bkmgBKMG]?$ ]]; then
+  echo "Error: size ($SIZE) format invalid." >&2
+  exit 64
+fi
+
+# Guard check: both baseline and comparison swap devices must be configured and active.
+# We decode \040 to space for path validation.
+if ! sed 's/\\040/ /g' /proc/swaps | awk '
+  NR > 1 {
+    if ($1 ~ /^\/dev\/(nbd|ublk|zram)/) comp = 1
+    else base = 1
+  }
+  END { exit (comp && base ? 0 : 1) }
+'; then
+  echo "Error: Both baseline and comparison swap devices must be configured and active in /proc/swaps." >&2
+  exit 78
+fi
+
 
 IS_FILE=0
 [ -b "$TARGET" ] || IS_FILE=1


### PR DESCRIPTION
Resumo: Added strict guard clauses to `scripts/p0/measure-swap-compare.sh` to validate `fio` dependency, numeric inputs, and importantly, ensure both baseline and comparison swap devices are active in `/proc/swaps`.
Commits:
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): add guard clauses and swap validation to measure-swap-compare.sh | Added `EX_USAGE` checks for inputs, `EX_UNAVAILABLE` for `fio`, and an `awk` check for `/proc/swaps` returning `EX_CONFIG` if baseline/comparison devices are missing. | To adhere to RamShared's architectural principles for script hardening, fail-fast mechanics, and semantic error codes before executing bounded tests. | Decodes `\040` spaces in `/proc/swaps` paths. |
Labels: type:scripts, type:security
Validacao: shellcheck cannot be run as it is unavailable in the environment. `bash scripts/p0/measure-swap-compare.sh || true` executed.
Rollback trigger: If the script fails in valid dual-tier swap benchmark topologies due to over-restrictive `awk` parsing of `/proc/swaps`.
Issue: OpsInfra100/2026-09-01/p0-observability/093
Responsavel: Jules

---
*PR created automatically by Jules for task [16567090634919549847](https://jules.google.com/task/16567090634919549847) started by @emersonbusson*