### PR TITLE
feat: make quickstart script idempotent and add semantic exit codes

### DIFF
--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -17,26 +17,32 @@ if ! command -v cargo >/dev/null 2>&1 || ! command -v rustc >/dev/null 2>&1; the
   echo "  Rust is not installed (need cargo + rustc)."
   echo "  Install from: https://rustup.rs/"
   echo ""
-  exit 1
+  exit 69
 fi
-
-echo "  Using: $(rustc --version)"
-echo ""
-echo "  Building (release)… this can take a few minutes the first time."
-echo ""
-
-cargo build -p ramshared-cli -p ramshared-wsl2d --release
 
 CLI="$ROOT/target/release/ramshared"
 DAEMON="$ROOT/target/release/ramsharedd"
 
-if [[ ! -x "$CLI" || ! -x "$DAEMON" ]]; then
-  echo "  Build finished but binaries are missing. Please open an issue."
-  exit 1
-fi
+if [[ -x "$CLI" && -x "$DAEMON" ]]; then
+  echo "  RamShared is already installed."
+  echo "  Upgrade path: Run 'git pull' to fetch latest changes, then 'cargo build --release' to upgrade."
+  echo ""
+else
+  echo "  Using: $(rustc --version)"
+  echo ""
+  echo "  Building (release)… this can take a few minutes the first time."
+  echo ""
 
-echo ""
-echo "  Build OK."
+  cargo build -p ramshared-cli -p ramshared-wsl2d --release
+
+  if [[ ! -x "$CLI" || ! -x "$DAEMON" ]]; then
+    echo "  Build finished but binaries are missing. Please open an issue."
+    exit 70
+  fi
+
+  echo ""
+  echo "  Build OK."
+fi
 echo ""
 echo "  Next steps (needs Linux/WSL2 + NVIDIA GPU + sudo):"
 echo ""


### PR DESCRIPTION
## Resumo
Updated `scripts/quickstart.sh` to make it idempotent by checking if the binaries already exist before building. Replaced generic exit codes with `sysexits.h` semantic exit codes (`EX_UNAVAILABLE` and `EX_SOFTWARE`).

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| <hash> | Make quickstart.sh idempotent and update exit codes | To prevent duplicate installations and follow architectural guidelines for fail-fast and specific error returns | <details>The script now checks if `ramshared` and `ramsharedd` exist and are executable. If so, it skips the build process and offers an upgrade path. Changed exit codes from 1 to 69 (EX_UNAVAILABLE) for missing Rust and 70 (EX_SOFTWARE) for missing binaries after build.</details> |

## Labels
type:scripts area:install

## Validacao
Ran `bash -n scripts/quickstart.sh` to check syntax. Executed the script twice to verify idempotency. Shellcheck could not be run because it is unavailable in the environment.

## Rollback trigger
Installation fails or the script exits unexpectedly on clean environments.

---
*PR created automatically by Jules for task [11236188336427718362](https://jules.google.com/task/11236188336427718362) started by @emersonbusson*