### PR TITLE
fix(windows): add named pipe readiness guard before client dispatch

### DIFF
--- a/scripts/windows/Run-GuestBrokerService.ps1
+++ b/scripts/windows/Run-GuestBrokerService.ps1
@@ -365,6 +365,20 @@ try {
         }
 
         if ($selectedCase -in @("All", "PeerMatrix")) {
+            $pipeReady = $false
+            for ($pipeAttempt = 0; $pipeAttempt -lt 150; $pipeAttempt++) {
+                $pipeNames = @([IO.Directory]::GetFiles("\\.\pipe\") | ForEach-Object {
+                        $_.Substring($_.LastIndexOf("\") + 1)
+                    })
+                if ($pipeNames -contains $brokerPipe) {
+                    $pipeReady = $true
+                    break
+                }
+                Start-Sleep -Milliseconds 100
+            }
+            if (-not $pipeReady) {
+                Write-Error -ErrorId "NamedPipeTimeout" -Message "named pipe server not ready before client dispatch" -ErrorAction Stop
+            }
             try { Start-Service $consumerService -ErrorAction Stop } catch {}
             $admitted = $false
             $observedLease = $false


### PR DESCRIPTION
## Resumo
Add a timeout guard for named pipe server readiness in `Run-GuestBrokerService.ps1` to fail fast with a semantic error before launching client connections.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| fix(windows): add named pipe readiness guard before client dispatch | Inserted a timeout guard checking named pipe readiness | Enforce physical limits and sanity checks before client dispatch, yielding semantic error | Added to `Run-GuestBrokerService.ps1` before `Start-Service $consumerService` |

## Issue
021

## Responsavel
OpsInfra100

## Labels
type:scripts, type:reliability

## Validacao
pwsh script cannot be run, PSScriptAnalyzer cannot be run

## Rollback trigger
Any named pipe timeout regression

---
*PR created automatically by Jules for task [17201354009333318686](https://jules.google.com/task/17201354009333318686) started by @emersonbusson*