### PR TITLE
test(test-winsvc): add config deserialization tests for defaults and invalid inputs

### DIFF
--- a/crates/ramshared-winsvc/src/config.rs
+++ b/crates/ramshared-winsvc/src/config.rs
@@ -291,6 +291,74 @@ tenant = "windrive-host"
     }
 
     #[test]
+    fn test_config_empty_input_fails() {
+        let bad = "";
+        let e = WinDriveConfig::from_toml(&bad).unwrap_err();
+        assert!(matches!(e, ConfigError::Parse(_)));
+    }
+
+    #[test]
+    fn test_config_missing_required_fields_fails() {
+        let bad = r#"
+[win_drive]
+size_bytes = 536870912
+block_size = 4096
+cuda_device = 0
+reserve_bytes = 536870912
+queue_depth = 4
+max_io_bytes = 1048576
+evidence_path = "C:\\ProgramData\\RamShared\\evidence"
+volume_letter = "D"
+broker_pipe = "named_pipe_v1"
+broker_ready_timeout_secs = 30
+"#;
+        let e = WinDriveConfig::from_toml(&bad).unwrap_err();
+        assert!(matches!(e, ConfigError::Parse(_)));
+    }
+
+    #[test]
+    fn test_config_missing_fields_with_defaults_parses_successfully() {
+        let toml_without_defaults = r#"
+[win_drive]
+size_bytes = 536870912
+block_size = 4096
+cuda_device = 0
+reserve_bytes = 536870912
+queue_depth = 4
+max_io_bytes = 1048576
+evidence_path = "C:\\ProgramData\\RamShared\\evidence"
+volume_letter = "D"
+broker_pipe = "named_pipe_v1"
+broker_ready_timeout_secs = 30
+tenant = "windrive-host"
+"#;
+        let c = WinDriveConfig::from_toml(&toml_without_defaults).unwrap();
+        // Check default fields
+        assert_eq!(c.heartbeat_secs, 5);
+        assert_eq!(c.volume_mount_path, None);
+    }
+
+    #[test]
+    fn test_config_invalid_types_fails() {
+        let bad = r#"
+[win_drive]
+size_bytes = "536870912"
+block_size = 4096
+cuda_device = 0
+reserve_bytes = 536870912
+queue_depth = 4
+max_io_bytes = 1048576
+evidence_path = "C:\\ProgramData\\RamShared\\evidence"
+volume_letter = "D"
+broker_pipe = "named_pipe_v1"
+broker_ready_timeout_secs = 30
+tenant = "windrive-host"
+"#;
+        let e = WinDriveConfig::from_toml(&bad).unwrap_err();
+        assert!(matches!(e, ConfigError::Parse(_)));
+    }
+
+    #[test]
     fn reject_zero_size() {
         let bad = GOOD.replace("536870912", "0");
         let e = WinDriveConfig::from_toml(&bad).unwrap_err();


### PR DESCRIPTION
## Resumo
Add unit tests to `crates/ramshared-winsvc/src/config.rs` to cover configuration deserialization scenarios involving empty inputs, invalid types, missing required fields, and missing fields correctly populating with default values.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| test(test-winsvc): add config deserialization tests for defaults and invalid inputs | Added tests to `config.rs`. | Verify edge cases for configuration parsing as requested by TestCov-100. | Tests missing required, defaults, empty, and invalid types. |

## Issue
TestCov-100 (test-winsvc/001)

## Responsavel
Jules

## Labels
type:test, scope:ramshared-winsvc

## Validacao
`cargo test --package ramshared-winsvc` and `node tools/ci/check-rust-slice-coverage.mjs -p ramshared-winsvc --files crates/ramshared-winsvc/src/config.rs --min 80`

## Rollback trigger
test suite failure on CI.

---
*PR created automatically by Jules for task [1679899731347063425](https://jules.google.com/task/1679899731347063425) started by @emersonbusson*