### PR TITLE
feat: add guard clauses to build-wsl-kernel.sh

### DIFF
--- a/scripts/kernel/build-wsl-kernel.sh
+++ b/scripts/kernel/build-wsl-kernel.sh
@@ -16,10 +16,21 @@ set -euo pipefail
 KTAG="${KTAG:-linux-msft-wsl-6.18.y}"
 KSRC="${KSRC:-$HOME/src/WSL2-Linux-Kernel}"
 JOBS="${JOBS:-2}"; [ "$JOBS" -lt 1 ] && JOBS=1
+MAX_JOBS="$(nproc 2>/dev/null || echo 1)"
+if [ "$JOBS" -gt "$MAX_JOBS" ]; then
+  JOBS="$MAX_JOBS"
+fi
 CONFIGS=("$@"); [ ${#CONFIGS[@]} -eq 0 ] && CONFIGS=(CONFIG_BLK_DEV_UBLK=m CONFIG_ZRAM_WRITEBACK=y CONFIG_IO_URING=y)
 
 echo "[build] deps..."
 sudo apt-get install -y -q build-essential flex bison libelf-dev libssl-dev bc dwarves cpio python3 >/dev/null
+
+for cmd in make gcc flex bison; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "[build] error: required tool '$cmd' is missing." >&2
+    exit 69
+  fi
+done
 
 if [ ! -d "$KSRC/.git" ]; then
   echo "[build] cloning $KTAG -> $KSRC"
@@ -27,8 +38,21 @@ if [ ! -d "$KSRC/.git" ]; then
 fi
 cd "$KSRC"
 
+if [ ! -f "Makefile" ]; then
+  echo "[build] error: Invalid kernel source tree in $KSRC" >&2
+  exit 78
+fi
+
 echo "[build] base = Microsoft/config-wsl + extra configs"
+if [ ! -f "Microsoft/config-wsl" ]; then
+  echo "[build] error: Microsoft/config-wsl not found" >&2
+  exit 78
+fi
 cp Microsoft/config-wsl .config
+if [ ! -f ".config" ]; then
+  echo "[build] error: .config was not created" >&2
+  exit 74
+fi
 for kv in "${CONFIGS[@]}"; do
   name="${kv%%=*}"; val="${kv##*=}"
   case "$val" in


### PR DESCRIPTION
## Resumo
Added guard clauses and sanity checks for dependencies, JOBS limit, and source files in build-wsl-kernel.sh to implement fail-fast behavior.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: add guard clauses | Added sanity checks | To fail fast | Checked dependencies and limits |

## Labels
type:scripts, type:infrastructure

## Validacao
`echo "shellcheck cannot be run as it is unavailable in the environment."` and syntax validation via bash -n.

## Rollback trigger
Revert if build-wsl-kernel.sh fails to build or incorrectly aborts due to dependency checks.

---
*PR created automatically by Jules for task [6706782058163180871](https://jules.google.com/task/6706782058163180871) started by @emersonbusson*