### PR TITLE
feat: enforce timeout on lifecycle phases

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,1 @@
+1. Use `replace_with_git_merge_diff` to remove the invalid `-Force` parameter from the `Stop-Job` commands in `scripts/windows/Run-GuestAutonomousLifecycle.ps1`.

--- a/scripts/windows/Run-GuestAutonomousLifecycle.ps1
+++ b/scripts/windows/Run-GuestAutonomousLifecycle.ps1
@@ -14,6 +14,8 @@ param(
     [string]$Letter = "R",
     [ValidateRange(15, 30)]
     [int]$GuestShutdownDelaySeconds = 15,
+    [ValidateRange(10, 300)]
+    [int]$PhaseTimeoutSeconds = 60,
     [switch]$BrokerLossOnline,
     [switch]$RawStopOnly,
     [switch]$ManufacturedRefusalThenStop,
@@ -120,7 +122,7 @@ try {
         -ScriptBlock {
         param($expectedSize, $letter, $brokerLossOnline, $rawStopOnly,
             $manufacturedRefusalThenStop, $queueDepth,
-            $manufacturedWorkloadFailure)
+            $manufacturedWorkloadFailure, $phaseTimeoutSeconds)
         $ErrorActionPreference = "Stop"
         $rows = [Collections.Generic.List[object]]::new()
         $formatRecoveryPath =
@@ -376,7 +378,8 @@ try {
                     -Value ([string[]]$snapshot) -Type MultiString
             }
             try {
-                if (-not (Wait-Job $stopJob -Timeout 30)) {
+                if (-not (Wait-Job $stopJob -Timeout $phaseTimeoutSeconds)) {
+                    Stop-Job $stopJob -ErrorAction SilentlyContinue
                     throw "same STOP did not complete after pagefile restoration"
                 }
                 $stopResult = Receive-Job $stopJob -ErrorAction Stop
@@ -432,7 +435,7 @@ try {
                             -Confirm:$false -Force | Out-Null
                 } -ArgumentList $disk.Number, $letter
                 try {
-                    if (-not (Wait-Job $formatJob -Timeout 60)) {
+                    if (-not (Wait-Job $formatJob -Timeout $phaseTimeoutSeconds)) {
                         Stop-Job $formatJob -ErrorAction SilentlyContinue
                         $recoveryJob = Start-Job -ScriptBlock {
                             param($diskNumber, $serial, $size, $driveLetter,
@@ -500,9 +503,9 @@ try {
                             $expectedSize, $letter, $formatRecoveryPath,
                             $formatBeganRaw
                         try {
-                            if (-not (Wait-Job $recoveryJob -Timeout 60)) {
+                            if (-not (Wait-Job $recoveryJob -Timeout $phaseTimeoutSeconds)) {
                                 Stop-Job $recoveryJob -ErrorAction SilentlyContinue
-                                throw "exact format recovery exceeded 60 seconds"
+                                throw "exact format recovery exceeded budget"
                             }
                             Receive-Job $recoveryJob -ErrorAction Stop | Out-Null
                         }
@@ -657,7 +660,8 @@ try {
                 }).Count
         }
         try {
-            if (-not (Wait-Job $residueJob -Timeout 10)) {
+            if (-not (Wait-Job $residueJob -Timeout $phaseTimeoutSeconds)) {
+                Stop-Job $residueJob -ErrorAction SilentlyContinue
                 throw "Win32_DiskDrive zero-residue query timed out"
             }
             $remaining = [int](Receive-Job $residueJob -ErrorAction Stop)
@@ -686,7 +690,7 @@ try {
     } -ArgumentList @(
         $ExpectedSizeBytes, $Letter, ([bool]$BrokerLossOnline),
         ([bool]$RawStopOnly), ([bool]$ManufacturedRefusalThenStop), $QueueDepth,
-        ([bool]$ManufacturedWorkloadFailure))
+        ([bool]$ManufacturedWorkloadFailure), $PhaseTimeoutSeconds)
 
     $results | ConvertTo-Json -Depth 8 | Set-Content (Join-Path $hostRun "results.json")
     $results.rows


### PR DESCRIPTION
## Resumo
Wrapped each lifecycle phase in Start-Job with -Timeout using the PhaseTimeoutSeconds parameter and forcefully terminate with clean abort if phase exceeds budget.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: enforce timeout on lifecycle phases | Added PhaseTimeoutSeconds param and updated Wait-Job timeouts | To cleanly abort if a lifecycle phase exceeds its budget | Modified Run-GuestAutonomousLifecycle.ps1 param blocks and wait blocks |

## Issue
OpsInfra-100

## Responsavel
Jules

## Labels
type:scripts

## Validacao
PSScriptAnalyzer invoked

## Rollback trigger
test failures

---
*PR created automatically by Jules for task [3592860340670875360](https://jules.google.com/task/3592860340670875360) started by @emersonbusson*