### PR TITLE
feat(scripts): add guard clauses for GPU workload gate

### DIFF
--- a/scripts/p0/Invoke-GpuWorkloadGate.ps1
+++ b/scripts/p0/Invoke-GpuWorkloadGate.ps1
@@ -14,18 +14,27 @@
 [CmdletBinding(DefaultParameterSetName = "Attach")]
 param(
     [Parameter(ParameterSetName = "Launch", Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
     [string]$WorkloadCommand,
 
     [Parameter(ParameterSetName = "Attach")]
     [switch]$AttachOnly,
 
+    [ValidateRange(1, 86400)]
     [int]$IdleDurationSec = 15,
+    [ValidateRange(1, 86400)]
     [int]$LoadedDurationSec = 60,
+    [ValidateRange(1, 86400)]
     [int]$RecoveryDurationSec = 15,
+    [ValidateRange(100, 60000)]
     [int]$IntervalMs = 500,
+    [ValidateRange(0, 32)]
     [int]$GpuIndex = 0,
+    [ValidateRange(1, 131072)]
     [int]$MinDeltaMib = 256,
+    [ValidateNotNullOrEmpty()]
     [string]$WorkloadLabel = "external-gpu-workload",
+    [ValidateNotNullOrEmpty()]
     [string]$OutDir = "ramshared-gpu-workload-gate-$(Get-Date -Format yyyyMMdd-HHmmss)"
 )
 
@@ -70,6 +79,13 @@ Require-Positive "LoadedDurationSec" $LoadedDurationSec
 Require-Positive "RecoveryDurationSec" $RecoveryDurationSec
 Require-Positive "IntervalMs" $IntervalMs
 Require-Positive "MinDeltaMib" $MinDeltaMib
+
+$hasNvidia = [bool](Get-Command "nvidia-smi" -ErrorAction SilentlyContinue)
+$hasAmd = [bool](Get-Command "rocm-smi" -ErrorAction SilentlyContinue)
+if (-not $hasNvidia -and -not $hasAmd) {
+    [System.Environment]::ExitCode = 69
+    throw [System.Exception]::new("Neither NVIDIA (nvidia-smi) nor AMD (rocm-smi) GPU driver runtime is accessible.")
+}
 
 if ($PSCmdlet.ParameterSetName -eq "Attach" -and -not $AttachOnly) {
     throw "Use -AttachOnly when the workload is started externally, or pass -WorkloadCommand."


### PR DESCRIPTION
Resumo: Added guard clauses and parameter validation to `Invoke-GpuWorkloadGate.ps1` to ensure GPU driver accessibility before workload dispatch and to validate inputs against physical limits.
Commits:
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): add guard clauses for GPU workload gate | Adicionado validação de parâmetros e verificação de drivers GPU. | Para alinhar com os princípios arquitetônicos e garantir falha rápida. | Adicionado `[ValidateRange]` e verificação para nvidia-smi/rocm-smi. |
Labels: type:scripts, type:security
Validacao: echo "PSScriptAnalyzer cannot be run as pwsh is unavailable in the environment."
Rollback trigger: If the script fails to run due to syntax errors or incorrect parameter validation preventing valid workloads.
Issue: p0-observability/094
Responsavel: Jules

---
*PR created automatically by Jules for task [1333186946620465798](https://jules.google.com/task/1333186946620465798) started by @emersonbusson*