### PR TITLE
feat(safety): idempotent cascade activation with pre-state validation

### DIFF
--- a/scripts/safety/cascade-up.sh
+++ b/scripts/safety/cascade-up.sh
@@ -69,6 +69,14 @@ fi
 [[ ${RAMSHARED_NBD_LIFECYCLE_APPROVAL:-} == "$EXPECTED_APPROVAL" ]] || refuse APPROVAL_MISSING
 RAMSHARED_NBD_VRAM_MIB=$VRAM_MIB "$PREFLIGHT" --check
 
+PID_FILE=${RAMSHARED_NBD_PID_FILE:-/run/ramshared/ramsharedd.pid}
+if [[ -s $PID_FILE ]] && kill -0 "$(< "$PID_FILE")" 2>/dev/null; then
+  printf 'NBD_LIFECYCLE_STATE=ALREADY_ACTIVE\n'
+  printf 'NBD_LIFECYCLE_ACTION=activate\n'
+  printf 'NBD_LIFECYCLE_VERSION=%s\n' "$RELEASE_VERSION"
+  exit 0
+fi
+
 printf 'NBD_LIFECYCLE_STATE=EXECUTING\n'
 printf 'NBD_LIFECYCLE_ACTION=activate\n'
 printf 'NBD_LIFECYCLE_VERSION=%s\n' "$RELEASE_VERSION"


### PR DESCRIPTION
## Resumo
Check if cascade is already active before attempting re-activation to prevent double-mount.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(safety): idempotent cascade activation with pre-state validation | Adicionou validação de estado (pid file / kill -0) antes de `EXECUTING` | Prevenir double-mounts garantindo idempotência conforme diretrizes | `cascade-up.sh` modificado para emitir `ALREADY_ACTIVE` e sair com sucesso |

## Labels
type:scripts, type:safety, type:lifecycle

## Validacao
run shellcheck on the modified file (shellcheck was missing, documented absence), and safety test suite execution passed.

## Rollback trigger
If the cascade activation fails or behaves incorrectly.

---
*PR created automatically by Jules for task [3354853655451356575](https://jules.google.com/task/3354853655451356575) started by @emersonbusson*