### PR TITLE
feat(safety): implement SIGALRM watchdog for wsl2 freeze

### DIFF
--- a/scripts/safety/wsl2-freeze-campaign.sh
+++ b/scripts/safety/wsl2-freeze-campaign.sh
@@ -375,17 +375,25 @@ if [[ "$RUN_ISOLATED" -eq 1 || "$RUN_SHARED" -eq 1 ]]; then
       fi
       if [[ -n "$action_pid" ]]; then
         watchdog_deadline=$((WATCHDOG_SEC + ACTION_CLEANUP_GRACE_SEC))
+
+        trap_cleanup() {
+          echo "action_cleanup_timeout after ${watchdog_deadline}s" >"$rdir/watchdog.txt"
+          kill -9 "$action_pid" 2>/dev/null || true
+        }
+        trap trap_cleanup SIGALRM
+
         (
           sleep "$watchdog_deadline"
-          if kill -0 "$action_pid" 2>/dev/null; then
-            echo "action_cleanup_timeout after ${watchdog_deadline}s" >"$rdir/watchdog.txt"
-          fi
+          kill -ALRM $$ 2>/dev/null || true
         ) &
         wd_pid=$!
+        set +e
         wait "$action_pid"
         action_rc=$?
+        set -e
         kill "$wd_pid" 2>/dev/null || true
         wait "$wd_pid" 2>/dev/null || true
+        trap - SIGALRM
       fi
       set -e
     else


### PR DESCRIPTION
## Resumo
Implement alarm-based timeout with trap SIGALRM handler and cleanup for WSL2 freeze operations.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: add SIGALRM handler | Replaced inline background sleep check with `trap SIGALRM` and `kill -ALRM` | Ensure robust watchdog timeout and process cleanup | The previous approach left processes running if the script exited, this guarantees termination. |

## Labels
type:scripts, type:security

## Validacao
shellcheck scripts/safety/wsl2-freeze-campaign.sh

## Rollback trigger
Script fails abruptly or leaves orphaned processes.

---
*PR created automatically by Jules for task [6803371975021292708](https://jules.google.com/task/6803371975021292708) started by @emersonbusson*