### PR TITLE
refactor: structure output and enforce sysexits in preflight.sh

### DIFF
--- a/scripts/safety/preflight.sh
+++ b/scripts/safety/preflight.sh
@@ -1,21 +1,26 @@
 #!/usr/bin/env bash
-# preflight.sh — PORTAO de seguranca (falha-seguro) antes de subir o daemon
-# VRAM/ublk no host WSL2 vivo. RECUSA (exit != 0) em vez de deixar um start perigoso
-# travar a maquina. Roda o snapshot baseline no sucesso.
+set -euo pipefail
+# preflight.sh — Security gate (fail-safe) before bringing up the daemon
+# VRAM/ublk on a live WSL2 host. REJECTS (exit != 0) instead of letting a dangerous start
+# freeze the machine. Runs the baseline snapshot on success.
 #
 # Motivated by the 2026-07-03 incident: a `--backend vram` run with a binary missing the
 # mlockall fix froze the host (kernel BUG). This gate guarantees that only a binary WITH the
 # fix, with a healthy GPU, and without orphaned devices, gets to run.
 #
-# Uso: preflight.sh [caminho_do_binario]
-#   exit 0 = seguro prosseguir (snapshot escrito, coletor armado)
-#   exit 1 = RECUSADO (motivo no stderr) — NAO suba o daemon
-# So LE estado; nao toca GPU/ublk/swap. O unico efeito e escrever o snapshot.
-set -uo pipefail
+# Usage: preflight.sh [binary_path]
+#   exit 0 = safe to proceed (snapshot written, collector armed)
+#   exit != 0 = REJECTED (reason on stderr) — DO NOT start the daemon
+# Only READS state; does not touch GPU/ublk/swap. The only effect is writing the snapshot.
+
+readonly EX_USAGE=64
+readonly EX_UNAVAILABLE=69
+readonly EX_IOERR=74
+readonly EX_CONFIG=78
 
 REPO="${RAMSHARED_REPO:-$(cd "$(dirname "$0")/../.." && pwd)}"
 BIN="${1:-$REPO/target/debug/ramsharedd}"
-FIX_MARKER='MCL_CURRENT-only no caminho ublk+vram'   # string do fix anti-dxgkrnl-BUG (#1)
+FIX_MARKER='MCL_CURRENT-only no caminho ublk+vram'   # string of the anti-dxgkrnl-BUG fix (#1)
 MIN_VRAM_FREE_MIB="${RAMSHARED_MIN_VRAM_FREE_MIB:-256}"
 
 # nvidia-smi in WSL2 is located in /usr/lib/wsl/lib, which is NOT in systemd's minimal PATH.
@@ -23,45 +28,60 @@ MIN_VRAM_FREE_MIB="${RAMSHARED_MIN_VRAM_FREE_MIB:-256}"
 NVSMI="$(command -v nvidia-smi 2>/dev/null || true)"
 [ -x "$NVSMI" ] || NVSMI="/usr/lib/wsl/lib/nvidia-smi"
 
-fail() { echo "PREFLIGHT: RECUSADO — $1" >&2; exit 1; }
+fail() {
+  local code="${2:-1}"
+  echo "PREFLIGHT: [FAIL] — $1" >&2
+  exit "$code"
+}
 
-echo "== RamShared preflight (falha-seguro) =="
+pass() {
+  echo "PREFLIGHT: [PASS] — $1"
+}
 
-# 1. Binario existe e TEM o fix do mlockall (senao = travamento garantido no #1).
-# Materializa `strings` numa var e usa here-string no grep -q: evita o gotcha
-# pipefail+grep-q+SIGPIPE (o pipe `strings | grep -q` retornava o SIGPIPE do strings,
-# nao o sucesso do grep, e recusava o binario bom).
-[ -x "$BIN" ] || fail "binario nao encontrado/executavel: $BIN (rode 'cargo build -p ramshared-wsl2d --bin ramsharedd')"
-BIN_STRINGS="$(strings "$BIN" 2>/dev/null)"
+skip() {
+  echo "PREFLIGHT: [SKIP] — $1"
+}
+
+echo "== RamShared preflight (fail-safe) =="
+
+# 1. Binary exists and HAS the mlockall fix (otherwise = guaranteed freeze in #1).
+# Materializes `strings` into a var and uses here-string in grep -q: avoids the gotcha
+# pipefail+grep-q+SIGPIPE (the pipe `strings | grep -q` returned the SIGPIPE of strings,
+# not the success of grep, and rejected the good binary).
+[ -x "$BIN" ] || fail "binary not found/executable: $BIN (run 'cargo build -p ramshared-wsl2d --bin ramsharedd')" "$EX_UNAVAILABLE"
+BIN_STRINGS="$(strings "$BIN" 2>/dev/null || true)"
 if ! grep -qF "$FIX_MARKER" <<<"$BIN_STRINGS"; then
-  fail "binario SEM o fix do mlockall ($BIN). Recompile com o fix (arm_future_lock) antes de rodar VRAM+ublk. Rodar assim TRAVA o host."
+  fail "binary WITHOUT the mlockall fix ($BIN). Recompile with the fix (arm_future_lock) before running VRAM+ublk. Running like this FREEZES the host." "$EX_CONFIG"
 fi
-echo "  [ok] binario tem o fix do mlockall"
+pass "binary has the mlockall fix"
 
-# 2. GPU saudavel: nvidia-smi responde e ha VRAM livre suficiente.
-SMI_OUT="$("$NVSMI" --query-gpu=memory.free --format=csv,noheader,nounits 2>/dev/null)"
-[ -n "$SMI_OUT" ] || fail "nvidia-smi nao respondeu — GPU/driver em estado ruim; NAO suba VRAM agora"
-VRAM_FREE="$(echo "$SMI_OUT" | head -1 | tr -dc '0-9')"
-[ -n "$VRAM_FREE" ] || fail "nao consegui ler VRAM livre de nvidia-smi"
+# 2. Healthy GPU: nvidia-smi responds and there is enough free VRAM.
+SMI_OUT="$("$NVSMI" --query-gpu=memory.free --format=csv,noheader,nounits 2>/dev/null || true)"
+[ -n "$SMI_OUT" ] || fail "nvidia-smi did not respond — GPU/driver in bad state; DO NOT start VRAM now" "$EX_UNAVAILABLE"
+VRAM_FREE="$(echo "$SMI_OUT" | head -1 | tr -dc '0-9' || true)"
+[ -n "$VRAM_FREE" ] || fail "could not read free VRAM from nvidia-smi" "$EX_UNAVAILABLE"
 if [ "$VRAM_FREE" -lt "$MIN_VRAM_FREE_MIB" ]; then
-  fail "VRAM livre ${VRAM_FREE} MiB < minimo ${MIN_VRAM_FREE_MIB} MiB — sem folga segura"
+  fail "free VRAM ${VRAM_FREE} MiB < minimum ${MIN_VRAM_FREE_MIB} MiB — no safe margin" "$EX_CONFIG"
 fi
-echo "  [ok] GPU responde, VRAM livre=${VRAM_FREE} MiB (>= ${MIN_VRAM_FREE_MIB})"
+pass "GPU responds, free VRAM=${VRAM_FREE} MiB (>= ${MIN_VRAM_FREE_MIB})"
 
-# 3. Sem /dev/ublkb* orfao (sobra de um crash anterior -> colisao/estado sujo).
-if ls /dev/ublkb* >/dev/null 2>&1; then
-  fail "existe /dev/ublkb* orfao (sobra de execucao anterior): $(ls /dev/ublkb* 2>/dev/null | tr '\n' ' '). Limpe antes (o coletor postmortem ja deve ter rodado)."
+# 3. No orphaned /dev/ublkb* (leftover from a previous crash -> collision/dirty state).
+shopt -s nullglob
+UBLK_DEVS=(/dev/ublkb*)
+shopt -u nullglob
+if [ "${#UBLK_DEVS[@]}" -gt 0 ]; then
+  fail "orphaned /dev/ublkb* exists (leftover from previous execution): ${UBLK_DEVS[*]}. Clean up first (the postmortem collector should have already run)." "$EX_IOERR"
 fi
-echo "  [ok] sem device ublk orfao"
+pass "no orphaned ublk device"
 
-# 4. Modulo ublk carregado (/dev/ublk-control presente).
-[ -e /dev/ublk-control ] || fail "/dev/ublk-control ausente — 'sudo modprobe ublk_drv' primeiro"
-echo "  [ok] ublk_drv carregado (/dev/ublk-control presente)"
+# 4. ublk module loaded (/dev/ublk-control present).
+[ -e /dev/ublk-control ] || fail "/dev/ublk-control missing — 'sudo modprobe ublk_drv' first" "$EX_UNAVAILABLE"
+pass "ublk_drv loaded (/dev/ublk-control present)"
 
-# 5. Tudo ok -> snapshot baseline + arma o coletor.
+# 5. Everything ok -> baseline snapshot + arm collector.
 "$REPO/scripts/safety/preflight-snapshot.sh" "${*:-ramsharedd (via preflight)}" >/dev/null 2>&1 \
-  && echo "  [ok] snapshot baseline escrito + coletor armado" \
-  || echo "  [aviso] snapshot falhou (nao-bloqueante), mas checks de seguranca passaram"
+  && pass "baseline snapshot written + collector armed" \
+  || skip "snapshot failed (non-blocking), but security checks passed"
 
-echo "PREFLIGHT: OK — seguro prosseguir."
+echo "PREFLIGHT: [PASS] — safe to proceed."
 exit 0


### PR DESCRIPTION
## Resumo
Refactored `preflight.sh` to use structured pass/fail/skip outputs, semantic exit codes (`sysexits.h`), and translated all Portuguese components to English.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Added structured output PASS/FAIL/SKIP and translated script to English | Enhanced automation parsing, visual clarity, and compliant with English-only rule | Added `sysexits.h` return codes, fixed globbing |

## Labels
type:scripts

## Validacao
Executed `bash -n scripts/safety/preflight.sh` and runtime execution bypass. `shellcheck` is unavailable in the environment.

## Rollback trigger
Script failures or unexpected blocking behavior in WSL environments due to `set -e` pipeline interruptions.

---
*PR created automatically by Jules for task [6227970780696501400](https://jules.google.com/task/6227970780696501400) started by @emersonbusson*