### PR TITLE
feat: validate crash dump and WinDbg prerequisites

### DIFF
--- a/scripts/windows/Recover-GuestVerifierExactRun.ps1
+++ b/scripts/windows/Recover-GuestVerifierExactRun.ps1
@@ -20,11 +20,32 @@ param(
     [string]$ExpectedPartialPublishedInf = "",
     [ValidateRange(15, 30)][int]$GuestRestartDelaySeconds = 15,
     [switch]$PlanOnly,
-    [switch]$ApproveExactRecovery
+    [switch]$ApproveExactRecovery,
+    [string]$ExpectedCrashDumpPath = "",
+    [string]$ExpectedWinDbgPath = ""
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+function Assert-CrashDumpAndWinDbgPreconditions {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$ExpectedCrashDumpPath,
+        [Parameter(Mandatory = $true)][string]$ExpectedWinDbgPath
+    )
+
+    if (-not (Test-Path -LiteralPath $ExpectedCrashDumpPath -PathType Leaf)) {
+        throw [System.IO.FileNotFoundException]::new("crash dump file is missing at path: $ExpectedCrashDumpPath")
+    }
+    if (-not (Test-Path -LiteralPath $ExpectedWinDbgPath -PathType Leaf)) {
+        throw [System.IO.FileNotFoundException]::new("WinDbg analysis tools are missing at path: $ExpectedWinDbgPath")
+    }
+}
+
+if (-not [string]::IsNullOrWhiteSpace($ExpectedCrashDumpPath) -and -not [string]::IsNullOrWhiteSpace($ExpectedWinDbgPath)) {
+    Assert-CrashDumpAndWinDbgPreconditions -ExpectedCrashDumpPath $ExpectedCrashDumpPath -ExpectedWinDbgPath $ExpectedWinDbgPath
+}
 
 if (-not $ApproveExactRecovery) {
     throw "exact recovery requires explicit approval"


### PR DESCRIPTION
## Resumo
Add guard clauses to validate crash dump availability and WinDbg tools before recovery analysis.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat: validate crash dump and WinDbg paths | Added standalone guard clauses and invoked them | Fail-fast on missing prerequisites | Validates paths in Recover-GuestVerifierExactRun.ps1 |

## Issue
None

## Responsavel
Jules

## Labels
type:scripts

## Validacao
`pwsh -Command "./scripts/windows/Recover-GuestVerifierExactRun.ps1"`
`echo "PSScriptAnalyzer cannot be run as it is unavailable in the environment."`

## Rollback trigger
Revert if the guard clauses cause false positives during recovery.

---
*PR created automatically by Jules for task [756117910014459479](https://jules.google.com/task/756117910014459479) started by @emersonbusson*