### PR TITLE
fix: linearize pci teardown and fix warnings

### DIFF
--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -43,7 +43,7 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 	}
 
 	if (queue_depth < 1 || queue_depth > 4096) {
-		dev_warn(&pdev->dev, "clamping queue_depth (%lu) to default (256)\n", queue_depth);
+		dev_warn(&pdev->dev, "clamping queue_depth (%u) to default (256)\n", queue_depth);
 		queue_depth = 256;
 	}
 
@@ -109,7 +109,6 @@ err_release_regions:
 	pci_release_mem_regions(pdev);
 err_clear_master:
 	pci_clear_master(pdev);
-err_disable_pci:
 	pci_disable_device(pdev);
 	return ret;
 }
@@ -125,6 +124,7 @@ static void ramshared_pci_remove(struct pci_dev *pdev)
 	if (!rs_dev)
 		return;
 
+	pci_set_drvdata(pdev, NULL);
 	ramshared_queue_cleanup(rs_dev);
 	ramshared_dma_cleanup(rs_dev);
 	pci_release_mem_regions(pdev);


### PR DESCRIPTION
## Resumo
Linearize the `pci_remove` teardown sequence by properly clearing driver data with `pci_set_drvdata(pdev, NULL)` explicitly, adhering to exact reverse probe order. Fixed two compiler warnings in `main.c` for clean compilation.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix: linearize pci teardown and fix warnings | Cleared pdev driver data in remove and fixed compiler warnings. | To adhere to architectural principles of exact reverse probe order and warning-free compilation. | Changed `%lu` to `%u`, collapsed unused label, and added `pci_set_drvdata(pdev, NULL)`. |

## Issue
Issue: N/A

## Labels
type:refactor, type:kernel

## Validacao
`export KDIR=/lib/modules/6.8.0-139-generic/build && cd drivers/block/ramshared && make -C $KDIR M=$(pwd) main.o` completed without warnings.

## Rollback trigger
Any unexpected kernel panic during device removal.

---
*PR created automatically by Jules for task [8376571747040557459](https://jules.google.com/task/8376571747040557459) started by @emersonbusson*