### PR TITLE
feat(ps1-windows): add guard clauses for Hyper-V and admin privileges

### DIFF
--- a/scripts/windows/Wait-Win11LabReady.ps1
+++ b/scripts/windows/Wait-Win11LabReady.ps1
@@ -55,6 +55,18 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [Security.Principal.WindowsPrincipal]::new($identity)
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Error -Message "Elevated administrator token required." -ErrorId "AccessDenied"
+    throw [System.Exception]::new("Elevated administrator token required.")
+}
+
+if (-not (Get-Module -ListAvailable -Name Hyper-V)) {
+    Write-Error -Message "Hyper-V module is not available." -ErrorId "ModuleNotFound"
+    throw [System.Exception]::new("Hyper-V module is not available.")
+}
+
 . (Join-Path $PSScriptRoot "Invoke-GuestPsDirectBounded.ps1")
 
 function Normalize-Win11LabReadyThumbprint {


### PR DESCRIPTION
## Resumo
Added admin and Hyper-V guard clauses.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(ps1-windows): add guard clauses for Hyper-V and admin privileges | Added administrator and Hyper-V module guard clauses | To fail-fast if prerequisites are missing | Used Write-Error and thrown typed exceptions |
## Issue
ps1-windows/008
## Responsavel
OpsInfra100/2026-09-01/ps1-windows/008
## Labels
type:scripts, type:security
## Validacao
echo "PSScriptAnalyzer cannot be run as pwsh is unavailable in the environment."
## Rollback trigger
Revert if the script incorrectly fails in valid environments.

---
*PR created automatically by Jules for task [4438523515031165624](https://jules.google.com/task/4438523515031165624) started by @emersonbusson*