### PR TITLE
feat: add explicit cgroup v2 and PSI guard clauses

### DIFF
--- a/scripts/safety/cascade-pressure-probe.sh
+++ b/scripts/safety/cascade-pressure-probe.sh
@@ -81,6 +81,20 @@ PY
 }
 
 need_root
+
+if [[ ! -f /sys/fs/cgroup/cgroup.controllers ]]; then
+  log "FAIL: cgroup v2 required"
+  exit 69
+fi
+if ! grep -qw memory /sys/fs/cgroup/cgroup.controllers; then
+  log "FAIL: memory controller not available"
+  exit 69
+fi
+if [[ ! -f /proc/pressure/memory ]]; then
+  log "FAIL: PSI interface not available"
+  exit 69
+fi
+
 read -r PZ PN PD <<<"$(read_prios)"
 if [[ -z "${PZ:-}" || -z "${PN:-}" || -z "${PD:-}" || "$PZ" -lt 0 || "$PN" -lt 0 || "$PD" -eq -1 ]]; then
   log "FAIL: need live zram + nbd + disk (sudo ramshared up first) prios=z:$PZ n:$PN d:$PD"
@@ -95,10 +109,6 @@ log "baseline prios ok: zram=$PZ nbd=$PN disk=$PD"
 read -r UZ0 UN0 UD0 <<<"$(read_used)"
 log "baseline used_kb: zram=$UZ0 nbd=$UN0 disk=$UD0"
 
-if [[ ! -d /sys/fs/cgroup ]]; then
-  log "FAIL: cgroup v2 required"
-  exit 1
-fi
 mkdir -p "$CG"
 # enable memory controller in parent if possible
 if [[ -w /sys/fs/cgroup/cgroup.subtree_control ]]; then

--- a/test_regex.js
+++ b/test_regex.js
@@ -1,0 +1,38 @@
+const body = `## Resumo
+Added explicit guard clauses to scripts/safety/cascade-pressure-probe.sh to validate the cgroup v2 mount, memory controller delegation, and the PSI memory interface. These will fail-fast with semantic exit code 69 (EX_UNAVAILABLE) if prerequisites are not met. The old, less specific directory check was removed.
+
+## Commits
+| Commit | O que fez | Por que fez | Detalhes |
+|---|---|---|---|
+| feat: add explicit cgroup v2 and PSI guard clauses | Added checks for /sys/fs/cgroup/cgroup.controllers, memory inside controllers, and /proc/pressure/memory returning EX_UNAVAILABLE (69) | Prevent test failure or unpredictable behavior on environments lacking strict cgroup v2 features and PSI support | Replaced the old -d /sys/fs/cgroup directory check with specific validations before calling read_prios |
+
+## Labels
+type:scripts, type:security, type:observability
+
+## Validacao
+shellcheck cannot be run...
+sudo bash scripts/safety/cascade-pressure-probe.sh || [ $? -eq 69 ]
+
+## Rollback trigger
+Revert if tests fail to run on legitimate environments that incorrectly appear to lack PSI or cgroup memory controller support.
+
+## Issue
+099
+
+## Responsavel
+jules`;
+
+const requiredSections = [
+  { name: 'Resumo', pattern: /^##\s+Resumo\s*$/im },
+  { name: 'Commits', pattern: /^##\s+Commits\s*$/im },
+  { name: 'Issue', pattern: /^##\s+Issue\s*$/im },
+  { name: 'Responsavel', pattern: /^##\s+Responsavel\s*$/im },
+  { name: 'Labels', pattern: /^##\s+Labels\s*$/im },
+  { name: 'Validacao', pattern: /^##\s+Validacao\s*$/im },
+  { name: 'Rollback trigger', pattern: /^##\s+Rollback trigger\s*$/im }
+];
+
+const missing = requiredSections
+  .filter(section => !section.pattern.test(body))
+  .map(section => section.name);
+console.log(missing);

--- a/test_regex2.js
+++ b/test_regex2.js
@@ -1,0 +1,35 @@
+const body = `## Resumo
+Added explicit guard clauses to scripts/safety/cascade-pressure-probe.sh to validate the cgroup v2 mount, memory controller delegation, and the PSI memory interface. These will fail-fast with semantic exit code 69 (EX_UNAVAILABLE) if prerequisites are not met. The old, less specific directory check was removed.
+
+## Commits: table
+| Commit | O que fez | Por que fez | Detalhes |
+|---|---|---|---|
+| feat: add explicit cgroup v2 and PSI guard clauses | Added checks for /sys/fs/cgroup/cgroup.controllers, memory inside controllers, and /proc/pressure/memory returning EX_UNAVAILABLE (69) | Prevent test failure or unpredictable behavior on environments lacking strict cgroup v2 features and PSI support | Replaced the old -d /sys/fs/cgroup directory check with specific validations before calling read_prios |
+
+## Labels
+type:scripts, type:security, type:observability
+
+## Validacao
+shellcheck cannot be run...
+sudo bash scripts/safety/cascade-pressure-probe.sh || [ $? -eq 69 ]
+
+## Rollback trigger
+Revert if tests fail to run on legitimate environments that incorrectly appear to lack PSI or cgroup memory controller support.
+
+Issue: 099
+Responsavel: jules`;
+
+const requiredSections = [
+  { name: 'Resumo', pattern: /^##\s+Resumo\s*$/im },
+  { name: 'Commits', pattern: /^##\s+Commits\s*$/im },
+  { name: 'Issue', pattern: /^##\s+Issue\s*$/im },
+  { name: 'Responsavel', pattern: /^##\s+Responsavel\s*$/im },
+  { name: 'Labels', pattern: /^##\s+Labels\s*$/im },
+  { name: 'Validacao', pattern: /^##\s+Validacao\s*$/im },
+  { name: 'Rollback trigger', pattern: /^##\s+Rollback trigger\s*$/im }
+];
+
+const missing = requiredSections
+  .filter(section => !section.pattern.test(body))
+  .map(section => section.name);
+console.log(missing);


### PR DESCRIPTION
## Resumo
Added explicit guard clauses to `scripts/safety/cascade-pressure-probe.sh` to validate the cgroup v2 mount, memory controller delegation, and the PSI memory interface. These will fail-fast with semantic exit code `69` (`EX_UNAVAILABLE`) if prerequisites are not met. The old, less specific directory check was removed.

## Commits: table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: add explicit cgroup v2 and PSI guard clauses | Added checks for `/sys/fs/cgroup/cgroup.controllers`, `memory` inside controllers, and `/proc/pressure/memory` returning EX_UNAVAILABLE (69) | Prevent test failure or unpredictable behavior on environments lacking strict cgroup v2 features and PSI support | Replaced the old `-d /sys/fs/cgroup` directory check with specific validations before calling `read_prios` |

## Labels
type:scripts, type:security, type:observability

## Validacao
shellcheck cannot be run...
sudo bash scripts/safety/cascade-pressure-probe.sh || [ $? -eq 69 ]

## Rollback trigger
Revert if tests fail to run on legitimate environments that incorrectly appear to lack PSI or cgroup memory controller support.

Issue: 099
Responsavel: jules

---
*PR created automatically by Jules for task [3538961237451856745](https://jules.google.com/task/3538961237451856745) started by @emersonbusson*