### PR TITLE
ci: add shellcheck to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,35 @@ jobs:
           --test-coverage-functions=80
           tools/ci/check-campaign-evidence-lifecycle.test.mjs
 
+  scripts:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Run ShellCheck
+        run: |
+          set -euo pipefail
+
+          if [ ! -d "scripts" ]; then
+            echo "Error: scripts directory not found." >&2
+            exit 78
+          fi
+
+          if ! command -v shellcheck >/dev/null 2>&1; then
+            echo "Error: shellcheck is not installed." >&2
+            exit 69
+          fi
+
+          find scripts -type f -name "*.sh" -exec shellcheck --severity=error {} +
+
   ci-summary:
     name: ci-summary
     if: always()
-    needs: [rust, docs]
+    needs: [rust, docs, scripts]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -144,9 +169,10 @@ jobs:
         env:
           RUST_RESULT: ${{ needs.rust.result }}
           DOCS_RESULT: ${{ needs.docs.result }}
+          SCRIPTS_RESULT: ${{ needs.scripts.result }}
         run: |
           set -euo pipefail
-          for result in "$RUST_RESULT" "$DOCS_RESULT"; do
+          for result in "$RUST_RESULT" "$DOCS_RESULT" "$SCRIPTS_RESULT"; do
             if [ "$result" != success ]; then
               echo "CI_CORE_SUMMARY=FAIL"
               exit 1


### PR DESCRIPTION
## Resumo
Add a shellcheck job to CI to validate bash scripts in scripts directory.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| ci: add shellcheck to CI | Added `scripts` job in `.github/workflows/ci.yml` | To ensure bash scripts follow best practices and avoid errors | Added guard clauses for missing directory (EX_CONFIG 78) and missing shellcheck (EX_UNAVAILABLE 69). |

## Issue
N/A

## Responsavel
Jules

## Labels
type:ci, type:scripts

## Validacao
`go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/*.yml` (shellcheck is unavailable locally)

## Rollback trigger
If the CI pipeline fails repeatedly due to the new `scripts` job blocking valid commits, revert this PR.

---
*PR created automatically by Jules for task [15794460780755248964](https://jules.google.com/task/15794460780755248964) started by @emersonbusson*