### PR TITLE
generate finding report

### DIFF
--- a/docs/jules/findings/27-ci-yml-pinning-trap.md
+++ b/docs/jules/findings/27-ci-yml-pinning-trap.md
@@ -1,0 +1,17 @@
+# FINDING_ONLY: ci.yml third-party action pinning trap
+
+## Executive Summary
+The prompt requested to "pin all third-party actions to full commit SHA hashes" in `.github/workflows/ci.yml`.
+
+However, upon inspecting `.github/workflows/ci.yml`, all third-party GitHub Actions (`actions/checkout`, `dtolnay/rust-toolchain`, `Swatinem/rust-cache`, `actions/setup-node`) are already strictly pinned to full 40-character commit SHA hashes. There are no `@v3` or `@v4` tags in use for these actions.
+
+## Details
+The file contains the following action usages:
+- `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7`
+- `dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # action pinned`
+- `Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2`
+- `actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7`
+
+The instructions explicitly state "Replace all @v3/@v4 action tags with pinned full 40-char SHA hashes", which is already satisfied for all GitHub Actions in the file. Modifying the file would mean attempting to pin something that is already pinned.
+
+As per the immutable contract, since safe code modification is not possible (as the required state already exists), a `FINDING_ONLY` report is generated.


### PR DESCRIPTION
## Resumo
Generated FINDING_ONLY report for ci.yml third-party action pinning trap as all third-party GitHub Actions are already securely pinned to 40-character SHA hashes.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| generate finding report | added 27-ci-yml-pinning-trap.md to docs/jules/findings/ | to document that all actions are already pinned | created markdown finding report |

## Labels
type:security, type:ci

## Validacao
read .github/workflows/ci.yml to verify existing SHAs.

## Rollback trigger
Any mismatch or inaccuracy in the documented finding report.

---
*PR created automatically by Jules for task [854660118275096752](https://jules.google.com/task/854660118275096752) started by @emersonbusson*