### PR TITLE
feat(windows): add exponential backoff to lab readiness gate

### DIFF
--- a/scripts/windows/Wait-Win11LabReady.ps1
+++ b/scripts/windows/Wait-Win11LabReady.ps1
@@ -48,8 +48,8 @@ param(
     [int]$PerAttemptTimeoutSeconds = 120,
     [ValidateRange(1, 180)]
     [int]$PsDirectConnectTimeoutSeconds = 60,
-    [ValidateRange(1, 30)]
-    [int]$PollIntervalSeconds = 5
+    [ValidateRange(2, 300)]
+    [int]$MaxPollIntervalSeconds = 300
 )
 
 Set-StrictMode -Version Latest
@@ -1233,6 +1233,7 @@ catch {
 }
 
 $attemptNumber = 0
+$currentSleep = [int]2
 while (-not $hostBeforeProviderFailed -and [DateTime]::UtcNow -lt $deadlineUtc) {
     $attemptNumber++
     $attemptStartedUtc = [DateTime]::UtcNow
@@ -1325,7 +1326,8 @@ while (-not $hostBeforeProviderFailed -and [DateTime]::UtcNow -lt $deadlineUtc) 
     if ($remainingAfterAttempt -le 0) {
         break
     }
-    Start-Sleep -Seconds ([Math]::Min($PollIntervalSeconds, $remainingAfterAttempt))
+    Start-Sleep -Seconds ([Math]::Min($currentSleep, $remainingAfterAttempt))
+    $currentSleep = [int][Math]::Min($currentSleep * 2, $MaxPollIntervalSeconds)
 }
 
 if ($null -eq $after) {


### PR DESCRIPTION
## Resumo
Replaced fixed `Start-Sleep` interval with exponential backoff (2s, 4s, 8s, up to max) to reduce aggressive polling on readiness gates while preserving timeout bounds.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(windows): add exponential backoff to lab readiness gate | Replaced `$PollIntervalSeconds` with `$MaxPollIntervalSeconds` and updated loop to use doubling sleep interval. | Wait-Win11LabReady.ps1 aggressively polled the host/guest boundary every 5s instead of progressively backing off. | Initialized sleep to 2s and doubled dynamically up to 5 min. |

## Issue
OpsInfra-100

## Responsavel
OpsInfra100/2026-09-01/ps1-windows/007

## Labels
type:scripts, type:windows, type:readiness

## Validacao
Verified parameter updates, logic changes via manual static inspection and PSScriptAnalyzer absence logged.

## Rollback trigger
Revert if exponential backoff induces test timeouts due to missed rapid state transitions.

---
*PR created automatically by Jules for task [7455596505331506306](https://jules.google.com/task/7455596505331506306) started by @emersonbusson*