### PR TITLE
refactor(packaging): implement semantic exit codes in rpm build script

### DIFF
--- a/scripts/package/build-rpm-package.sh
+++ b/scripts/package/build-rpm-package.sh
@@ -29,7 +29,7 @@ fi
 
 if [[ ! -x "$CLI_BIN" || ! -x "$DAEMON_BIN" ]]; then
   echo "ERROR: Target release binaries not found ($CLI_BIN / $DAEMON_BIN)" >&2
-  exit 1
+  exit 65
 fi
 
 # Clean previous build root
@@ -81,8 +81,14 @@ SPEC_EOF
 
 if command -v rpmbuild >/dev/null 2>&1; then
   echo "==> Executing rpmbuild..."
-  rpmbuild --define "_topdir $RPM_ROOT" -bb "$SPEC_FILE"
-  cp "$RPM_ROOT"/RPMS/*/*.rpm "$OUT_DIR/" 2>/dev/null || true
+  if ! rpmbuild --define "_topdir $RPM_ROOT" -bb "$SPEC_FILE"; then
+    echo "ERROR: rpmbuild failed" >&2
+    exit 74
+  fi
+  if ! cp "$RPM_ROOT"/RPMS/*/*.rpm "$OUT_DIR/" 2>/dev/null; then
+    echo "ERROR: Failed to copy RPM packages" >&2
+    exit 73
+  fi
   echo "✓ RPM package built under $OUT_DIR/"
 else
   echo "==> rpmbuild not installed on host. Spec generated at $SPEC_FILE (PASS)."


### PR DESCRIPTION
## Resumo
Updated the `build-rpm-package.sh` script to use semantic exit codes defined in `sysexits.h` to align with infrastructure hardening principles.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `<hash>` | Updated exit codes to 65, 73, and 74 | Infrastructure hardening guidelines require semantic exit codes | Modified missing dependency exit to 65, rpmbuild failure to 74, and copy failures to 73. |

## Labels
type:scripts, type:packaging

## Validacao
bash -n scripts/package/build-rpm-package.sh
(shellcheck is unavailable)

## Rollback trigger
script crashes unexpectedly during CI pipeline runs due to unexpected behavior from the exit codes

---
*PR created automatically by Jules for task [17023074894029550023](https://jules.google.com/task/17023074894029550023) started by @emersonbusson*