### PR TITLE
feat: semantic errno returns on ioremap_wc and DMA mask configuration failures

### DIFF
--- a/drivers/block/ramshared/dma.c
+++ b/drivers/block/ramshared/dma.c
@@ -15,10 +15,21 @@
 int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
 {
 	int bar = 0;
+	int ret;
 	resource_size_t bar_start, bar_len;
 
 	if (!rs_dev || !pdev)
 		return -EINVAL;
+
+	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
+	if (ret) {
+		dev_warn(&pdev->dev, "64-bit DMA failed, attempting 32-bit DMA\n");
+		ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
+		if (ret) {
+			dev_err(&pdev->dev, "no usable DMA configuration\n");
+			return -EFAULT;
+		}
+	}
 
 	bar_start = pci_resource_start(pdev, bar);
 	bar_len = pci_resource_len(pdev, bar);

--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -66,16 +66,6 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 
 	pci_set_master(pdev);
 
-	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
-	if (ret) {
-		dev_warn(&pdev->dev, "64-bit DMA failed, attempting 32-bit DMA\n");
-		ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
-		if (ret) {
-			dev_err(&pdev->dev, "no usable DMA configuration\n");
-			goto err_clear_master;
-		}
-	}
-
 	ret = pci_request_mem_regions(pdev, RAMSHARED_DRIVER_NAME);
 	if (ret) {
 		dev_err(&pdev->dev, "failed to claim PCIe memory regions\n");


### PR DESCRIPTION
## Resumo
Relocate DMA mask configuration to `dma.c` from `main.c` and update it to return semantic `-EFAULT` error upon failure, instead of a generic return. The other specified conditions (`-ENOMEM` and `-ENODEV`) are already satisfied.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: semantic errno returns on ioremap_wc and DMA mask configuration failures | Relocate DMA mask configuration to `dma.c` and use `-EFAULT`. | To return precise semantic kernel errnos instead of swallowing kernel failure codes. | - |

## Issue
Issue: N/A

## Responsavel
Jules

## Labels
type:kernel

## Validacao
Executed `scripts/ci/check-kernel-style.sh` and `scripts/ci/check-kernel-checkpatch.sh`.

## Rollback trigger
Kernel crash, build failure, or regressions in CI pipelines.

---
*PR created automatically by Jules for task [16910586913886549881](https://jules.google.com/task/16910586913886549881) started by @emersonbusson*