### PR TITLE
fix(kernel): enforce capacity_mb bounds check against 1 TiB and PCIe BAR0

### DIFF
--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -28,6 +28,7 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 			       const struct pci_device_id *id)
 {
 	struct ramshared_device *rs_dev;
+	resource_size_t bar_len;
 	int ret;
 
 	if (!pdev || !id)
@@ -37,9 +38,21 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 		 capacity_mb);
 
 	if (capacity_mb == 0 || capacity_mb > (1UL << 20)) {
-		dev_err(&pdev->dev, "invalid capacity_mb parameter: %lu\n",
+		dev_err(&pdev->dev, "capacity_mb (%lu MiB) invalid or exceeds 1 TiB maximum\n",
 			capacity_mb);
-		return -EINVAL;
+		return -ERANGE;
+	}
+
+	bar_len = pci_resource_len(pdev, 0);
+	if (!bar_len) {
+		dev_err(&pdev->dev, "PCIe BAR0 length is zero or missing\n");
+		return -ENODEV;
+	}
+
+	if (((u64)capacity_mb << 20) > bar_len) {
+		dev_err(&pdev->dev, "capacity_mb (%lu MiB) exceeds physical PCIe BAR0 aperture (%llu bytes)\n",
+			capacity_mb, (unsigned long long)bar_len);
+		return -ERANGE;
 	}
 
 	if (queue_depth < 1 || queue_depth > 4096) {


### PR DESCRIPTION
## Resumo
Modified `ramshared_pci_probe()` to validate the `capacity_mb` module parameter directly against the detected physical PCIe BAR0 hardware aperture bounds limit and properly return semantic kernel errnos like `-ERANGE` and `-ENODEV`. The existing 1 TiB logic was also adapted to return `-ERANGE`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| fix(kernel): enforce capacity_mb limits against 1 TiB and PCIe BAR0 | Added PCIe BAR0 aperture sanity check & modified 1 TiB validation to use -ERANGE | Enforces defensive kernel programming physical bounds principles against unverified parameter inputs | <details>Added `pci_resource_len(pdev, 0)` check inside probe routine.</details> |

## Labels
type:refactor, type:security, type:kernel

## Validacao
Ran static/C mock compilation checks with `gcc -c drivers/block/ramshared/main.c`. Validated Node CI test suite with `node --test tools/ci/*.test.mjs`.

## Issue
Issue: N/A

## Responsavel
Jules

## Rollback trigger
Any unhandled Kernel panics related to PCIe BAR0 or parameter initialization in `ramshared_pci_probe()`.

---
*PR created automatically by Jules for task [1777382553059561601](https://jules.google.com/task/1777382553059561601) started by @emersonbusson*