### PR TITLE
test: produce finding_only for missing parser in proto.rs

### DIFF
--- a/docs/jules/findings/27-proto-fuzz-tests-parser-missing.md
+++ b/docs/jules/findings/27-proto-fuzz-tests-parser-missing.md
@@ -1,0 +1,15 @@
+# Finding: Protocol Parser Validation Logic Missing in `proto.rs`
+
+## Objective
+The task instructed adding "fuzz-style tests for malformed protocol frames" to `crates/ramshared-winsvc/src/proto.rs`. The specification explicitly mentioned: "Test protocol parser with truncated headers, wrong magic bytes, and oversized length fields."
+
+## Evidence
+- `crates/ramshared-winsvc/src/proto.rs` only defines the C-compatible data structures (`RingHdr`, `Sqe`, `Cqe`, etc.) and basic constants for the protocol.
+- It contains NO parsing, deserialization, or validation logic (e.g., no `fn parse(...)` or `impl RingHdr { fn validate(...) }`).
+- Protocol validation and usage actually happen in other modules like `driver_link.rs` and `windows_driver.rs`, where pointers or byte slices are converted into these structures and validated.
+- Any test added to `proto.rs` itself can only tautologically instantiate the structs and assert on their fields locally, which does not test a "protocol parser" or fulfill the requirement of verifying how the application handles malformed frames.
+
+## Conclusion
+Safe, meaningful code modification in `proto.rs` to satisfy this request is NOT possible, as the file lacks the parser logic to test. The requested parser validation logic exists outside of this target file, meaning the task specification's target file is structurally incorrect for the intended objective.
+
+PRODUCING FINDING_ONLY as per immutable contract rule 4.


### PR DESCRIPTION
## Resumo
The issue requested adding fuzz tests to `crates/ramshared-winsvc/src/proto.rs` to validate the protocol parser against malformed headers, magic bytes, and oversized lengths. However, this file only contains struct definitions and constants, lacking any parsing or validation logic to test. A `FINDING_ONLY` artifact was produced to document this structural mismatch as per Immutable Contract rule 4.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| test: produce finding_only for missing parser in proto.rs | Created a FINDING_ONLY document in `docs/jules/findings`. | `proto.rs` lacks the parsing logic described in the task, making code modification impossible. | `27-proto-fuzz-tests-parser-missing.md` |

## Issue
test-winsvc/008

## Responsavel
TestCov100

## Labels
type:test, scope:ramshared-winsvc

## Validacao
cargo test --package ramshared-winsvc

## Rollback trigger
No rollback necessary as no functional code was modified. Revert if the finding document is structurally invalid.

---
*PR created automatically by Jules for task [17735665807323094875](https://jules.google.com/task/17735665807323094875) started by @emersonbusson*