### PR TITLE
feat: add checksum validation to media contract

### DIFF
--- a/scripts/windows/Win11LabMediaContract.ps1
+++ b/scripts/windows/Win11LabMediaContract.ps1
@@ -517,6 +517,29 @@ function Assert-Win11LabPrimaryIsoContract {
     }
 }
 
+function Assert-Win11LabMediaArtifactChecksum {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ArtifactPath,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ExpectedSha256
+    )
+
+    if (-not (Test-Path -LiteralPath $ArtifactPath -PathType Leaf)) {
+        throw "win11_lab_media_contract_artifact_missing"
+    }
+
+    $expected = Normalize-Win11LabSha256 -Sha256 $ExpectedSha256 -FailureCode "manifest_sha256_invalid"
+    $actual = Get-Win11LabFileSha256 -Path $ArtifactPath
+
+    if ($actual -cne $expected) {
+        throw "win11_lab_media_contract_artifact_checksum_mismatch"
+    }
+}
+
 function Wait-Win11LabExactVhdGrowth {
     [CmdletBinding()]
     param(


### PR DESCRIPTION
## Resumo
Add `Assert-Win11LabMediaArtifactChecksum` to `scripts/windows/Win11LabMediaContract.ps1` to compute and verify the SHA-256 hash of downloaded media artifacts against expected manifest checksums, fulfilling the security hardening objective.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: add checksum validation to media contract | Added `Assert-Win11LabMediaArtifactChecksum` | To compute and verify SHA-256 of downloaded media artifacts | Validates prerequisites and inputs, normalizes hashes, compares, and throws specific typed exceptions. |

## Issue
OpsInfra100

## Responsavel
Jules

## Labels
type:security, type:scripts

## Validacao
echo "PSScriptAnalyzer cannot be run as pwsh runtime is unavailable."

## Rollback trigger
Revert if Win11LabMediaContract fails during ISO or VHD checksum validation

---
*PR created automatically by Jules for task [7115731504469724997](https://jules.google.com/task/7115731504469724997) started by @emersonbusson*