### PR TITLE
feat: add initramfs checksum sealing and verification

### DIFF
--- a/scripts/kernel/seal-kernel-pair.sh
+++ b/scripts/kernel/seal-kernel-pair.sh
@@ -24,7 +24,8 @@ fi
 usage() {
 	cat <<'EOF'
 Usage: seal-kernel-pair.sh \
-  --kernel <bzImage> --modules <modules.vhdx> --module-file <module.ko> \
+  --kernel <bzImage> --initramfs <initramfs.cpio.gz> \
+  --modules <modules.vhdx> --module-file <module.ko> \
   --release <kernelrelease> --layout-inventory <file> --qemu-stamp <file> \
   --output-root <directory> [--minimum-wsl-version 2.7.12.0]
 
@@ -36,6 +37,7 @@ EOF
 }
 
 kernel=""
+initramfs=""
 modules=""
 module_file=""
 release=""
@@ -51,13 +53,14 @@ argument_error() {
 }
 while (($#)); do
 	case "$1" in
-	--kernel|--modules|--module-file|--release|--layout-inventory|--qemu-stamp|--output-root|--minimum-wsl-version)
+	--kernel|--initramfs|--modules|--module-file|--release|--layout-inventory|--qemu-stamp|--output-root|--minimum-wsl-version)
 		key="${1#--}"
 		[[ -z "${seen[$key]+x}" ]] || argument_error "duplicate --$key"
 		[[ $# -ge 2 && -n "${2//[[:space:]]/}" && "$2" != --* ]] || argument_error "missing or blank value for --$key"
 		seen[$key]=1
 		case "$key" in
 		kernel) kernel="$2" ;;
+		initramfs) initramfs="$2" ;;
 		modules) modules="$2" ;;
 		module-file) module_file="$2" ;;
 		release) release="$2" ;;
@@ -73,7 +76,7 @@ while (($#)); do
 	esac
 done
 
-for required in kernel modules module-file release layout-inventory qemu-stamp output-root; do
+for required in kernel initramfs modules module-file release layout-inventory qemu-stamp output-root; do
 	[[ -n "${seen[$required]+x}" ]] || argument_error "missing --$required"
 done
 
@@ -105,7 +108,7 @@ assert_canonical_path() {
 	done
 }
 
-for item in kernel modules module_file layout_inventory qemu_stamp; do
+for item in kernel initramfs modules module_file layout_inventory qemu_stamp; do
 	value="${!item}"
 	assert_canonical_path "$value" "$item" 1 || exit 2
 	[[ -f "$value" && ! -L "$value" && "$(stat -c '%h' -- "$value")" == 1 ]] || {
@@ -124,12 +127,14 @@ assert_canonical_path "$output_root" output-root 0 || exit 2
 }
 
 kernel_sha="$(sha256sum -- "$kernel" | awk '{print $1}')"
+initramfs_sha="$(sha256sum -- "$initramfs" | awk '{print $1}')"
 modules_sha="$(sha256sum -- "$modules" | awk '{print $1}')"
 module_file_sha="$(sha256sum -- "$module_file" | awk '{print $1}')"
 kernel_size="$(stat -c '%s' -- "$kernel")"
+initramfs_size="$(stat -c '%s' -- "$initramfs")"
 modules_size="$(stat -c '%s' -- "$modules")"
-((kernel_size > 1048576 && modules_size > 0)) || {
-	echo "kernel must exceed 1 MiB and modules must be non-empty" >&2
+((kernel_size > 1048576 && initramfs_size > 0 && modules_size > 0)) || {
+	echo "kernel must exceed 1 MiB and initramfs/modules must be non-empty" >&2
 	exit 2
 }
 
@@ -259,7 +264,7 @@ published_here=0
 publication_complete=0
 published_identity=""
 owned_pair_leaves=(
-	kernel.bzImage modules.vhdx modules-layout.manifest
+	kernel.bzImage initramfs.cpio.gz modules.vhdx modules-layout.manifest
 	qemu-pass.stamp kernel-pair.manifest
 )
 cleanup_owned_pair_directory() {
@@ -344,7 +349,7 @@ fi
 
 declare -A source_identity=()
 declare -A source_hash=()
-for item in kernel modules layout_inventory qemu_stamp; do
+for item in kernel initramfs modules layout_inventory qemu_stamp; do
 	value="${!item}"
 	source_identity[$item]="$(stat -c '%d:%i:%h:%s' -- "$value")"
 	source_hash[$item]="$(sha256sum -- "$value" | awk '{print $1}')"
@@ -354,6 +359,7 @@ for item in kernel modules layout_inventory qemu_stamp; do
 	}
 done
 [[ "${source_hash[kernel]}" == "$kernel_sha" &&
+	"${source_hash[initramfs]}" == "$initramfs_sha" &&
 	"${source_hash[modules]}" == "$modules_sha" &&
 	"${source_hash[layout_inventory]}" == "$layout_sha" &&
 	"${source_hash[qemu_stamp]}" == "$stamp_sha" ]] || {
@@ -362,18 +368,21 @@ done
 }
 
 exec {kernel_fd}<"$kernel"
+exec {initramfs_fd}<"$initramfs"
 exec {modules_fd}<"$modules"
 exec {layout_fd}<"$layout_inventory"
 exec {qemu_fd}<"$qemu_stamp"
 dd status=none bs=1048576 <&"$kernel_fd" >"$staging/kernel.bzImage"
+dd status=none bs=1048576 <&"$initramfs_fd" >"$staging/initramfs.cpio.gz"
 dd status=none bs=1048576 <&"$modules_fd" >"$staging/modules.vhdx"
 dd status=none bs=1048576 <&"$layout_fd" >"$staging/modules-layout.manifest"
 dd status=none bs=1048576 <&"$qemu_fd" >"$staging/qemu-pass.stamp"
 exec {kernel_fd}<&-
+exec {initramfs_fd}<&-
 exec {modules_fd}<&-
 exec {layout_fd}<&-
 exec {qemu_fd}<&-
-for item in kernel modules layout_inventory qemu_stamp; do
+for item in kernel initramfs modules layout_inventory qemu_stamp; do
 	value="${!item}"
 	[[ "$(stat -c '%d:%i:%h:%s' -- "$value")" == "${source_identity[$item]}" &&
 		"$(sha256sum -- "$value" | awk '{print $1}')" == "${source_hash[$item]}" ]] || {
@@ -389,6 +398,9 @@ release=$release
 kernel_file=kernel.bzImage
 kernel_sha256=$kernel_sha
 kernel_size_bytes=$kernel_size
+initramfs_file=initramfs.cpio.gz
+initramfs_sha256=$initramfs_sha
+initramfs_size_bytes=$initramfs_size
 modules_file=modules.vhdx
 modules_sha256=$modules_sha
 modules_size_bytes=$modules_size
@@ -405,13 +417,14 @@ qemu_release=$release
 EOF
 
 [[ "$(sha256sum -- "$staging/kernel.bzImage" | awk '{print $1}')" == "$kernel_sha" &&
+	"$(sha256sum -- "$staging/initramfs.cpio.gz" | awk '{print $1}')" == "$initramfs_sha" &&
 	"$(sha256sum -- "$staging/modules.vhdx" | awk '{print $1}')" == "$modules_sha" &&
 	"$(sha256sum -- "$staging/modules-layout.manifest" | awk '{print $1}')" == "$layout_sha" &&
 	"$(sha256sum -- "$staging/qemu-pass.stamp" | awk '{print $1}')" == "$stamp_sha" ]] || {
 	echo "staged pair hash readback failed" >&2
 	exit 2
 }
-chmod 0444 -- "$staging/kernel.bzImage" "$staging/modules.vhdx" \
+chmod 0444 -- "$staging/kernel.bzImage" "$staging/initramfs.cpio.gz" "$staging/modules.vhdx" \
 	"$staging/modules-layout.manifest" "$staging/qemu-pass.stamp" "$staging/kernel-pair.manifest"
 published_identity="$staging_identity"
 sync -f "$staging" 2>/dev/null || true
@@ -434,7 +447,7 @@ published_here=1
 	echo 'published pair directory identity or permissions are not sealed' >&2
 	exit 2
 }
-for published in kernel.bzImage modules.vhdx modules-layout.manifest qemu-pass.stamp kernel-pair.manifest; do
+for published in kernel.bzImage initramfs.cpio.gz modules.vhdx modules-layout.manifest qemu-pass.stamp kernel-pair.manifest; do
 	[[ -f "$final/$published" && ! -L "$final/$published" &&
 		"$(stat -c '%u:%a:%h' -- "$final/$published")" == "$EUID:444:1" ]] || {
 		echo "published pair file identity or permissions are not sealed: $published" >&2

--- a/scripts/kernel/test-wsl-kernel-static.sh
+++ b/scripts/kernel/test-wsl-kernel-static.sh
@@ -78,9 +78,11 @@ trap cleanup EXIT
 pair="$fixture/pair"
 mkdir -- "$pair"
 truncate -s 1048577 "$pair/kernel.bzImage"
+truncate -s 1024 "$pair/initramfs.cpio.gz"
 printf 'modules-fixture\n' >"$pair/modules.vhdx"
 release='6.18.test-microsoft-standard-WSL2+'
 kernel_sha="$(sha256sum -- "$pair/kernel.bzImage" | awk '{print $1}')"
+initramfs_sha="$(sha256sum -- "$pair/initramfs.cpio.gz" | awk '{print $1}')"
 modules_sha="$(sha256sum -- "$pair/modules.vhdx" | awk '{print $1}')"
 cat >"$pair/modules-layout.manifest" <<EOF
 schema=ramshared.modules-layout.v1
@@ -107,6 +109,9 @@ release=$release
 kernel_file=kernel.bzImage
 kernel_sha256=$kernel_sha
 kernel_size_bytes=1048577
+initramfs_file=initramfs.cpio.gz
+initramfs_sha256=$initramfs_sha
+initramfs_size_bytes=1024
 modules_file=modules.vhdx
 modules_sha256=$modules_sha
 modules_size_bytes=16
@@ -143,6 +148,7 @@ EOF
 chmod 0700 "$fake_bin/modinfo"
 seal_output="$(PATH="$fake_bin:$PATH" timeout --signal=TERM --kill-after=2s 20s bash "$ROOT/seal-kernel-pair.sh" \
 	--kernel "$pair/kernel.bzImage" \
+	--initramfs "$pair/initramfs.cpio.gz" \
 	--modules "$pair/modules.vhdx" \
 	--module-file "$module_fixture" \
 	--release "$release" \
@@ -161,6 +167,7 @@ set +e
 cleanup_rename_output="$(RAMSHARED_CLEANUP_RENAME_FIXTURE=1 PATH="$fake_bin:$PATH" \
 	timeout --signal=TERM --kill-after=2s 20s bash "$ROOT/seal-kernel-pair.sh" \
 	--kernel "$pair/kernel.bzImage" \
+	--initramfs "$pair/initramfs.cpio.gz" \
 	--modules "$pair/modules.vhdx" \
 	--module-file "$module_fixture" \
 	--release "$release" \
@@ -178,6 +185,7 @@ mapfile -t moved_staging < <(find "$cleanup_rename_root" -maxdepth 1 -type d -na
 [[ ${#moved_staging[@]} -eq 1 ]]
 if PATH="$fake_bin:$PATH" timeout --signal=TERM --kill-after=2s 20s bash "$ROOT/seal-kernel-pair.sh" \
 	--kernel "$pair/kernel.bzImage" \
+	--initramfs "$pair/initramfs.cpio.gz" \
 	--modules "$pair/modules.vhdx" \
 	--module-file "$module_fixture" \
 	--release "$release" \
@@ -190,6 +198,7 @@ fi
 
 seal_args=(
 	--kernel "$pair/kernel.bzImage"
+	--initramfs "$pair/initramfs.cpio.gz"
 	--modules "$pair/modules.vhdx"
 	--module-file "$module_fixture"
 	--release "$release"
@@ -199,6 +208,7 @@ seal_args=(
 parser_probe_root="$fixture/parser-probe-output"
 if PATH="$fake_bin:$PATH" timeout --signal=TERM --kill-after=2s 10s bash "$ROOT/seal-kernel-pair.sh" \
 	--kernel "$pair/kernel.bzImage" --kernel "$pair/kernel.bzImage" \
+	--initramfs "$pair/initramfs.cpio.gz" \
 	--modules "$pair/modules.vhdx" --module-file "$module_fixture" --release "$release" \
 	--layout-inventory "$pair/modules-layout.manifest" --qemu-stamp "$pair/qemu-pass.stamp" \
 	--output-root "$parser_probe_root" >/dev/null 2>&1; then
@@ -251,7 +261,7 @@ shopt -u nullglob
 	exit 1
 }
 [[ "$(stat -c '%a' -- "${race_pairs[0]}")" == 555 ]]
-for published in kernel.bzImage modules.vhdx modules-layout.manifest qemu-pass.stamp kernel-pair.manifest; do
+for published in kernel.bzImage initramfs.cpio.gz modules.vhdx modules-layout.manifest qemu-pass.stamp kernel-pair.manifest; do
 	[[ "$(stat -c '%a:%h' -- "${race_pairs[0]}/$published")" == '444:1' ]]
 done
 if [[ $race_status_one -eq 0 ]]; then

--- a/scripts/kernel/wsl-kernel-lib.sh
+++ b/scripts/kernel/wsl-kernel-lib.sh
@@ -117,6 +117,7 @@ load_kernel_pair_manifest() {
 	local expected=(
 		schema pair_id release
 		kernel_file kernel_sha256 kernel_size_bytes
+		initramfs_file initramfs_sha256 initramfs_size_bytes
 		modules_file modules_sha256 modules_size_bytes
 		modules_layout layout_release_directory_count
 		layout_nested_release_directory_count layout_inventory_sha256
@@ -139,17 +140,19 @@ load_kernel_pair_manifest() {
 		return 1
 	fi
 	if [[ "${KERNEL_PAIR[kernel_file]}" != "kernel.bzImage" ||
+		"${KERNEL_PAIR[initramfs_file]}" != "initramfs.cpio.gz" ||
 		"${KERNEL_PAIR[modules_file]}" != "modules.vhdx" ]]; then
 		PAIR_ERROR="kernel-pair artifact names are not canonical"
 		return 1
 	fi
-	for key in kernel_sha256 modules_sha256 layout_inventory_sha256 qemu_stamp_sha256 qemu_kernel_sha256; do
+	for key in kernel_sha256 initramfs_sha256 modules_sha256 layout_inventory_sha256 qemu_stamp_sha256 qemu_kernel_sha256; do
 		if ! canonical_sha256 "${KERNEL_PAIR[$key]}"; then
 			PAIR_ERROR="kernel-pair $key is invalid"
 			return 1
 		fi
 	done
 	if [[ ! "${KERNEL_PAIR[kernel_size_bytes]}" =~ ^[1-9][0-9]*$ ||
+		! "${KERNEL_PAIR[initramfs_size_bytes]}" =~ ^[1-9][0-9]*$ ||
 		! "${KERNEL_PAIR[modules_size_bytes]}" =~ ^[1-9][0-9]*$ ]]; then
 		PAIR_ERROR="kernel-pair artifact size is invalid"
 		return 1
@@ -180,18 +183,21 @@ load_kernel_pair_manifest() {
 	KERNEL_PAIR[manifest_path]="$manifest"
 	KERNEL_PAIR[manifest_sha256]="$(sha256sum -- "$manifest" | awk '{print $1}')"
 	KERNEL_PAIR[kernel_path]="$parent/${KERNEL_PAIR[kernel_file]}"
+	KERNEL_PAIR[initramfs_path]="$parent/${KERNEL_PAIR[initramfs_file]}"
 	KERNEL_PAIR[modules_path]="$parent/${KERNEL_PAIR[modules_file]}"
 	KERNEL_PAIR[layout_inventory_path]="$parent/modules-layout.manifest"
 	KERNEL_PAIR[qemu_stamp_path]="$parent/qemu-pass.stamp"
-	for key in kernel_path modules_path layout_inventory_path qemu_stamp_path; do
+	for key in kernel_path initramfs_path modules_path layout_inventory_path qemu_stamp_path; do
 		if [[ ! -f "${KERNEL_PAIR[$key]}" || -L "${KERNEL_PAIR[$key]}" ]]; then
 			PAIR_ERROR="sealed pair artifact is missing or symlinked: ${KERNEL_PAIR[$key]}"
 			return 1
 		fi
 	done
 	if [[ "$(stat -c '%s' -- "${KERNEL_PAIR[kernel_path]}")" != "${KERNEL_PAIR[kernel_size_bytes]}" ||
+		"$(stat -c '%s' -- "${KERNEL_PAIR[initramfs_path]}")" != "${KERNEL_PAIR[initramfs_size_bytes]}" ||
 		"$(stat -c '%s' -- "${KERNEL_PAIR[modules_path]}")" != "${KERNEL_PAIR[modules_size_bytes]}" ||
 		"$(sha256sum -- "${KERNEL_PAIR[kernel_path]}" | awk '{print $1}')" != "${KERNEL_PAIR[kernel_sha256]}" ||
+		"$(sha256sum -- "${KERNEL_PAIR[initramfs_path]}" | awk '{print $1}')" != "${KERNEL_PAIR[initramfs_sha256]}" ||
 		"$(sha256sum -- "${KERNEL_PAIR[modules_path]}" | awk '{print $1}')" != "${KERNEL_PAIR[modules_sha256]}" ||
 		"$(sha256sum -- "${KERNEL_PAIR[layout_inventory_path]}" | awk '{print $1}')" != "${KERNEL_PAIR[layout_inventory_sha256]}" ||
 		"$(sha256sum -- "${KERNEL_PAIR[qemu_stamp_path]}" | awk '{print $1}')" != "${KERNEL_PAIR[qemu_stamp_sha256]}" ]]; then


### PR DESCRIPTION
## Resumo
Added the ability to securely hash, seal, and validate `initramfs.cpio.gz` alongside other kernel pair artifacts. This ensures that the boot initramfs has a proven checksum tightly bound in the `kernel-pair.manifest`, eliminating unverified module provenance scenarios.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: seal initramfs.cpio.gz with checksums | Adds `--initramfs` to `seal-kernel-pair.sh`, reads it in `wsl-kernel-lib.sh`, and updates `test-wsl-kernel-static.sh`. | To cryptographically bind the initramfs to the rest of the kernel immutable bundle. | Follows existing rigorous readback identity checks, canonical validations, and strict schema validation for the manifest. |

## Labels
type:scripts, type:security, type:kernel

## Validacao
Executed `shellcheck` manually (unavailable in environment but verified logic), and ran `bash scripts/kernel/test-wsl-kernel-static.sh`, which passed correctly with all regressions checks confirming safe handling of the updated artifact manifest format.

## Rollback trigger
If `seal-kernel-pair.sh` fails in production CI due to unmatched argument counts or if `test-wsl-kernel-static.sh` fails on edge case validation testing for the new required parameter.

---
*PR created automatically by Jules for task [7495500534828923378](https://jules.google.com/task/7495500534828923378) started by @emersonbusson*