### PR TITLE
feat(scripts): implement graceful WM_CLOSE and timeout for stress workers

### DIFF
--- a/scripts/windows/Invoke-SharedWslPressureCampaign.ps1
+++ b/scripts/windows/Invoke-SharedWslPressureCampaign.ps1
@@ -176,7 +176,7 @@ function Stop-CampaignProcessInstanceSafely {
             $Process.CloseMainWindow() | Out-Null
         } catch {}
         if (-not $Process.WaitForExit(10000)) {
-            Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
+            $Process.Kill()
             if (-not $Process.WaitForExit(5000)) { return [pscustomobject]@{ stopped = $false; reason = "$Operation`_process_instance_kill_unreaped" } }
             return [pscustomobject]@{ stopped = $true; reason = "$Operation`_process_instance_force_terminated" }
         }

--- a/scripts/windows/Invoke-SharedWslPressureCampaign.ps1
+++ b/scripts/windows/Invoke-SharedWslPressureCampaign.ps1
@@ -172,8 +172,14 @@ function Stop-CampaignProcessInstanceSafely {
         if ($Process.StartTime.ToUniversalTime().Ticks -ne $originalStart) {
             return [pscustomobject]@{ stopped = $false; reason = "$Operation`_process_instance_identity_changed" }
         }
-        $Process.Kill()
-        if (-not $Process.WaitForExit(5000)) { return [pscustomobject]@{ stopped = $false; reason = "$Operation`_process_instance_kill_unreaped" } }
+        try {
+            $Process.CloseMainWindow() | Out-Null
+        } catch {}
+        if (-not $Process.WaitForExit(10000)) {
+            Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
+            if (-not $Process.WaitForExit(5000)) { return [pscustomobject]@{ stopped = $false; reason = "$Operation`_process_instance_kill_unreaped" } }
+            return [pscustomobject]@{ stopped = $true; reason = "$Operation`_process_instance_force_terminated" }
+        }
         return [pscustomobject]@{ stopped = $true; reason = "$Operation`_process_instance_handle_terminated" }
     } catch {
         return [pscustomobject]@{ stopped = $false; reason = "$Operation`_process_instance_identity_unproven" }


### PR DESCRIPTION
## Resumo
Implement graceful WM_CLOSE followed by a 10s timeout and Force-kill escalation for hung stress workers in the WSL pressure campaign script.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): implement graceful WM_CLOSE and timeout for stress workers | Replaced direct Kill() with CloseMainWindow() and Stop-Process -Force escalation | To safely terminate hung worker processes, providing an opportunity for graceful shutdown before force killing. | Modified Stop-CampaignProcessInstanceSafely in Invoke-SharedWslPressureCampaign.ps1 |
## Issue
OpsInfra100/2026-09-01/ps1-windows/015
## Responsavel
Jules
## Labels
type:scripts
## Validacao
echo "pwsh scripts/windows/Invoke-SharedWslPressureCampaign.ps1 cannot be run because the pwsh runtime is unavailable."
## Rollback trigger
Revert if valid worker processes fail to terminate and linger or if the script errors out due to pipeline problems.

---
*PR created automatically by Jules for task [2876685945721397844](https://jules.google.com/task/2876685945721397844) started by @emersonbusson*