### PR TITLE
test(winsvc): boundary tests for configuration numeric limits

### DIFF
--- a/crates/ramshared-winsvc/src/config.rs
+++ b/crates/ramshared-winsvc/src/config.rs
@@ -291,7 +291,7 @@ tenant = "windrive-host"
     }
 
     #[test]
-    fn reject_zero_size() {
+    fn test_config_reject_zero_size_invalid() {
         let bad = GOOD.replace("536870912", "0");
         let e = WinDriveConfig::from_toml(&bad).unwrap_err();
         assert!(matches!(
@@ -610,6 +610,38 @@ volume_mount_path = "C:\\Users\\Public\\lun""#,
         assert!(is_absolute_path(Path::new(r"\\?\C:\x")));
         assert_eq!(is_absolute_path(Path::new("/tmp/x")), cfg!(unix));
         assert!(!is_absolute_path(Path::new("relative")));
+    }
+
+
+
+
+    #[test]
+    fn test_config_reject_u64_max_size_invalid() {
+        let bad = GOOD.replace("size_bytes = 536870912", "size_bytes = 18446744073709551615");
+        let e = WinDriveConfig::from_toml(&bad).unwrap_err();
+        assert!(matches!(
+            e,
+            ConfigError::Invalid {
+                field: "size_bytes",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_config_reject_negative_size_parse_error() {
+        let bad = GOOD.replace("size_bytes = 536870912", "size_bytes = -1");
+        let e = WinDriveConfig::from_toml(&bad).unwrap_err();
+        assert!(matches!(e, ConfigError::Parse(_)));
+    }
+
+    #[test]
+    fn test_config_reject_non_utf8_string_parse_error() {
+        // Test with invalid bytes
+        let mut bad = GOOD.to_string().into_bytes();
+        bad.extend_from_slice(&[0xff, 0xfe, 0xfd]);
+        let e = WinDriveConfig::from_reader(bad.as_slice()).unwrap_err();
+        assert!(matches!(e, ConfigError::Parse(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Resumo

Added boundary condition tests to `crates/ramshared-winsvc/src/config.rs` to verify numeric limits and parsing robustness. Ensured that zero capacity, `u64::MAX`, negative values, and non-UTF8 strings are explicitly rejected by the config parsing logic. Test names were also formatted to align with the standard `test_{module}_{scenario}_{expected_outcome}` convention.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1 | Added config numeric limit tests | To ensure edge cases (0, max, negative, invalid utf-8) do not panic or yield invalid configs | `test_config_reject_zero_size_invalid`, `test_config_reject_u64_max_size_invalid`, `test_config_reject_negative_size_parse_error`, `test_config_reject_non_utf8_string_parse_error` |

## Issue

TestCov100/2026-09-02/test-winsvc/002

## Responsavel

Jules

## Labels

type:test, scope:ramshared-winsvc

## Validacao

Ran `cargo test -p ramshared-winsvc` to verify all new boundary tests pass correctly and no regressions were introduced.

## Rollback trigger

Revert if down-stream CI platforms face unexpected configuration parsing variations triggering false positives in the new tests.

---
*PR created automatically by Jules for task [10298801763956759156](https://jules.google.com/task/10298801763956759156) started by @emersonbusson*