### PR TITLE
scripts: add checksum validation for downloaded ISO and VHD artifacts

### DIFF
--- a/scripts/windows/Test-Win11LabMediaContractStatic.ps1
+++ b/scripts/windows/Test-Win11LabMediaContractStatic.ps1
@@ -68,7 +68,8 @@ foreach ($functionName in @(
     "Invoke-Win11LabPrimaryIsoContract",
     "Invoke-Win11LabSourceIsoStage",
     "Invoke-Win11LabExternalProcessBounded",
-    "Wait-Win11LabExactVhdGrowth"
+    "Wait-Win11LabExactVhdGrowth",
+    "Assert-Win11LabArtifactChecksum"
 )) {
     if (-not (Get-Command -Name $functionName -CommandType Function -ErrorAction SilentlyContinue)) {
         throw ("win11_lab_media_static: missing function " + $functionName)

--- a/scripts/windows/Win11LabMediaContract.ps1
+++ b/scripts/windows/Win11LabMediaContract.ps1
@@ -1011,6 +1011,56 @@ function Assert-Win11LabWorkerIsoNotAttached {
     }
 }
 
+function Assert-Win11LabArtifactChecksum {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ManifestPath,
+        [Parameter(Mandatory = $true)]
+        [string]$ArtifactPath,
+        [Parameter(Mandatory = $true)]
+        [string]$Role
+    )
+
+    if (-not (Test-Path -LiteralPath $ManifestPath -PathType Leaf)) {
+        throw "win11_lab_media_contract_manifest_missing"
+    }
+    if (-not (Test-Path -LiteralPath $ArtifactPath -PathType Leaf)) {
+        throw "win11_lab_media_contract_artifact_missing"
+    }
+
+    $manifest = $null
+    try {
+        $manifestJson = [System.IO.File]::ReadAllText($ManifestPath)
+        $manifest = $manifestJson | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        throw "win11_lab_media_contract_manifest_invalid"
+    }
+
+    if ($null -eq $manifest -or $null -eq $manifest.artifacts -or $manifest.artifacts -isnot [array]) {
+        throw "win11_lab_media_contract_manifest_artifacts_missing"
+    }
+
+    $expectedSha256 = $null
+    foreach ($artifact in $manifest.artifacts) {
+        if ($null -ne $artifact.role -and [string]$artifact.role -ceq $Role) {
+            $expectedSha256 = [string]$artifact.sha256
+            break
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($expectedSha256)) {
+        throw "win11_lab_media_contract_manifest_artifact_role_missing"
+    }
+
+    $computedSha256 = Get-Win11LabFileSha256 -Path $ArtifactPath
+    $normalizedExpected = Normalize-Win11LabSha256 -Sha256 $expectedSha256 -FailureCode "manifest_artifact_sha256_invalid"
+
+    if ($computedSha256 -cne $normalizedExpected) {
+        throw "win11_lab_media_contract_artifact_hash_mismatch"
+    }
+}
+
 function Invoke-Win11LabMediaWorkerMode {
     [CmdletBinding()]
     param(


### PR DESCRIPTION
## Resumo
Implemented `Assert-Win11LabArtifactChecksum` to validate downloaded ISO and VHD artifacts against expected manifest checksums to ensure file integrity.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| scripts: add checksum validation for downloaded ISO and VHD artifacts | Added `Assert-Win11LabArtifactChecksum` to `Win11LabMediaContract.ps1` | To verify downloaded artifacts match expected hashes | Parses manifest, extracts sha256, compares with computed artifact hash |

## Issue
011

## Responsavel
jules

## Labels
type:scripts

## Validacao
echo "PSScriptAnalyzer cannot be run because the pwsh runtime is unavailable."

## Rollback trigger
Revert if artifact validation blocks legitimate downloads

---
*PR created automatically by Jules for task [10004728441838324686](https://jules.google.com/task/10004728441838324686) started by @emersonbusson*