### PR TITLE
ci: add hash-based actions/cache for kernel build artifacts

### DIFF
--- a/.github/workflows/kernel-ci.yml
+++ b/.github/workflows/kernel-ci.yml
@@ -61,6 +61,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      - name: Cache kernel object files
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
+        with:
+          path: drivers/block/ramshared/**/*.o
+          key: ${{ runner.os }}-kernel-${{ matrix.compiler }}-${{ hashFiles('drivers/block/ramshared/**/*.c', 'drivers/block/ramshared/**/*.h') }}
+
       - name: Install cross-compilation toolchain
         if: matrix.compiler == 'aarch64-gcc'
         run: sudo apt-get update -qq && sudo apt-get install -y -qq gcc-aarch64-linux-gnu


### PR DESCRIPTION
## Resumo
Adiciona o actions/cache aos artefatos de build do kernel (.o) no workflow de CI para acelerar builds incrementais, utilizando como chave um hash da árvore de código-fonte (C e Headers) do driver ramshared, incluindo a arquitetura do compilador na chave.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| ci: add cache for kernel object files based on source tree hash | Adicionou o passo actions/cache em .github/workflows/kernel-ci.yml | Para acelerar os builds incrementais evitando compilação redundante. | Incluiu `${{ matrix.compiler }}` na cache key para prevenir poisonamento cruzado entre arquiteturas. |

## Labels
type:ci, type:scripts

## Validacao
actionlint estava indisponível. Foi feita revisão manual usando `git diff` e Code Review tool com aprovação total de segurança e consistência.

## Rollback trigger
Se o cache envenenar o ambiente (ex. falso-positivo do cache hit e linker falhando logo após), reverter imediatamente.

---
*PR created automatically by Jules for task [5353056518005972394](https://jules.google.com/task/5353056518005972394) started by @emersonbusson*