### PR TITLE
feat(scripts): validate disk performance counters

### DIFF
--- a/scripts/windows/Measure-RamSharedDiskIo.ps1
+++ b/scripts/windows/Measure-RamSharedDiskIo.ps1
@@ -34,6 +34,29 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+
+function Assert-PerfDiskCountersAvailable {
+    try {
+        $phys = @(Get-CimInstance -ClassName Win32_PerfFormattedData_PerfDisk_PhysicalDisk -ErrorAction Stop)
+        $log = @(Get-CimInstance -ClassName Win32_PerfFormattedData_PerfDisk_LogicalDisk -ErrorAction Stop)
+    } catch {
+        try {
+            $phys = @(Get-WmiObject -Class Win32_PerfFormattedData_PerfDisk_PhysicalDisk -ErrorAction Stop)
+            $log = @(Get-WmiObject -Class Win32_PerfFormattedData_PerfDisk_LogicalDisk -ErrorAction Stop)
+        } catch {
+            Write-Error -ErrorId "MissingDiskCounters" -Message "Failed to query Disk performance counters: $($_.Exception.Message)" -ErrorAction Stop
+        }
+    }
+    if ($phys.Count -eq 0) {
+        Write-Error -ErrorId "MissingPhysicalDiskCounters" -Message "PhysicalDisk performance counters are missing or return zero instances." -ErrorAction Stop
+    }
+    if ($log.Count -eq 0) {
+        Write-Error -ErrorId "MissingLogicalDiskCounters" -Message "LogicalDisk performance counters are missing or return zero instances." -ErrorAction Stop
+    }
+}
+
+Assert-PerfDiskCountersAvailable
+
 function L($m) { Write-Host ("[{0}] {1}" -f (Get-Date -Format "HH:mm:ss"), $m) }
 
 function Get-Sha256Hex {


### PR DESCRIPTION
## Resumo
Adicionado fail-fast guard clauses em Measure-RamSharedDiskIo.ps1 para validar a disponibilidade de contadores de disco (PhysicalDisk e LogicalDisk).

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(scripts): validate disk performance counters | Add Assert-PerfDiskCountersAvailable | Ensure performance counters exist | Validates both PhysicalDisk and LogicalDisk instances before continuing |

## Issue
validate disk performance counter availability before measurement

## Responsavel
OpsInfra-100

## Labels
type:scripts, type:reliability

## Validacao
echo "pwsh scripts/windows/Measure-RamSharedDiskIo.ps1 cannot be run because the pwsh runtime is unavailable."

## Rollback trigger
Revert se a validação impedir execuções válidas de medição em servidores de produção.

---
*PR created automatically by Jules for task [18246149114966871607](https://jules.google.com/task/18246149114966871607) started by @emersonbusson*