### PR TITLE
docs: add finding about missing memory thresholds in wsl pressure campaign

### DIFF
--- a/docs/jules/findings/Invoke-SharedWslPressureCampaign-threshold.md
+++ b/docs/jules/findings/Invoke-SharedWslPressureCampaign-threshold.md
@@ -1,0 +1,7 @@
+# FINDING_ONLY
+
+**Target File:** `scripts/windows/Invoke-SharedWslPressureCampaign.ps1`
+**Task:** Validate that configured pressure thresholds are between 0 and 100 and that memory_high < memory_max.
+
+## Evidence
+After exploring the `scripts/windows/Invoke-SharedWslPressureCampaign.ps1` file, I found that there are no parameters or variables named `memory_high`, `memory_max`, or anything related to "pressure thresholds" that range between 0 and 100. The only related parameter is `$PressureAllocGiB`. Therefore, safe and orthogonal code modification is not possible.


### PR DESCRIPTION
## Resumo
This PR adds a FINDING_ONLY report detailing that `scripts/windows/Invoke-SharedWslPressureCampaign.ps1` lacks `memory_high` and `memory_max` parameters, making safe validation logic impossible.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: add finding | Added FINDING_ONLY report | Target logic is absent from the script | No code was modified |

## Issue
N/A

## Responsavel
Jules

## Labels
type:scripts

## Validacao
echo "No code was modified, test execution is inapplicable for a FINDING_ONLY report."

## Rollback trigger
N/A - Documentation only.

---
*PR created automatically by Jules for task [8995191947244314354](https://jules.google.com/task/8995191947244314354) started by @emersonbusson*