### PR TITLE
ci: add guard condition to prevent cancellation of protected branches

### DIFF
--- a/.github/workflows/cancel-closed-pr.yml
+++ b/.github/workflows/cancel-closed-pr.yml
@@ -21,6 +21,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Cancel queued and running checks for the closed pull request
+        if: github.event.pull_request.base.ref != 'main' && !startsWith(github.event.pull_request.base.ref, 'release/')
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |


### PR DESCRIPTION
## Resumo
Added an `if` guard condition to the step in the cancel-closed-pr workflow to skip execution for PRs targeting `main` or `release/*` branches to prevent data loss.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| ci: add guard condition to prevent cancellation of protected branches | Added `if` guard to step | To prevent cancellation on protected branches | Evaluates `github.event.pull_request.base.ref` |

## Labels
type:ci, type:security

## Validacao
`echo "actionlint is unavailable"`

## Rollback trigger
If PR check cancellations fail to process properly on non-protected branches.

---
*PR created automatically by Jules for task [16174052065462158100](https://jules.google.com/task/16174052065462158100) started by @emersonbusson*