### PR TITLE
feat(winsvc): validate service state before origin install or uninstall

### DIFF
--- a/scripts/windows/Manage-RamSharedOrigin.ps1
+++ b/scripts/windows/Manage-RamSharedOrigin.ps1
@@ -399,6 +399,15 @@ if (($LogicalCapacityMiB % 1024) -ne 0) { throw "logical capacity must be whole 
 if (($PhysicalCacheCapMiB % 1024) -ne 0 -or $PhysicalCacheCapMiB -gt $LogicalCapacityMiB) { throw "physical cache cap must be whole GiB and no larger than logical capacity" }
 if ($Action -eq "install" -and $PARTUUID -cne "00000000-0000-0000-0000-000000000000") { throw "Windows assigns the GPT PARTUUID; seal the generated value from the mounted origin VHDX" }
 
+if ($Action -eq "install" -or $Action -eq "uninstall") {
+    foreach ($svcName in @("RamSharedBroker", "RamSharedWinSvc")) {
+        $svc = Get-Service -Name $svcName -ErrorAction SilentlyContinue
+        if ($null -ne $svc -and $svc.Status -ne "Stopped") {
+            Write-Error -ErrorId "ServiceNotStopped" -Message "Service $svcName must be stopped before attempting $Action." -ErrorAction Stop
+        }
+    }
+}
+
 switch ($Action) {
     "install" {
         $transaction = New-OriginInstallTransaction

--- a/scripts/windows/Test-RamSharedOriginStatic.ps1
+++ b/scripts/windows/Test-RamSharedOriginStatic.ps1
@@ -40,6 +40,7 @@ foreach ($required in @(
     'Remove-Item -LiteralPath $transaction.staging_vhdx -Force',
     'Remove-Item -LiteralPath $OriginVhdx -Force',
     'origin uninstall requires exact sealed ownership proof',
+    'Write-Error -ErrorId "ServiceNotStopped"',
     'New-VHD',
     'Mount-VHD',
     'Dismount-VHD -Path $VhdxPath',


### PR DESCRIPTION
## Resumo
Added guard clauses to ensure RamSharedBroker and RamSharedWinSvc are stopped before attempting to install or uninstall the origin VHDX.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(winsvc): validate service state before origin install or uninstall | Adicionou validação de estado dos serviços | Para prevenir corrupção no estado e falhas ao modificar o VHDX origin enquanto em uso. | `scripts/windows/Manage-RamSharedOrigin.ps1` atualizado com verificações usando `Write-Error`. |

## Labels
type:scripts, type:safety

## Validacao
pwsh test execution unavailable in environment (documented).

## Rollback trigger
Origin install or uninstall fails immediately due to false positives in service state reporting when services are actually stopped.

---
*PR created automatically by Jules for task [14382505242001375641](https://jules.google.com/task/14382505242001375641) started by @emersonbusson*