### PR TITLE
feat(scripts): add guard clauses for CUDA toolkit and GPU compute capability

### DIFF
--- a/scripts/p0/Start-CudaVramWorkload.ps1
+++ b/scripts/p0/Start-CudaVramWorkload.ps1
@@ -23,35 +23,37 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$system32 = [Environment]::GetFolderPath("System")
-$nvcudaPath = Join-Path $system32 "nvcuda.dll"
-if (-not (Test-Path $nvcudaPath)) {
-    [System.Environment]::ExitCode = 69
-    throw [System.Exception]::new("nvcuda.dll not found in $system32. Ensure NVIDIA drivers are installed.")
-}
-
-$nvidiaSmi = Get-Command nvidia-smi.exe -ErrorAction SilentlyContinue
-if ($null -eq $nvidiaSmi) {
-    [System.Environment]::ExitCode = 69
-    throw [System.Exception]::new("nvidia-smi.exe not found in PATH.")
-}
-
-try {
-    $computeCapOutput = & nvidia-smi.exe --query-gpu=compute_cap --format=csv,noheader -i $Device 2>&1
-    if ($LASTEXITCODE -ne 0) {
+if (-not $CleanupSelfTest -and -not $HandshakeSelfTest) {
+    $system32 = [Environment]::GetFolderPath("System")
+    $nvcudaPath = Join-Path $system32 "nvcuda.dll"
+    if (-not (Test-Path $nvcudaPath)) {
         [System.Environment]::ExitCode = 69
-        throw [System.Exception]::new("nvidia-smi.exe failed to query GPU compute capability.")
+        throw [System.Exception]::new("nvcuda.dll not found in $system32. Ensure NVIDIA drivers are installed.")
     }
 
-    $computeCapStr = ($computeCapOutput -join "`n").Trim()
-    $computeCap = [double]$computeCapStr
-
-    if ($computeCap -lt 6.0) {
-        [System.Environment]::ExitCode = 78
-        throw [System.Exception]::new("GPU compute capability $computeCap is below minimum required 6.0.")
+    $nvidiaSmi = Get-Command nvidia-smi.exe -ErrorAction SilentlyContinue
+    if ($null -eq $nvidiaSmi) {
+        [System.Environment]::ExitCode = 69
+        throw [System.Exception]::new("nvidia-smi.exe not found in PATH.")
     }
-} catch {
-    throw
+
+    try {
+        $computeCapOutput = & nvidia-smi.exe --query-gpu=compute_cap --format=csv,noheader -i $Device 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            [System.Environment]::ExitCode = 69
+            throw [System.Exception]::new("nvidia-smi.exe failed to query GPU compute capability.")
+        }
+
+        $computeCapStr = ($computeCapOutput -join "`n").Trim()
+        $computeCap = [double]$computeCapStr
+
+        if ($computeCap -lt 6.0) {
+            [System.Environment]::ExitCode = 78
+            throw [System.Exception]::new("GPU compute capability $computeCap is below minimum required 6.0.")
+        }
+    } catch {
+        throw
+    }
 }
 
 if (-not ("RamSharedCudaVramWorkload" -as [type])) {

--- a/scripts/p0/Start-CudaVramWorkload.ps1
+++ b/scripts/p0/Start-CudaVramWorkload.ps1
@@ -23,6 +23,37 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+$system32 = [Environment]::GetFolderPath("System")
+$nvcudaPath = Join-Path $system32 "nvcuda.dll"
+if (-not (Test-Path $nvcudaPath)) {
+    [System.Environment]::ExitCode = 69
+    throw [System.Exception]::new("nvcuda.dll not found in $system32. Ensure NVIDIA drivers are installed.")
+}
+
+$nvidiaSmi = Get-Command nvidia-smi.exe -ErrorAction SilentlyContinue
+if ($null -eq $nvidiaSmi) {
+    [System.Environment]::ExitCode = 69
+    throw [System.Exception]::new("nvidia-smi.exe not found in PATH.")
+}
+
+try {
+    $computeCapOutput = & nvidia-smi.exe --query-gpu=compute_cap --format=csv,noheader -i $Device 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        [System.Environment]::ExitCode = 69
+        throw [System.Exception]::new("nvidia-smi.exe failed to query GPU compute capability.")
+    }
+
+    $computeCapStr = ($computeCapOutput -join "`n").Trim()
+    $computeCap = [double]$computeCapStr
+
+    if ($computeCap -lt 6.0) {
+        [System.Environment]::ExitCode = 78
+        throw [System.Exception]::new("GPU compute capability $computeCap is below minimum required 6.0.")
+    }
+} catch {
+    throw
+}
+
 if (-not ("RamSharedCudaVramWorkload" -as [type])) {
     Add-Type -TypeDefinition @'
 using System;


### PR DESCRIPTION
## Resumo
Adicionados guard clauses no script `Start-CudaVramWorkload.ps1` para validar requisitos do CUDA (presença do `nvcuda.dll` e `nvidia-smi.exe`) e garantir que a capacidade computacional da GPU seja >= 6.0 antes de iniciar o workload.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Adicionou validação CUDA e GPU no script | Para garantir que o workload falhe rapidamente se os drivers ou a GPU não suportarem os recursos, protegendo a infraestrutura. | <details>Verificou `nvcuda.dll` via `Test-Path` no System32, e verificou o `nvidia-smi.exe`. Validou o `compute_cap` (>= 6.0) via consulta `nvidia-smi` usando tratamento seguro contra erros e códigos de saída semânticos (69, 78) conforme diretrizes de hardening operacional.</details> |

## Issue
Closes #096

## Responsavel
@jules

## Labels
type:scripts, type:security, area:p0

## Validacao
`echo "PSScriptAnalyzer cannot be run as pwsh is unavailable in the environment."`

## Rollback trigger
Se o script falhar incorretamente em sistemas onde o ambiente CUDA estiver corretamente configurado.

---
*PR created automatically by Jules for task [12275694687437649192](https://jules.google.com/task/12275694687437649192) started by @emersonbusson*