### PR TITLE
feat(ps1-windows): add GPU guard clauses for VRAM validation

### DIFF
--- a/scripts/windows/Measure-PagefileVram.ps1
+++ b/scripts/windows/Measure-PagefileVram.ps1
@@ -12,14 +12,34 @@
 #>
 [CmdletBinding()]
 param(
+    [ValidateRange(1, [int]::MaxValue)]
     [int]$Runs = 3,
     [ValidateSet("idle", "loaded")]
     [string]$LoadTag = "idle",
     [string]$RepoRoot = "",
+    [ValidateNotNullOrEmpty()]
     [string]$ArtifactDir = ".\artifacts\pagefile-vram-measure"
 )
 
 $ErrorActionPreference = "Stop"
+
+$gpuAdapters = Get-CimInstance -ClassName Win32_VideoController -ErrorAction SilentlyContinue
+if ($null -eq $gpuAdapters -or $gpuAdapters.Count -eq 0) {
+    Write-Error -ErrorId "GPU_ADAPTER_MISSING" -Message "No GPU adapter detected via Win32_VideoController." -ErrorAction Stop
+}
+
+$hasVram = $false
+foreach ($adapter in @($gpuAdapters)) {
+    if ($null -ne $adapter.AdapterRAM) {
+        $hasVram = $true
+        break
+    }
+}
+
+if (-not $hasVram) {
+    Write-Error -ErrorId "VRAM_QUERY_UNAVAILABLE" -Message "VRAM query availability failed: AdapterRAM property is null or unavailable." -ErrorAction Stop
+}
+
 New-Item -ItemType Directory -Force -Path $ArtifactDir | Out-Null
 
 function Measure-Once {


### PR DESCRIPTION
## Resumo
Added guard clauses to `scripts/windows/Measure-PagefileVram.ps1` to validate GPU adapter presence and VRAM query availability via Win32_VideoController. Parameter validations (`ValidateRange` and `ValidateNotNullOrEmpty`) were added.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Add GPU and VRAM guard clauses | Enforce fail-fast prerequisites | <details><summary>Details</summary>Validated Get-CimInstance Win32_VideoController</details> |

## Issue
Resolves #028

## Responsavel
@jules

## Labels
type:scripts, area:validation

## Validacao
PSScriptAnalyzer (skipped via echo, tool unavailable)

## Rollback trigger
Revert if the script fails prematurely on valid systems with accessible GPUs.

---
*PR created automatically by Jules for task [2839032318724173143](https://jules.google.com/task/2839032318724173143) started by @emersonbusson*