### PR TITLE
feat(scripts): validate disk volume paths and free space

### DIFF
--- a/scripts/windows/Invoke-WindowsStorageMatrix.ps1
+++ b/scripts/windows/Invoke-WindowsStorageMatrix.ps1
@@ -1597,6 +1597,16 @@ function Invoke-Workload(
     [int]$QueueDepth,
     [UInt64]$AvailableBytes
 ) {
+    $driveRoot = [System.IO.Path]::GetPathRoot($Path)
+    if (-not (Test-Path -LiteralPath $driveRoot)) {
+        Write-Error "Target volume path does not exist: $driveRoot" -ErrorId "VolumeNotFound"
+        throw [System.Exception]::new("Target volume path does not exist: $driveRoot")
+    }
+    $driveInfo = [System.IO.DriveInfo]::new($driveRoot)
+    if ($driveInfo.AvailableFreeSpace -lt 1GB) {
+        Write-Error "Target volume requires minimum 1 GB free space" -ErrorId "InsufficientFreeSpace"
+        throw [System.Exception]::new("Target volume requires minimum 1 GB free space: free=$($driveInfo.AvailableFreeSpace)")
+    }
     $workerFileBytes = [UInt64]([math]::Floor(
             ([double]$AvailableBytes * 0.25 / $QueueDepth) / 4096) * 4096)
     $workerFileBytes = [UInt64][math]::Max(1MB, [math]::Min(32MB, $workerFileBytes))


### PR DESCRIPTION
## Resumo
Adicionado guard clauses na função `Invoke-Workload` do `Invoke-WindowsStorageMatrix.ps1` para validar que o path do volume existe e tem pelo menos 1 GB de espaço livre antes de iniciar os testes destrutivos.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): validate disk volume paths and free space | Adicionou validação de existência de diretório e espaço livre. | Para evitar falhas durante testes I/O destrutivos caso o volume não exista ou não possua espaço suficiente. | Utiliza `System.IO.DriveInfo` para consultar o espaço. Lança erro usando `Write-Error` com `ErrorId` apropriado e termina a execução com `throw`. |

## Issue
OpsInfra100/2026-09-01/ps1-windows/006

## Responsavel
jules

## Labels
type:scripts, type:security, category:ps1-windows

## Validacao
PSScriptAnalyzer não disponível para execução no ambiente. O script PowerShell também não pôde ser rodado devido à ausência do pwsh. As modificações foram inseridas com sucesso usando sed.

## Rollback trigger
Reverter se a validação de espaço livre reportar falsos positivos ou se a obtenção de informações de DriveRoot falhar para paths de volume válidos, impedindo a execução dos testes.

---
*PR created automatically by Jules for task [1764339728140161632](https://jules.google.com/task/1764339728140161632) started by @emersonbusson*