### PR TITLE
feat(windows): skip vm creation gracefully if already exists

### DIFF
--- a/scripts/windows/New-Win11Wsl2LabVm.ps1
+++ b/scripts/windows/New-Win11Wsl2LabVm.ps1
@@ -157,7 +157,8 @@ function Get-Win11LabSetupStartFailureCode {
 }
 
 if (Get-VM -Name $VMName -ErrorAction SilentlyContinue) {
-    Fail "VM already exists: $VMName"
+    Write-Output "VM already exists: $VMName"
+    exit 0
 }
 if (-not (Test-Path -LiteralPath $WindowsIso)) {
     Fail "Windows ISO not found: $WindowsIso"


### PR DESCRIPTION
## Resumo
Changed VM pre-existence guard clause in New-Win11Wsl2LabVm.ps1 to write an informational message and exit cleanly instead of throwing a failure. This ensures idempotent VM creation scripts gracefully skip instead of terminating execution with an error, preventing pipeline disruption.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(windows): skip vm creation gracefully if already exists | Replaced Fail call with Write-Output and exit 0. | To make the script execution idempotent and skip gracefully. | Modifies New-Win11Wsl2LabVm.ps1 to exit 0 instead of 2. |

## Labels
type:scripts

## Validacao
echo "pwsh scripts/windows/Test-Win11Wsl2LabVmStatic.ps1 cannot be run because the pwsh runtime is unavailable."

## Rollback trigger
Revert if VM creation silently skips when a conflicting VM exists but is in an unexpected state.

---
*PR created automatically by Jules for task [4637335927250946787](https://jules.google.com/task/4637335927250946787) started by @emersonbusson*