### PR TITLE
feat(packaging): add guard clauses for debian packaging tools

### DIFF
--- a/scripts/package/build-deb-package.sh
+++ b/scripts/package/build-deb-package.sh
@@ -4,6 +4,13 @@
 # Usage: scripts/package/build-deb-package.sh [version]
 set -euo pipefail
 
+for cmd in dpkg-deb fakeroot lintian; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: Required command '$cmd' is not available." >&2
+    exit 69
+  fi
+done
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 VERSION="${1:-${RAMSHARED_PACKAGE_VERSION:-v0.9.0-beta.2}}"
 VERSION_CLEAN="${VERSION#v}"


### PR DESCRIPTION
## Resumo
Added guard clauses to validate availability of dpkg-deb, fakeroot, and lintian with EX_UNAVAILABLE (69) early exit.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Add guard clauses | Fail fast on missing deps | Exits with 69 |

## Labels
type:packaging

## Validacao
bash -n syntax validation. shellcheck unavailable.

## Rollback trigger
Revert if packaging pipelines fail due to missing lintian or fakeroot dependencies during staging.

---
*PR created automatically by Jules for task [295321218519143228](https://jules.google.com/task/295321218519143228) started by @emersonbusson*