### PR TITLE
feat(scripts): add wddm 2.7 gpu presence validation

### DIFF
--- a/scripts/p0/Invoke-ExternalGpuWddmPressureAudit.ps1
+++ b/scripts/p0/Invoke-ExternalGpuWddmPressureAudit.ps1
@@ -17,7 +17,9 @@ param(
     [string]$RamsharedExe = "",
     [switch]$RunGpuGate,
     [string]$WorkloadCommand = "",
+    [ValidateRange(0, 1048576)]
     [int]$MinDeltaMib = 256,
+    [ValidateNotNullOrEmpty()]
     [string]$OutDir = "ramshared-external-gpu-wddm-pressure-audit-$(Get-Date -Format yyyyMMdd-HHmmss)"
 )
 
@@ -27,9 +29,41 @@ function L([string]$Message) {
     Write-Host "[external-gpu-wddm-pressure-audit] $Message"
 }
 
+function Assert-WddmGpuPresence {
+    $drivers = Get-CimInstance -ClassName Win32_PnPSignedDriver -Filter "DeviceClass = 'DISPLAY'" -ErrorAction SilentlyContinue
+    if (-not $drivers) {
+        throw [System.Management.Automation.ItemNotFoundException]::new("No GPU adapters found via WMI.")
+    }
+
+    $validWddm = $false
+    foreach ($driver in $drivers) {
+        if ([string]::IsNullOrWhiteSpace($driver.DriverVersion)) { continue }
+        $parts = $driver.DriverVersion.Split('.')
+        if ($parts.Length -ge 1) {
+            $major = 0
+            if ([int]::TryParse($parts[0], [ref]$major)) {
+                if ($major -ge 27) {
+                    $validWddm = $true
+                    break
+                }
+            }
+        }
+    }
+    if (-not $validWddm) {
+        throw [System.NotSupportedException]::new("External GPU adapter requires WDDM driver version >= 2.7.")
+    }
+}
+
+Assert-WddmGpuPresence
+
 function Resolve-RamsharedExe {
     param([string]$Candidate)
-    if (-not [string]::IsNullOrWhiteSpace($Candidate)) { return $Candidate }
+    if (-not [string]::IsNullOrWhiteSpace($Candidate)) {
+        if (-not (Test-Path -LiteralPath $Candidate)) {
+            throw [System.IO.FileNotFoundException]::new("Provided RamsharedExe not found.", $Candidate)
+        }
+        return $Candidate
+    }
     $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
     foreach ($path in @(
         (Join-Path $repoRoot "target\release\ramshared.exe"),
@@ -48,7 +82,7 @@ function Resolve-InputPath {
     if (Test-Path -LiteralPath $Path) {
         return (Resolve-Path -LiteralPath $Path).Path
     }
-    return $Path
+    throw [System.IO.FileNotFoundException]::new("Provided input path not found.", $Path)
 }
 
 New-Item -Force -ItemType Directory -Path $OutDir | Out-Null


### PR DESCRIPTION
Resumo: Adiciona validação de pré-requisitos no script `Invoke-ExternalGpuWddmPressureAudit.ps1` para garantir a presença de uma GPU com driver WDDM >= 2.7 e aplica diretrizes de segurança com `[ValidateRange]` e `[ValidateNotNullOrEmpty]`. Também aprimora a resolução de caminhos com falha rápida (`fail-fast`).

Commits:
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): add wddm 2.7 gpu presence validation | Adicionada a função `Assert-WddmGpuPresence` e restrições de validação de parâmetro | Para assegurar o fail-fast caso os pré-requisitos do WDDM não sejam atingidos ou se parâmetros inválidos forem fornecidos, cumprindo a diretriz do OpsInfra-100 | Lança exceções tipadas para drivers ausentes ou incompatíveis e arquivos não encontrados. |

Labels: type:scripts, type:security
Validacao: `pwsh scripts/p0/Test-ExternalGpuWddmPressureAuditStatic.ps1` (simulado via fallback devido à indisponibilidade do pwsh no ambiente)
Rollback trigger: Reverter se ocorrerem falsos negativos na detecção da versão do WDDM que bloqueiem fluxos de telemetria existentes.
Issue: 097
Responsavel: OpsInfra100/2026-09-01/p0-observability/097

---
*PR created automatically by Jules for task [7735218792681160740](https://jules.google.com/task/7735218792681160740) started by @emersonbusson*