### PR TITLE
ci: add artifact integrity verification to release pipeline

### DIFF
--- a/.github/workflows/release-integrity.yml
+++ b/.github/workflows/release-integrity.yml
@@ -31,6 +31,8 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
+    outputs:
+      revision: ${{ steps.identity.outputs.revision }}
     env:
       RELEASE_TARGET_TAG: v0.9.0-beta.1
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
@@ -194,3 +196,33 @@ jobs:
           path: tmp/release-integrity-candidate
           if-no-files-found: error
           retention-days: 14
+
+  release-integrity-verification:
+    name: release-integrity-verification
+    needs: release-integrity
+    if: github.event_name == 'push' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+    steps:
+      - name: Download exact integrity candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-integrity-${{ env.RELEASE_TAG }}-${{ needs.release-integrity.outputs.revision }}
+          path: tmp/release-integrity-artifact
+
+      - name: Verify exact four-file integrity candidate checksum
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd tmp/release-integrity-artifact/artifacts/release
+          archive="ramshared-linux-$RELEASE_TAG.tar.gz"
+
+          # Sanity check: Ensure files exist before attempting to verify
+          test -f "$archive" || exit 69
+          test -f "$archive.sha256" || exit 69
+
+          sha256sum --check "$archive.sha256"


### PR DESCRIPTION
## Resumo
Add end-to-end artifact integrity verification pipeline to release-integrity.yml.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| Add verification job | Added release-integrity-verification job | Verify downloaded release artifacts match published checksums in a clean isolated runner environment | Downloads artifact, checks sha256sum |

## Labels
type:ci

## Validacao
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/*.yml

## Rollback trigger
CI failure

---
*PR created automatically by Jules for task [848468523901027418](https://jules.google.com/task/848468523901027418) started by @emersonbusson*