### PR TITLE
feat(scripts): add guard clauses for postmortem fallbacks

### DIFF
--- a/scripts/safety/postmortem.sh
+++ b/scripts/safety/postmortem.sh
@@ -99,7 +99,11 @@ fi
 # the pipefail+grep-q+SIGPIPE gotcha that caused false "no crash" reports).
 dump_boot() { # $1 = boot index -> arquivo em $TMPDIR_PM
   local idx="$1" f="$TMPDIR_PM/boot${1}.log"
-  [ -f "$f" ] || journalctl -b "$idx" --no-pager >"$f" 2>/dev/null
+  if command -v journalctl &>/dev/null; then
+    [ -f "$f" ] || journalctl -b "$idx" --no-pager >"$f" 2>/dev/null
+  else
+    [ -f "$f" ] || echo "(journalctl indisponivel)" >"$f"
+  fi
   echo "$f"
 }
 
@@ -129,8 +133,12 @@ case "${1:-}" in
   * ) BOOT_INDEX="$1" ;;
 esac
 
-BOOT_ID="$(journalctl -b "$BOOT_INDEX" --no-pager -o json -n 1 2>/dev/null \
-            | grep -o '"_BOOT_ID":"[a-f0-9]*"' | head -1 | cut -d'"' -f4)"
+if command -v journalctl &>/dev/null; then
+  BOOT_ID="$(journalctl -b "$BOOT_INDEX" --no-pager -o json -n 1 2>/dev/null \
+              | grep -o '"_BOOT_ID":"[a-f0-9]*"' | head -1 | cut -d'"' -f4)"
+else
+  BOOT_ID=""
+fi
 [ -z "$BOOT_ID" ] && BOOT_ID="unknown-$(date +%s)"
 
 if [ "$AUTO" = "1" ]; then
@@ -247,7 +255,7 @@ REPORT="$FORENSICS_DIR/postmortem-${TS}-boot${BOOT_INDEX}.md"
   echo "# nvidia-smi:"; "$NVSMI" --query-gpu=memory.used,memory.free,memory.total --format=csv 2>&1 || echo "(nvidia-smi indisponivel)"
   echo; echo "# free -h:"; free -h 2>&1
   echo; echo "# /proc/swaps:"; cat /proc/swaps 2>&1
-  echo; echo "# dmesg (ultimas 20):"; (sudo -n dmesg 2>/dev/null || dmesg 2>/dev/null || echo "(dmesg precisa de root)") | tail -20
+  echo; echo "# dmesg (ultimas 20):"; if command -v dmesg &>/dev/null; then (sudo -n dmesg 2>/dev/null || dmesg 2>/dev/null || echo "(dmesg precisa de root)") | tail -20; else echo "(dmesg indisponivel)"; fi
   echo '```'
   echo
 
@@ -267,8 +275,26 @@ REPORT="$FORENSICS_DIR/postmortem-${TS}-boot${BOOT_INDEX}.md"
 
   echo "## 8. Crash dumps do WSL (se houver)"
   echo '```'
-  ls -la /var/crash/ 2>/dev/null | tail -10 || echo "(sem /var/crash)"
-  ls -la /mnt/c/Users/*/AppData/Local/Temp/*.dmp 2>/dev/null | tail -5 || echo "(sem .dmp em Temp)"
+  if [ -d "/var/crash/" ]; then
+    shopt -s nullglob
+    CRASH_FILES=(/var/crash/*)
+    shopt -u nullglob
+    if [ ${#CRASH_FILES[@]} -gt 0 ]; then
+      ls -la "${CRASH_FILES[@]}" | tail -10
+    else
+      echo "(sem arquivos em /var/crash)"
+    fi
+  else
+    echo "(sem /var/crash)"
+  fi
+  shopt -s nullglob
+  DMP_FILES=(/mnt/c/Users/*/AppData/Local/Temp/*.dmp)
+  shopt -u nullglob
+  if [ ${#DMP_FILES[@]} -gt 0 ]; then
+    ls -la "${DMP_FILES[@]}" | tail -5
+  else
+    echo "(sem .dmp em Temp)"
+  fi
   echo '```'
 } > "$REPORT" 2>&1
 


### PR DESCRIPTION
## Resumo
Added guard clauses for dmesg, journalctl, and crash dump availability in postmortem script to prevent errors in environments missing these tools.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| add guard clauses | added fallbacks for missing journalctl/dmesg and safe wildcards | prevent script crash in environments missing tools | checks if journalctl and dmesg exist before running them, uses shopt nullglob |

## Labels
type:scripts
type:safety

## Validacao
bash -n scripts/safety/postmortem.sh
bash scripts/safety/postmortem.sh

## Rollback trigger
if the script starts failing in valid wsl2 environments

---
*PR created automatically by Jules for task [6957021911513107461](https://jules.google.com/task/6957021911513107461) started by @emersonbusson*