### PR TITLE
fix(scripts): add guard clauses for ublk module and device

### DIFF
--- a/scripts/kernel/qemu-ublk-daemon.sh
+++ b/scripts/kernel/qemu-ublk-daemon.sh
@@ -58,8 +58,14 @@ if $BB insmod /modules/ublk_drv.ko 2>/tmp/e; then
   echo "KTEST-INSMOD=ok"
 else
   echo "KTEST-INSMOD=fail: $($BB cat /tmp/e)"
+  exit 69
 fi
-[ -e /dev/ublk-control ] && echo "KTEST-UBLK-CONTROL=present" || echo "KTEST-UBLK-CONTROL=absent"
+if [ -e /dev/ublk-control ]; then
+  echo "KTEST-UBLK-CONTROL=present"
+else
+  echo "KTEST-UBLK-CONTROL=absent"
+  exit 69
+fi
 
 # 2) starts the daemon in the isolated generic-Linux QEMU guest (--force for best-effort mlockall)
 /ramsharedd --transport ublk --backend ram \


### PR DESCRIPTION
## Resumo
Added guard clauses to `scripts/kernel/qemu-ublk-daemon.sh` to validate that the `ublk_drv` kernel module is successfully loaded and that the `/dev/ublk-control` character device exists. This satisfies the fail-fast architectural principle by immediately exiting if requirements are not met.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| - | - | - | - |
| - | Added guard clauses | Fail-fast principle | Hardened ublk module loading using exit code 69 |

## Labels
type:scripts, type:security

## Validacao
echo "shellcheck cannot be run as it is unavailable in the environment."

## Rollback trigger
Revert if the QEMU isolation test fails to boot or test the daemon.

---
*PR created automatically by Jules for task [367654888972802772](https://jules.google.com/task/367654888972802772) started by @emersonbusson*