### PR TITLE
feat: validate GPU device detection

### DIFF
--- a/scripts/p0/measure-vram-headroom.sh
+++ b/scripts/p0/measure-vram-headroom.sh
@@ -8,6 +8,21 @@
 # output: CSV on stdout plus a summary (free min/max/mean plus volatility).
 set -euo pipefail
 
+if command -v nvidia-smi >/dev/null 2>&1; then
+  if ! nvidia-smi -L >/dev/null 2>&1; then
+    echo "Error: nvidia-smi found but failed to detect working GPU." >&2
+    exit 69
+  fi
+elif command -v vulkaninfo >/dev/null 2>&1; then
+  if ! vulkaninfo >/dev/null 2>&1; then
+    echo "Error: vulkaninfo found but failed to detect working GPU." >&2
+    exit 69
+  fi
+else
+  echo "Error: Neither nvidia-smi nor vulkaninfo is available." >&2
+  exit 69
+fi
+
 DUR="${1:-30}"
 STEP="${2:-2}"
 N=$(( DUR / STEP ))


### PR DESCRIPTION
## Resumo
Added guard clauses to validate GPU detection before measuring VRAM headroom.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: validate GPU device detection | Added checks for nvidia-smi and vulkaninfo | Prevent script from running without valid GPU context | Used sysexits.h EX_UNAVAILABLE (69) for early exit |

## Labels
type:scripts, type:security

## Validacao
shellcheck scripts/p0/measure-vram-headroom.sh

## Rollback trigger
Measurement script fails prematurely on nodes that actually have valid GPUs detected by other means.

---
*PR created automatically by Jules for task [5011941251649248402](https://jules.google.com/task/5011941251649248402) started by @emersonbusson*