### PR TITLE
feat(ci): guard conditions for release tag format and changelog existence

### DIFF
--- a/.github/workflows/release-publication.yml
+++ b/.github/workflows/release-publication.yml
@@ -77,6 +77,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "Invalid tag format: $RELEASE_TAG" >&2
+            exit 65
+          fi
+          test -f CHANGELOG.md
+          VERSION="${RELEASE_TAG#v}"
+          if ! grep -Fq "## [$VERSION]" CHANGELOG.md && ! grep -Fq "## [$RELEASE_TAG]" CHANGELOG.md; then
+            echo "Missing entry for $RELEASE_TAG in CHANGELOG.md" >&2
+            exit 65
+          fi
           node tools/ci/check-release-publication.mjs \
             --policy docs/governance/release-promotion.json \
             --tag "$RELEASE_TAG" \
@@ -143,6 +153,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "Invalid tag format: $RELEASE_TAG" >&2
+            exit 65
+          fi
+          test -f CHANGELOG.md
+          VERSION="${RELEASE_TAG#v}"
+          if ! grep -Fq "## [$VERSION]" CHANGELOG.md && ! grep -Fq "## [$RELEASE_TAG]" CHANGELOG.md; then
+            echo "Missing entry for $RELEASE_TAG in CHANGELOG.md" >&2
+            exit 65
+          fi
           node tools/ci/check-release-publication.mjs \
             --policy docs/governance/release-promotion.json \
             --tag "$RELEASE_TAG" \


### PR DESCRIPTION
## Resumo
Add guard clauses to validate semantic version tag format and CHANGELOG.md entry before creating GitHub release

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| [hash] | Add tag format and CHANGELOG validation in release-publication workflow | To ensure semantic versioning format and prevent releases without changelog entries | Added regex check for vX.Y.Z format and grep check for tag presence in CHANGELOG.md |

## Labels
type:ci, type:scripts

## Validacao
actionlint command executed (unavailable, visually inspected logic and bash tests manually)

## Rollback trigger
Revert if the release workflow fails on valid tags or correctly formed CHANGELOG entries

---
*PR created automatically by Jules for task [14643556024224840746](https://jules.google.com/task/14643556024224840746) started by @emersonbusson*