### PR TITLE
feat(windows): add service lock and existence validation to revoke drill

### DIFF
--- a/scripts/windows/Invoke-RevokeDrill.ps1
+++ b/scripts/windows/Invoke-RevokeDrill.ps1
@@ -19,6 +19,15 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+
+$svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+if ($null -eq $svc) {
+    Write-Error -ErrorId "EX_UNAVAILABLE" -Message "Revocation target service '$ServiceName' does not exist." -ErrorAction Stop
+}
+if ($svc.Status -ne 'Stopped' -and $svc.Status -ne 'Running') {
+    Write-Error -ErrorId "EX_USAGE" -Message "Revocation target service '$ServiceName' is locked in state '$($svc.Status)'." -ErrorAction Stop
+}
+
 New-Item -ItemType Directory -Force -Path $ArtifactDir | Out-Null
 $runId = "revoke-{0:yyyyMMdd-HHmmss}" -f (Get-Date)
 $log = Join-Path $ArtifactDir "$runId.log"


### PR DESCRIPTION
## Resumo
Added guard clauses to validate that the revocation target service exists and is not locked in a pending state before executing the drill, aligning with infrastructure hardening principles.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(windows): add service lock and existence validation to revoke drill | Added Get-Service checks for existence and status | Fail-fast on invalid target state to prevent teardown deadlocks | <details><summary>Detalhes</summary>Validates service existence and throws a semantic error if missing or locked in a pending state.</details> |

## Issue
Resolves #024

## Responsavel
@OpsInfra100

## Labels
type:scripts, area:windows, type:security

## Validacao
PSScriptAnalyzer executed cleanly on `scripts/windows/Invoke-RevokeDrill.ps1`. Execution test confirmed fail-fast behavior.

## Rollback trigger
Teardown deadlock or unintended test failure due to missing service during valid drill execution.

---
*PR created automatically by Jules for task [11458395493769132172](https://jules.google.com/task/11458395493769132172) started by @emersonbusson*