### PR TITLE
refactor(preflight): return structured check results

### DIFF
--- a/scripts/windows/Get-WinDrivePreflight.ps1
+++ b/scripts/windows/Get-WinDrivePreflight.ps1
@@ -22,11 +22,12 @@ param(
 $ErrorActionPreference = 'Continue'
 $fail = 0
 $start = Get-Date
+$script:results = @()
 
-function Ok([string]$msg) { Write-Host "[OK]  $msg" -ForegroundColor Green }
-function Warn([string]$msg) { Write-Host "[WARN] $msg" -ForegroundColor Yellow }
-function Bad([string]$msg) {
-    Write-Host "[FAIL] $msg" -ForegroundColor Red
+function Ok([string]$Name, [string]$Msg) { $script:results += [PSCustomObject]@{ CheckName = $Name; Status = "Pass"; Detail = $Msg } }
+function Warn([string]$Name, [string]$Msg) { $script:results += [PSCustomObject]@{ CheckName = $Name; Status = "Skip"; Detail = $Msg } }
+function Bad([string]$Name, [string]$Msg) {
+    $script:results += [PSCustomObject]@{ CheckName = $Name; Status = "Fail"; Detail = $Msg }
     $script:fail++
 }
 function Test-ControlPath([string]$Path) {
@@ -71,16 +72,16 @@ function Test-ConfiguredPagingFilesConcrete {
         }
         if ($badConfigured.Count -gt 0) {
             if ($StorageOnly) {
-                Bad "Ambiguous/malformed PagingFiles entry blocks storage-only teardown: $($badConfigured -join ', ')"
+                Bad "PagingFilesConfig" "Ambiguous/malformed PagingFiles entry blocks storage-only teardown: $($badConfigured -join ', ')"
             } else {
-                Warn "Ambiguous/malformed PagingFiles entry: $($badConfigured -join ', ')"
+                Warn "PagingFilesConfig" "Ambiguous/malformed PagingFiles entry: $($badConfigured -join ', ')"
             }
         } else {
-            Ok "Configured PagingFiles entries are concrete"
+            Ok "PagingFilesConfig" "Configured PagingFiles entries are concrete"
         }
     } catch {
-        if ($StorageOnly) { Bad "PagingFiles registry query failed (fail-closed): $_" }
-        else { Warn "PagingFiles registry query failed: $_" }
+        if ($StorageOnly) { Bad "PagingFilesConfig" "PagingFiles registry query failed (fail-closed): $_" }
+        else { Warn "PagingFilesConfig" "PagingFiles registry query failed: $_" }
     }
 }
 
@@ -96,9 +97,9 @@ try {
     $build = $cv.CurrentBuildNumber
     $ubr = $cv.UBR
     Write-Host "OS build: $build.$ubr (ProductName=$($cv.ProductName))"
-    if (-not [Environment]::Is64BitOperatingSystem) { Bad "x64 OS required" } else { Ok "x64 OS" }
+    if (-not [Environment]::Is64BitOperatingSystem) { Bad "OS" "x64 OS required" } else { Ok "OS" "x64 OS" }
 } catch {
-    Bad "Could not read OS version: $_"
+    Bad "OS" "Could not read OS version: $_"
 }
 
 # NVIDIA / nvcuda
@@ -106,13 +107,13 @@ $nvsmi = Get-Command nvidia-smi -ErrorAction SilentlyContinue
 if ($nvsmi) {
     try {
         $gpu = & nvidia-smi --query-gpu=name,memory.total,memory.free,driver_version --format=csv,noheader 2>$null
-        Ok "nvidia-smi: $gpu"
+        Ok "NVIDIA" "nvidia-smi: $gpu"
     } catch {
-        Warn "nvidia-smi present but query failed: $_"
+        Warn "NVIDIA" "nvidia-smi present but query failed: $_"
     }
 } else {
-    if ($StorageOnly) { Bad "nvidia-smi required for storage-only CUDA product" }
-    else { Warn "nvidia-smi not in PATH" }
+    if ($StorageOnly) { Bad "NVIDIA" "nvidia-smi required for storage-only CUDA product" }
+    else { Warn "NVIDIA" "nvidia-smi not in PATH" }
 }
 
 $dllCandidates = @(
@@ -122,32 +123,32 @@ $dllCandidates = @(
 $foundDll = $false
 foreach ($p in $dllCandidates) {
     if (Test-Path $p) {
-        Ok "Found $p"
+        Ok "NVIDIA" "Found $p"
         $foundDll = $true
         break
     }
 }
 if (-not $foundDll) {
-    if ($StorageOnly) { Bad "nvcuda.dll missing (product probe-cuda will fail)" }
-    else { Warn "nvcuda.dll not found" }
+    if ($StorageOnly) { Bad "NVIDIA" "nvcuda.dll missing (product probe-cuda will fail)" }
+    else { Warn "NVIDIA" "nvcuda.dll not found" }
 }
 
 # Admin
 $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
     [Security.Principal.WindowsBuiltInRole]::Administrator)
-if ($isAdmin) { Ok "Running elevated" }
+if ($isAdmin) { Ok "Admin" "Running elevated" }
 else {
-    if ($StorageOnly) { Warn "Not elevated - product install/SCM needs admin" }
-    else { Warn "Not elevated" }
+    if ($StorageOnly) { Warn "Admin" "Not elevated - product install/SCM needs admin" }
+    else { Warn "Admin" "Not elevated" }
 }
 
 # Test-signing
 try {
     $bcd = bcdedit /enum '{current}' 2>$null | Out-String
-    if ($bcd -match 'testsigning\s+Yes') { Ok "testsigning Yes (lab driver load)" }
-    else { Warn "testsigning not Yes (signed package or lab policy required)" }
+    if ($bcd -match 'testsigning\s+Yes') { Ok "TestSigning" "testsigning Yes (lab driver load)" }
+    else { Warn "TestSigning" "testsigning not Yes (signed package or lab policy required)" }
 } catch {
-    Warn "bcdedit not queryable"
+    Warn "TestSigning" "bcdedit not queryable"
 }
 
 # Active pagefiles
@@ -156,16 +157,16 @@ try {
     $rs = @($pf | Where-Object { $_.Name -match 'RamShared|VRAM' })
     if ($rs.Count -gt 0) {
         if ($StorageOnly) {
-            Bad "RamShared/VRAM pagefile active: $($rs.Name -join ', ') — PREFLIGHT_STORAGE_ONLY refuse"
+            Bad "ActivePagefiles" "RamShared/VRAM pagefile active: $($rs.Name -join ', ') — PREFLIGHT_STORAGE_ONLY refuse"
         } else {
-            Warn "pagefile on VRAM volume present"
+            Warn "ActivePagefiles" "pagefile on VRAM volume present"
         }
     } else {
-        Ok "No RamShared pagefile in Win32_PageFileUsage"
+        Ok "ActivePagefiles" "No RamShared pagefile in Win32_PageFileUsage"
     }
 } catch {
-    if ($StorageOnly) { Bad "pagefile WMI query failed (fail-closed): $_" }
-    else { Warn "pagefile WMI query failed: $_" }
+    if ($StorageOnly) { Bad "ActivePagefiles" "pagefile WMI query failed (fail-closed): $_" }
+    else { Warn "ActivePagefiles" "pagefile WMI query failed: $_" }
 }
 
 # Existing RamShared disks
@@ -175,15 +176,15 @@ try {
         })
     if ($disks.Count -gt 0) {
         if ($StorageOnly) {
-            Bad "Existing RamShared disk(s): $($disks.Number -join ',') — clear before campaign"
+            Bad "ExistingDisks" "Existing RamShared disk(s): $($disks.Number -join ',') — clear before campaign"
         } else {
-            Ok "RamShared disk present: N=$($disks.Number -join ',')"
+            Ok "ExistingDisks" "RamShared disk present: N=$($disks.Number -join ',')"
         }
     } else {
-        Ok "No RamShared disk currently enumerated"
+        Ok "ExistingDisks" "No RamShared disk currently enumerated"
     }
 } catch {
-    Warn "Get-Disk failed: $_"
+    Warn "ExistingDisks" "Get-Disk failed: $_"
 }
 
 # Redundant Win32 disk inventory catches residual class-stack devices that may
@@ -195,16 +196,16 @@ try {
     if ($win32Disks.Count -gt 0) {
         $ids = @($win32Disks | ForEach-Object { "Index=$($_.Index) Model=$($_.Model) Serial=$($_.SerialNumber)" }) -join '; '
         if ($StorageOnly) {
-            Bad "Residual RamShared Win32_DiskDrive node(s): $ids"
+            Bad "Win32Disks" "Residual RamShared Win32_DiskDrive node(s): $ids"
         } else {
-            Warn "Residual RamShared Win32_DiskDrive node(s): $ids"
+            Warn "Win32Disks" "Residual RamShared Win32_DiskDrive node(s): $ids"
         }
     } else {
-        Ok "No residual RamShared Win32_DiskDrive nodes"
+        Ok "Win32Disks" "No residual RamShared Win32_DiskDrive nodes"
     }
 } catch {
-    if ($StorageOnly) { Bad "Win32_DiskDrive query failed (fail-closed): $_" }
-    else { Warn "Win32_DiskDrive query failed: $_" }
+    if ($StorageOnly) { Bad "Win32Disks" "Win32_DiskDrive query failed (fail-closed): $_" }
+    else { Warn "Win32Disks" "Win32_DiskDrive query failed: $_" }
 }
 
 # Ghost/stale PnP disk nodes can survive after surprise removal even when
@@ -218,40 +219,40 @@ try {
     if ($ghostDisks.Count -gt 0) {
         $ids = @($ghostDisks | ForEach-Object { $_.InstanceId }) -join ', '
         if ($StorageOnly) {
-            Bad "Stale RamShared PnP disk node(s) present: $ids"
+            Bad "GhostDisks" "Stale RamShared PnP disk node(s) present: $ids"
         } else {
-            Warn "Stale RamShared PnP disk node(s): $ids"
+            Warn "GhostDisks" "Stale RamShared PnP disk node(s): $ids"
         }
     } else {
-        Ok "No stale RamShared PnP disk nodes"
+        Ok "GhostDisks" "No stale RamShared PnP disk nodes"
     }
 } catch {
-    if ($StorageOnly) { Bad "PnP ghost disk query failed (fail-closed): $_" }
-    else { Warn "PnP ghost disk query failed: $_" }
+    if ($StorageOnly) { Bad "GhostDisks" "PnP ghost disk query failed (fail-closed): $_" }
+    else { Warn "GhostDisks" "PnP ghost disk query failed: $_" }
 }
 
 # Product binary / config
 if ($StorageOnly) {
     if (Test-Path -LiteralPath $ProductExe) {
         $h = (Get-FileHash -Algorithm SHA256 -LiteralPath $ProductExe).Hash
-        Ok "Product exe $ProductExe SHA256=$h"
+        Ok "ProductConfig" "Product exe $ProductExe SHA256=$h"
         if ($ProductExe -match 'WinDriveBackend|RamSharedWinSvc\.cs|Start-RamSharedLab') {
-            Bad "Product path looks like lab backend (false RAM green risk)"
+            Bad "ProductConfig" "Product path looks like lab backend (false RAM green risk)"
         }
     } else {
-        Bad "Product exe missing: $ProductExe"
+        Bad "ProductConfig" "Product exe missing: $ProductExe"
     }
     if (Test-Path -LiteralPath $ConfigPath) {
         $ch = (Get-FileHash -Algorithm SHA256 -LiteralPath $ConfigPath).Hash
-        Ok "Config $ConfigPath SHA256=$ch"
+        Ok "ProductConfig" "Config $ConfigPath SHA256=$ch"
         $raw = Get-Content -LiteralPath $ConfigPath -Raw
         if ($raw -match 'backend\s*=') {
-            Bad "Config contains backend= (product forbid)"
+            Bad "ProductConfig" "Config contains backend= (product forbid)"
         } else {
-            Ok "Config has no backend selector"
+            Ok "ProductConfig" "Config has no backend selector"
         }
     } else {
-        Warn "Config missing: $ConfigPath (install will copy example)"
+        Warn "ProductConfig" "Config missing: $ConfigPath (install will copy example)"
     }
 }
 
@@ -265,12 +266,12 @@ $sys = @($serviceImage, "C:\ramshared\package\ramshared.sys") | Where-Object { $
 $drv = $false
 foreach ($s in $sys) {
     if (Test-Path $s) {
-        Ok "Driver package candidate: $s"
+        Ok "DriverPackage" "Driver package candidate: $s"
         $drv = $true
     }
 }
 if (-not $drv) {
-    Warn "ramshared.sys not found in default paths (build/sign/deploy first)"
+    Warn "DriverPackage" "ramshared.sys not found in default paths (build/sign/deploy first)"
 }
 if ($StorageOnly -and
     $serviceImage -and
@@ -279,9 +280,9 @@ if ($StorageOnly -and
     $serviceHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $serviceImage).Hash
     $packageHash = (Get-FileHash -Algorithm SHA256 -LiteralPath "C:\ramshared\package\ramshared.sys").Hash
     if ($serviceHash -eq $packageHash) {
-        Ok "Driver image matches package SHA256=$serviceHash"
+        Ok "DriverPackage" "Driver image matches package SHA256=$serviceHash"
     } else {
-        Bad "Driver image/package mismatch: service=$serviceHash package=$packageHash"
+        Bad "DriverPackage" "Driver image/package mismatch: service=$serviceHash package=$packageHash"
     }
 }
 
@@ -298,26 +299,26 @@ try {
             $err = Test-ControlPath $ctl
             if ($err -eq 0) {
                 $ctlOk = $true
-                Ok "Control path $ctl"
+                Ok "MiniportHealth" "Control path $ctl"
                 break
             } else {
-                Warn "Control path $ctl open failed err=$err"
+                Warn "MiniportHealth" "Control path $ctl open failed err=$err"
             }
         } catch {
-            Warn "Control path $ctl query failed: $_"
+            Warn "MiniportHealth" "Control path $ctl query failed: $_"
         }
     }
     if ($svcRunning -and -not $ctlOk) {
         if ($StorageOnly) {
-            Bad "ramshared service is RUNNING but RamSharedCtl is absent; reboot/unload/redeploy before physical Online"
+            Bad "MiniportHealth" "ramshared service is RUNNING but RamSharedCtl is absent; reboot/unload/redeploy before physical Online"
         } else {
-            Warn "ramshared service is RUNNING but RamSharedCtl is absent"
+            Warn "MiniportHealth" "ramshared service is RUNNING but RamSharedCtl is absent"
         }
     } elseif (-not $svcRunning) {
-        Warn "ramshared service not running yet; campaign must start it before Online"
+        Warn "MiniportHealth" "ramshared service not running yet; campaign must start it before Online"
     }
 } catch {
-    Warn "ramshared service/control query failed: $_"
+    Warn "MiniportHealth" "ramshared service/control query failed: $_"
 }
 
 # Latest dump identity (no contents)
@@ -325,17 +326,17 @@ $dumpDir = "C:\Windows\Minidump"
 if (Test-Path $dumpDir) {
     $latest = Get-ChildItem $dumpDir -Filter *.dmp -EA SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 1
     if ($latest) {
-        Ok "Latest dump: $($latest.Name) @ $($latest.LastWriteTimeUtc.ToString('u')) size=$($latest.Length)"
+        Ok "DumpIdentity" "Latest dump: $($latest.Name) @ $($latest.LastWriteTimeUtc.ToString('u')) size=$($latest.Length)"
     } else {
-        Ok "No minidumps present"
+        Ok "DumpIdentity" "No minidumps present"
     }
 } else {
-    Ok "Minidump directory absent"
+    Ok "DumpIdentity" "Minidump directory absent"
 }
 
 $elapsed = ((Get-Date) - $start).TotalSeconds
 if ($elapsed -gt $TimeoutSec) {
-    Warn "Preflight exceeded TimeoutSec=$TimeoutSec (elapsed=$([int]$elapsed)s)"
+    Warn "Timeout" "Preflight exceeded TimeoutSec=$TimeoutSec (elapsed=$([int]$elapsed)s)"
 }
 Write-Host ("PREFLIGHT_ELAPSED_SEC={0:n1}" -f $elapsed)
 
@@ -347,9 +348,8 @@ if ($StorageOnly) {
     }
 }
 
+$script:results
+
 if ($fail -gt 0) {
-    Write-Host "Preflight finished with $fail failure(s)." -ForegroundColor Red
-    exit 1
+    Write-Error -ErrorId "PreflightFailures" -Message "Preflight finished with $fail failure(s)." -ErrorAction Stop
 }
-Write-Host "Preflight finished with no hard failures." -ForegroundColor Green
-exit 0


### PR DESCRIPTION
## Resumo
Update `Get-WinDrivePreflight.ps1` to return an array of PSCustomObject elements describing check results rather than just console output, improving machine readability while adhering to fail-fast principles with Write-Error termination for hard failures.
## Issue
OpsInfra-100
## Responsavel
Jules
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(preflight) | Updated Get-WinDrivePreflight.ps1 | For structured script execution validation | Used PSCustomObject and Write-Error |
## Labels
type:scripts
## Validacao
echo "pwsh script.ps1 cannot be run because the pwsh runtime is unavailable."
## Rollback trigger
If structured results array processing fails or missing check names cause parsing exceptions.

---
*PR created automatically by Jules for task [2419550210810533353](https://jules.google.com/task/2419550210810533353) started by @emersonbusson*