### PR TITLE
docs: report architectural mismatch for swap drain guard in cascade-down

### DIFF
--- a/docs/jules/findings/cascade-down-mismatch.md
+++ b/docs/jules/findings/cascade-down-mismatch.md
@@ -1,0 +1,12 @@
+# FINDING_ONLY: cascade-down swap drain guard
+
+## Issue
+Task requested adding a swap draining guard check before deactivation to ensure no processes are pinning swap pages in `scripts/safety/cascade-down.sh`.
+
+## Findings
+`scripts/safety/cascade-down.sh` does not directly perform the swapoff action; it only signals the `$CLI down` process (`exec "$CLI" down`).
+The `swapoff` action and the handling of pages is delegated to the daemon lifecycle or other orchestration layers.
+Adding an active swap check here is an architectural mismatch because the Rust lifecycle owns swapoff-first as stated in the script's header.
+
+## Action
+No code changes were made to `scripts/safety/cascade-down.sh` to avoid hallucinating functionality not present in the current script scope.


### PR DESCRIPTION
## Resumo
Created a FINDING_ONLY report to document an architectural mismatch regarding adding a swap drain guard in `scripts/safety/cascade-down.sh`.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| (hash) | Added FINDING_ONLY report | To comply with immutable contract rule 4 | Documented that adding a swapoff guard in `cascade-down.sh` is an architectural mismatch since the script delegates the swapoff lifecycle to Rust orchestration. |

## Labels
type:scripts, type:security, type:docs

## Validacao
shellcheck scripts/safety/cascade-down.sh (Passed)
PSScriptAnalyzer (Unavailable in environment)

## Rollback trigger
Revert if the findings document causes CI/CD checks to fail due to file tracking rules.

---
*PR created automatically by Jules for task [14599598913474928568](https://jules.google.com/task/14599598913474928568) started by @emersonbusson*