### PR TITLE
feat: add guard clauses for wslconfig path and semantic exits

### DIFF
--- a/scripts/safety/wslconfig-ctl.sh
+++ b/scripts/safety/wslconfig-ctl.sh
@@ -36,12 +36,16 @@ cmd_check() {
 	local cfg
 	if ! cfg="$(wslconfig_path)"; then
 		echo "CHECK: cannot resolve .wslconfig (set WSL_CONFIG= or WIN_USER=)"
-		exit 2
+		exit 69
 	fi
 	echo "CHECK path=$cfg"
+	if [[ ! "$cfg" == /mnt/c/Users/* ]]; then
+		echo "CHECK: .wslconfig path ($cfg) is not in expected Windows home directory"
+		exit 78
+	fi
 	if [[ ! -f "$cfg" ]]; then
 		echo "CHECK: MISSING (run: bash scripts/safety/wslconfig-ctl.sh apply)"
-		exit 1
+		exit 74
 	fi
 	if wslconfig_validate_file "$cfg"; then
 		echo "CHECK: OK (no unsafe escapes or unapproved sparse VHD)"
@@ -52,14 +56,22 @@ cmd_check() {
 		exit 0
 	fi
 	echo "CHECK: FAIL — fix with: bash scripts/safety/wslconfig-ctl.sh apply"
-	exit 1
+	exit 78
 }
 
 cmd_apply() {
 	local cfg
 	if ! cfg="$(wslconfig_path)"; then
 		echo "APPLY: cannot resolve .wslconfig"
-		exit 2
+		exit 69
+	fi
+	if [[ ! "$cfg" == /mnt/c/Users/* ]]; then
+		echo "APPLY: .wslconfig path ($cfg) is not in expected Windows home directory"
+		exit 78
+	fi
+	if [[ -f "$cfg" ]] && ! wslconfig_validate_file "$cfg"; then
+		echo "APPLY: .wslconfig format validation failed before modification"
+		exit 78
 	fi
 	wslconfig_write_host "$cfg"
 	echo "APPLY: OK — restart WSL when idle to reload memory=/swap= (wsl --shutdown)"
@@ -215,7 +227,7 @@ cmd_selftest() {
 	rm -rf "$td"
 	if [[ "$fail" -ne 0 ]]; then
 		echo "SELFTEST: FAIL"
-		exit 1
+		exit 78
 	fi
 	echo "SELFTEST: PASS"
 	exit 0
@@ -233,7 +245,7 @@ main() {
 	-h | --help | help) usage ;;
 	*)
 		usage >&2
-		exit 2
+		exit 64
 		;;
 	esac
 }


### PR DESCRIPTION
## Resumo
Adicionou guard clauses para validar o caminho do .wslconfig e atualizou os códigos de saída para os padrões do `sysexits.h`.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: add guard clauses for wslconfig path and semantic exits | Adicionou validação de caminho para `%UserProfile%`, e atualizou os códigos de erro. | Seguir o princípio de Guard Clauses e Fail-Fast, limitando as modificações apenas à home dir esperada e retornando falhas semânticas. | exit codes alterados para 64, 69, 74, 78. |

## Labels
type:scripts

## Validacao
shellcheck scripts/safety/wslconfig-ctl.sh não pôde ser executado pois a ferramenta não está disponível no ambiente. Foram executados bash -n scripts/safety/wslconfig-ctl.sh (sintaxe) e os selftests do arquivo que passaram com sucesso, e verificação manual de regressão das funções check.

## Rollback trigger
Se os testes de pipeline falharem com os novos exit codes (como 69, 74, 78) em vez de 1 e 2.

---
*PR created automatically by Jules for task [17435139277387929083](https://jules.google.com/task/17435139277387929083) started by @emersonbusson*