### PR TITLE
refactor(kernel): add guard clauses to ramshared_alloc_disk

### DIFF
--- a/drivers/block/ramshared/compat.h
+++ b/drivers/block/ramshared/compat.h
@@ -37,6 +37,15 @@ static inline struct gendisk *ramshared_alloc_disk(struct blk_mq_tag_set *set,
 						   unsigned int sector_size,
 						   unsigned int max_sectors)
 {
+	if (!set || !queuedata)
+		return ERR_PTR(-EINVAL);
+
+	if (sector_size != 512 && sector_size != 4096)
+		return ERR_PTR(-EINVAL);
+
+	if (!max_sectors)
+		return ERR_PTR(-EINVAL);
+
 #if defined(RAMSHARED_HAVE_QUEUE_LIMITS_FEATURES)
 	struct queue_limits lim = {
 		.logical_block_size	= sector_size,


### PR DESCRIPTION
## Resumo

Add linear guard clauses and strict parameter validation to the `ramshared_alloc_disk` function to ensure safe, predictable allocations across supported kernel block layer boundaries.

## Commits table

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(kernel): add guard clauses to ramshared_alloc_disk | Added early sanity checks for pointers, physical bounds, and queue capacities. | Prevents kernel unhandled exceptions or invalid limits allocations in blk-mq. | Returns precise -EINVAL errno on invalid parameters. |

## Labels

type:refactor, type:kernel

## Validacao

- Clean compile syntax verification was confirmed.
- Verified absence of test artifacts.

## Rollback trigger

Revert if disk block devices fail to allocate properly due to false positive limits filtering.

---
*PR created automatically by Jules for task [15517173439157065669](https://jules.google.com/task/15517173439157065669) started by @emersonbusson*