### PR TITLE
feat(scripts): add guard clauses for build dependencies and architecture

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,6 +19,24 @@ echo "    RamShared Installer — High-Performance VRAM Tier     "
 echo "  ======================================================="
 echo ""
 
+# Validate architecture and build dependencies
+validate_prerequisites() {
+  local arch
+  arch="$(uname -m)"
+  if [[ "$arch" != "x86_64" && "$arch" != "aarch64" ]]; then
+    echo "Error: Unsupported architecture $arch" >&2
+    exit 69
+  fi
+
+  for cmd in cargo rustc gcc; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      echo "Error: Missing required dependency: $cmd" >&2
+      exit 69
+    fi
+  done
+}
+validate_prerequisites
+
 # Check root permissions
 if [[ $EUID -ne 0 ]]; then
   echo "Error: This installer must be run as root (use sudo)." >&2


### PR DESCRIPTION
## Resumo
Added `validate_prerequisites` guard clause to `scripts/install.sh` to validate the target architecture (`x86_64` or `aarch64`) and ensure required build dependencies (`cargo`, `rustc`, `gcc`) are available. Fail-fast with EX_UNAVAILABLE (69) if they are missing.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| [hash] | Added architecture and dependency checks | Enforce physical limits and required dependencies before execution | Fail-fast with EX_UNAVAILABLE (69) if `uname -m` is unsupported or `cargo`/`rustc`/`gcc` are missing. |

## Labels
type:scripts

## Validacao
Ran `bash -n scripts/install.sh`. 

## Rollback trigger
If the deployment scripts fail on valid environments due to missing path settings for dependencies or a misidentified architecture.

---
*PR created automatically by Jules for task [11364044069333051803](https://jules.google.com/task/11364044069333051803) started by @emersonbusson*