### PR TITLE
feat(scripts): add guard clauses and param validation to GuestExhaustive

### DIFF
--- a/scripts/windows/Run-GuestExhaustive.ps1
+++ b/scripts/windows/Run-GuestExhaustive.ps1
@@ -11,6 +11,7 @@
 #>
 [CmdletBinding()]
 param(
+    [ValidateSet("win11-drill")]
     [string]$VMName = "win11-drill",
     [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
@@ -63,6 +64,15 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+if (-not [bool](Get-Command "Get-VM" -ErrorAction SilentlyContinue) -or -not (Get-Module -ListAvailable -Name Hyper-V)) {
+    Write-Error -Message "Hyper-V module is not available" -ErrorId "HyperVModuleMissing"
+    throw [System.Exception]::new("Hyper-V module is missing")
+}
+if (-not (Get-VM -Name $VMName -ErrorAction SilentlyContinue)) {
+    Write-Error -Message "VM not found: $VMName" -ErrorId "VMNotFound"
+    throw [System.Exception]::new("VM not found: $VMName")
+}
 
 . (Join-Path $PSScriptRoot "Invoke-GuestPsDirectBounded.ps1")
 


### PR DESCRIPTION
## Resumo
Adicionado guard clauses e validação de parâmetros no script `Run-GuestExhaustive.ps1` para garantir que o módulo Hyper-V e a máquina virtual existam antes da execução, promovendo *fail-fast* conforme princípios arquiteturais.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): add guard clauses and param validation to GuestExhaustive | Adicionou validação `[ValidateSet("win11-drill")]` no parâmetro `$VMName` e guard clauses iniciais de verificação de pré-requisitos para Hyper-V e VM. | Para prevenir falhas durante a execução devido a requisitos faltantes (VM ou módulo Hyper-V) e seguir os princípios de infraestrutura. | Usa `-ErrorAction SilentlyContinue` para bypass do `$ErrorActionPreference = "Stop"` no check de ambiente e lança exceptions tipadas. |

## Issue
OpsInfra100/2026-09-01/ps1-windows/001

## Responsavel
Jules

## Labels
type:scripts, type:security, type:infrastructure

## Validacao
N/A - pwsh indisponível no ambiente local. Modificações verificadas visualmente de acordo com a sintaxe correta do PowerShell.

## Rollback trigger
Se a execução do script for barrada em ambientes operacionais onde a VM ou módulo devessem ser detectados mas não são, indicando uma falha de query no `Get-VM` ou `Get-Module`.

---
*PR created automatically by Jules for task [2597260397901076775](https://jules.google.com/task/2597260397901076775) started by @emersonbusson*