### PR TITLE
refactor(dma): validate 64-bit DMA mask with fallback in dma module

### DIFF
--- a/drivers/block/ramshared/dma.c
+++ b/drivers/block/ramshared/dma.c
@@ -14,11 +14,23 @@
 
 int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
 {
+	int ret;
 	int bar = 0;
 	resource_size_t bar_start, bar_len;
 
 	if (!rs_dev || !pdev)
 		return -EINVAL;
+
+	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
+	if (ret) {
+		dev_warn(&pdev->dev, "64-bit DMA failed, attempting 32-bit DMA\n");
+		ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
+	}
+
+	if (ret) {
+		dev_err(&pdev->dev, "no usable DMA configuration\n");
+		return -EOPNOTSUPP;
+	}
 
 	bar_start = pci_resource_start(pdev, bar);
 	bar_len = pci_resource_len(pdev, bar);

--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -66,16 +66,6 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 
 	pci_set_master(pdev);
 
-	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
-	if (ret) {
-		dev_warn(&pdev->dev, "64-bit DMA failed, attempting 32-bit DMA\n");
-		ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
-		if (ret) {
-			dev_err(&pdev->dev, "no usable DMA configuration\n");
-			goto err_clear_master;
-		}
-	}
-
 	ret = pci_request_mem_regions(pdev, RAMSHARED_DRIVER_NAME);
 	if (ret) {
 		dev_err(&pdev->dev, "failed to claim PCIe memory regions\n");


### PR DESCRIPTION
## Resumo

Refactored DMA initialization to validate the 64-bit DMA mask and properly fallback to 32-bit if it fails, returning `-EOPNOTSUPP` if both fail. This centralizes the logic in `dma.c` and cleans up `main.c`, adhering to the C/Kernel clean architecture principles.

## Commits table

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(dma): validate 64-bit DMA mask with fallback in dma module | Moved DMA negotiation to `ramshared_dma_init` in `dma.c` | Consolidate logic and avoid nested if/else pyramids in main | <details>Removed code from `main.c`, added error code handling with `-EOPNOTSUPP` in `dma.c`</details> |

## Labels
type:refactor, type:kernel

## Validacao
`git diff`
`echo "kernel build environment is unavailable"` (Skipped module compilation as kernel headers are unavailable in the environment).

## Rollback trigger
If the block device fails to probe or map PCIe VRAM properly, trigger a rollback of this patch.

---
*PR created automatically by Jules for task [10163822468174647955](https://jules.google.com/task/10163822468174647955) started by @emersonbusson*