### PR TITLE
kernel-ci: cache kernel build artifacts

### DIFF
--- a/.github/workflows/kernel-ci.yml
+++ b/.github/workflows/kernel-ci.yml
@@ -69,6 +69,14 @@ jobs:
         if: matrix.compiler == 'clang'
         run: sudo apt-get update -qq && sudo apt-get install -y -qq clang
 
+      - name: Cache kernel object files
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: "**/*.o"
+          key: kernel-obj-${{ matrix.compiler }}-${{ matrix.arch }}-${{ hashFiles('**/*.c', '**/*.h', '**/Makefile') }}
+          restore-keys: |
+            kernel-obj-${{ matrix.compiler }}-${{ matrix.arch }}-
+
       - name: Run build matrix (${{ matrix.compiler }} / ${{ matrix.arch }})
         run: ./scripts/ci/check-kernel-build-matrix.sh "${{ matrix.compiler }}" "${{ matrix.arch }}"
 


### PR DESCRIPTION
## Resumo
Add actions/cache for kernel object files keyed on source tree hash to speed up incremental builds.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| kernel-ci: cache kernel build artifacts | Added actions/cache to kernel-build-matrix job. | Speed up incremental builds. | Keyed on source tree hash (`**/*.c`, `**/*.h`, `**/Makefile`). |

## Issue
OpsInfra100/2026-09-01/ci-workflows/061

## Responsavel
Jules

## Labels
type:ci, type:scripts

## Validacao
`./actionlint .github/workflows/kernel-ci.yml`

## Rollback trigger
CI jobs failing on actions/cache step or cache corruption causing subsequent step failures.

---
*PR created automatically by Jules for task [18345893391713475646](https://jules.google.com/task/18345893391713475646) started by @emersonbusson*