### PR TITLE
feat: enforce 4096-byte alignment check on PCIe BAR physical address

### DIFF
--- a/drivers/block/ramshared/dma.c
+++ b/drivers/block/ramshared/dma.c
@@ -31,6 +31,11 @@ int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
 	rs_dev->dma.pci_addr = bar_start;
 	rs_dev->dma.size = min_t(size_t, bar_len, rs_dev->capacity_bytes);
 
+	if (!IS_ALIGNED(rs_dev->dma.pci_addr, PAGE_SIZE)) {
+		dev_err(&pdev->dev, "PCIe BAR0 address not %lu-byte aligned\n", PAGE_SIZE);
+		return -EINVAL;
+	}
+
 	/* Map PCIe VRAM BAR using Write-Combining for peak throughput */
 	rs_dev->dma.cpu_addr = devm_ioremap_wc(&pdev->dev, rs_dev->dma.pci_addr,
 					       rs_dev->dma.size);


### PR DESCRIPTION
## Resumo
Enforce 4096-byte page alignment check on PCIe BAR0 physical address.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: enforce 4096-byte alignment check on PCIe BAR physical address | Added IS_ALIGNED check in ramshared_dma_init | Defensively verify hardware boundaries before ioremap_wc | Returns -EINVAL if address is unaligned. |

## Labels
type:kernel, type:refactor

## Validacao
Compiled drivers/block/ramshared/dma.c using `make -C /lib/modules/6.8.0-1066-gcp/build M=/app/drivers/block/ramshared CONFIG_BLK_DEV_RAMSHARED=m dma.o`

## Rollback trigger
Revert if driver fails to initialize on valid hardware due to alignment errors.

---
*PR created automatically by Jules for task [14417890411384143639](https://jules.google.com/task/14417890411384143639) started by @emersonbusson*