### PR TITLE
test(winsvc): FINDING_ONLY protocol handshake test impossible

### DIFF
--- a/docs/jules/findings/test-winsvc-007.md
+++ b/docs/jules/findings/test-winsvc-007.md
@@ -1,0 +1,3 @@
+FINDING_ONLY
+
+The target file `crates/ramshared-winsvc/src/proto.rs` is a declarative mirror of a C header (`drivers/windows/ramshared/protocol.h`) and only contains constants and `#[repr(C)]` structs. There is no protocol handshake sequence, version negotiation logic, incompatible version rejection, or timeout handling implemented in this file. Furthermore, the file already contains tests and does not have zero test coverage. Therefore, safe code modification to add the requested unit tests is not possible.


### PR DESCRIPTION
## Resumo

The objective of this PR was to add unit tests for the protocol handshake sequence to `crates/ramshared-winsvc/src/proto.rs`. However, after investigating the file, it was determined that it is a declarative mirror of a C header (`drivers/windows/ramshared/protocol.h`) and only contains constants and `#[repr(C)]` structs. There is no protocol handshake sequence, version negotiation logic, incompatible version rejection, or timeout handling implemented in this file. The file already contains basic layout tests and therefore does not have zero test coverage. Since safe code modification to add the requested logic tests is impossible in this file, a `FINDING_ONLY` report has been generated in `docs/jules/findings/test-winsvc-007.md`.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| HEAD | Gerou FINDING_ONLY documentando impossibilidade de testes | O arquivo alvo é apenas declarativo e não contém a lógica requisitada | Evita adicionar testes irrelevantes a um arquivo puramente estrutural |

## Issue

TestCov100/2026-09-02/test-winsvc/007

## Responsavel

Jules

## Labels

type:test, scope:ramshared-winsvc, status:finding-only

## Validacao

`cargo test -p ramshared-winsvc` executado para garantir que a suite base continua intacta.

## Rollback trigger

Failing to pass standard CI checks due to the presence of the findings document.

---
*PR created automatically by Jules for task [17432864534622927852](https://jules.google.com/task/17432864534622927852) started by @emersonbusson*