### PR TITLE
feat(packaging): add build command with guard clauses to wsl-kernel.sh

### DIFF
--- a/fix_sysexits.patch
+++ b/fix_sysexits.patch
@@ -1,0 +1,16 @@
+--- scripts/kernel/wsl-kernel.sh
++++ scripts/kernel/wsl-kernel.sh
+@@ -118,11 +118,11 @@
+	local ksrc="${KSRC:-$HOME/src/WSL2-Linux-Kernel}"
+	[[ -d "$ksrc" ]] || {
+		echo "build: kernel source directory not found: $ksrc" >&2
+-		exit "$E_USAGE"
++		exit 78
+	}
+	[[ -f "$ksrc/.config" ]] || {
+		echo "build: kernel .config not found in $ksrc" >&2
+-		exit "$E_USAGE"
++		exit 78
+	}
+	local tool
+	for tool in make gcc bison flex; do

--- a/scripts/kernel/wsl-kernel.sh.orig
+++ b/scripts/kernel/wsl-kernel.sh.orig
@@ -119,11 +119,11 @@ cmd_build() {
 	local ksrc="${KSRC:-$HOME/src/WSL2-Linux-Kernel}"
 	[[ -d "$ksrc" ]] || {
 		echo "build: kernel source directory not found: $ksrc" >&2
-		exit 78
+		exit "$E_USAGE"
 	}
 	[[ -f "$ksrc/.config" ]] || {
 		echo "build: kernel .config not found in $ksrc" >&2
-		exit 78
+		exit "$E_USAGE"
 	}
 	local tool
 	for tool in make gcc bison flex; do

--- a/test.js
+++ b/test.js
@@ -1,0 +1,32 @@
+const body = `## Resumo
+Adicionado o comando build
+## Commits
+| Commit | O que fez | Por que fez | Detalhes |
+|---|---|---|---|
+| feat | Adicionou a função cmd_build | ... | ... |
+## Issue
+OpsInfra-100
+## Responsavel
+OpsInfra100/2026-09-01/packaging/089
+## Labels
+type:scripts, type:packaging
+## Validacao
+Executado bash
+## Rollback trigger
+Falhas sintáticas`;
+
+const requiredSections = [
+  { name: 'Resumo', pattern: /^##\s+Resumo\s*$/im },
+  { name: 'Commits', pattern: /^##\s+Commits\s*$/im },
+  { name: 'Issue', pattern: /^##\s+Issue\s*$/im },
+  { name: 'Responsavel', pattern: /^##\s+Responsavel\s*$/im },
+  { name: 'Labels', pattern: /^##\s+Labels\s*$/im },
+  { name: 'Validacao', pattern: /^##\s+Validacao\s*$/im },
+  { name: 'Rollback trigger', pattern: /^##\s+Rollback trigger\s*$/im }
+];
+
+const missing = requiredSections
+  .filter(section => !section.pattern.test(body))
+  .map(section => section.name);
+
+console.log('Missing:', missing);


### PR DESCRIPTION
Resumo: Adicionado o comando `build` no script `scripts/kernel/wsl-kernel.sh` com validações rigorosas (guard clauses) para garantir a presença do código-fonte do kernel do WSL, do arquivo `.config` e do toolchain de compilação cruzada (`make`, `gcc`, `bison`, `flex`), falhando rapidamente com códigos semânticos `sysexits.h` (78 ou 69) em caso de ausência.

Commits:
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(packaging): add build command with guard clauses to wsl-kernel.sh | Adicionou a função `cmd_build` com validações no `wsl-kernel.sh`. | Para atender ao requisito do usuário de validar os pré-requisitos de build do kernel do WSL aplicando os princípios de arquitetura de OpsInfra. | Utiliza `sysexits.h` para erros semânticos (78 para configuração ausente, 69 para dependência indisponível). |

Labels: type:scripts, type:packaging

Validacao: Executado `bash scripts/kernel/test-wsl-kernel-static.sh` com sucesso. O `shellcheck` não estava disponível no ambiente.

Rollback trigger: Falhas sintáticas ou interrupção no funcionamento dos comandos existentes do `wsl-kernel.sh`.

---
*PR created automatically by Jules for task [14764791792226898047](https://jules.google.com/task/14764791792226898047) started by @emersonbusson*