### PR TITLE
fix(scripts): enforce semantic exit code in measure-psi.sh guard clause

### DIFF
--- a/scripts/p0/measure-psi.sh
+++ b/scripts/p0/measure-psi.sh
@@ -15,7 +15,7 @@ log() { echo "$LOG_PREFIX $*" >&2; }
 # Preflight: without CONFIG_PSI the file does not exist — the broker depends on PSI (DT-15).
 [ -r "$PSI" ] || {
 	log "ERROR: $PSI is unreadable. Kernel without CONFIG_PSI/PSI_DEFAULT_DISABLED? PSI is required."
-	exit 1
+	exit 69
 }
 
 log "sampling $PSI for ${DURATION}s -> $OUT"


### PR DESCRIPTION
## Resumo
Added specific semantic error exit code (EX_UNAVAILABLE = 69) for `/proc/pressure/memory` check in `measure-psi.sh`.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| c60c31b | Modified exit code in measure-psi.sh | To adhere to architectural principles requiring sysexits.h codes | Changed `exit 1` to `exit 69` on guard clause failure |

## Labels
type:scripts

## Validacao
echo "shellcheck cannot be run as it is unavailable in the environment."

## Rollback trigger
Revert if the script causes downstream CI/CD failures due to the exit code change.

---
*PR created automatically by Jules for task [10611438934157572736](https://jules.google.com/task/10611438934157572736) started by @emersonbusson*