### PR TITLE
ci: add PSScriptAnalyzer step for Windows scripts

### DIFF
--- a/.github/workflows/windows-static.yml
+++ b/.github/workflows/windows-static.yml
@@ -24,6 +24,22 @@ jobs:
         with:
           toolchain: 1.98.0
 
+      - name: PSScriptAnalyzer static analysis
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not (Test-Path -Path 'scripts/windows' -PathType Container)) {
+            throw [System.IO.DirectoryNotFoundException]"The path 'scripts/windows' does not exist."
+          }
+          if (-not (Get-Command -Name Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue)) {
+            throw [System.Management.Automation.CommandNotFoundException]"Invoke-ScriptAnalyzer is not available."
+          }
+          $findings = Invoke-ScriptAnalyzer -Path 'scripts/windows/*.ps1' -Severity Error
+          if ($findings) {
+            $findings | Format-Table
+            throw [System.Management.Automation.RuntimeException]"PSScriptAnalyzer found Error severity findings."
+          }
+
       - name: Windows Rust tests
         shell: pwsh
         run: |


### PR DESCRIPTION
## Resumo
Add PSScriptAnalyzer step to Windows CI

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| ci: add PSScriptAnalyzer step | Added PSScriptAnalyzer to windows-static.yml | To fail on Error severity findings | Enforces script quality |

## Labels
type:ci, type:scripts

## Validacao
echo 'actionlint is unavailable'

## Rollback trigger
Revert if the CI fails due to PSScriptAnalyzer false positives or command not found.

---
*PR created automatically by Jules for task [3189841785091749275](https://jules.google.com/task/3189841785091749275) started by @emersonbusson*