### PR TITLE
feat(ps1-windows): validate pagefile size against physical RAM and disk capacity

### DIFF
--- a/scripts/windows/Set-WinPagingFilesConcrete.ps1
+++ b/scripts/windows/Set-WinPagingFilesConcrete.ps1
@@ -16,10 +16,36 @@ param(
     [switch]$Apply,
     [switch]$Restore,
     [switch]$Approve,
-    [string]$SnapshotPath = "C:\ProgramData\RamShared\pagingfiles-snapshot.json"
+    [string]$SnapshotPath = "C:\ProgramData\RamShared\pagingfiles-snapshot.json",
+    [long]$RequestedSizeBytes = 0,
+    [string]$TargetVolume = "C:\"
 )
 
 $ErrorActionPreference = "Stop"
+
+function Assert-ValidPagefileSize {
+    param(
+        [long]$SizeBytes,
+        [string]$VolumePath
+    )
+    if ($SizeBytes -le 0) { return }
+
+    $cs = Get-CimInstance Win32_ComputerSystem
+    $physicalRam = [long]$cs.TotalPhysicalMemory
+    $minSize = $physicalRam
+    $maxSize = $physicalRam * 3
+
+    if ($SizeBytes -lt $minSize -or $SizeBytes -gt $maxSize) {
+        throw [System.ArgumentOutOfRangeException]::new("RequestedSizeBytes", "Requested pagefile size must be between 1x and 3x physical RAM.")
+    }
+
+    $driveRoot = [System.IO.Path]::GetPathRoot($VolumePath)
+    $freeSpace = [System.IO.DriveInfo]::new($driveRoot).AvailableFreeSpace
+
+    if ($SizeBytes -gt $freeSpace) {
+        throw [System.IO.IOException]::new("Requested pagefile size exceeds available free space on target volume.")
+    }
+}
 $key = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management"
 $valueName = "PagingFiles"
 
@@ -64,6 +90,10 @@ function Read-Snapshot {
 
 if ($Apply -and $Restore) {
     throw "Use either -Apply or -Restore, not both."
+}
+
+if ($RequestedSizeBytes -gt 0) {
+    Assert-ValidPagefileSize -SizeBytes $RequestedSizeBytes -VolumePath $TargetVolume
 }
 
 $current = @(Read-Current)


### PR DESCRIPTION
## Resumo
Added guard clauses to Set-WinPagingFilesConcrete.ps1 to validate requested pagefile size against physical RAM (1x to 3x) and available disk capacity.
## Issue
027
## Responsavel
Jules
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: validate pagefile size limits | Added `Assert-ValidPagefileSize` function and parameters | Enforce physical limits on requested pagefile size | Checks 1x-3x physical RAM and disk free space via CIM/DriveInfo |
## Labels
type:scripts, type:reliability
## Validacao
echo "pwsh scripts/windows/Set-WinPagingFilesConcrete.ps1 cannot be run because the pwsh runtime is unavailable."
echo "pwsh scripts/windows/Test-WinPagingFilesConcreteStatic.ps1 cannot be run because the pwsh runtime is unavailable."
echo "PSScriptAnalyzer cannot be run as it is unavailable in the environment."
## Rollback trigger
Revert if pagefile size validation incorrectly blocks legitimate setups or causes runtime errors.

---
*PR created automatically by Jules for task [8396786162202212256](https://jules.google.com/task/8396786162202212256) started by @emersonbusson*