### PR TITLE
docs: document finding that Win11LabMediaContract lacks downloads

### DIFF
--- a/docs/jules/findings/Win11LabMediaContract-no-downloads.md
+++ b/docs/jules/findings/Win11LabMediaContract-no-downloads.md
@@ -1,0 +1,7 @@
+# FINDING_ONLY
+
+## Target File
+`scripts/windows/Win11LabMediaContract.ps1`
+
+## Finding
+Safe code modification is not possible. The requested task requires adding guard clauses for disk space and network connectivity before starting large artifact downloads. However, `scripts/windows/Win11LabMediaContract.ps1` is a sealed unattended-media contract helper that only inspects, probes, and stages *existing* ISOs and local VHDs. It does not contain any logic for downloading artifacts (such as `Invoke-WebRequest` or `Start-BitsTransfer`). As the file lacks the requested logic entirely, safe and orthogonal code modification to validate network connectivity and disk space for downloads cannot be performed here.


### PR DESCRIPTION
## Resumo
Created FINDING_ONLY report documenting that Win11LabMediaContract.ps1 does not perform any large artifact downloads, making the requested disk space and network connectivity guard clauses inapplicable.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: document finding that Win11LabMediaContract lacks downloads | Created FINDING_ONLY report in docs/jules/findings/ | Safe code modification in the target file is impossible because it does not contain the requested logic. | Fulfills immutable contract 4 by documenting the discrepancy. |

## Issue
N/A

## Responsavel
Jules

## Labels
type:docs

## Validacao
echo "No tests to run for FINDING_ONLY report."

## Rollback trigger
N/A

---
*PR created automatically by Jules for task [11451041743158382466](https://jules.google.com/task/11451041743158382466) started by @emersonbusson*