### PR TITLE
fix(kernel-win): validate RegistryPath in DriverEntry

### DIFF
--- a/drivers/windows/ramshared/driver.c
+++ b/drivers/windows/ramshared/driver.c
@@ -255,6 +255,9 @@ DriverEntry(_In_ PDRIVER_OBJECT DriverObject, _In_ PUNICODE_STRING RegistryPath)
 	HW_INITIALIZATION_DATA hw;
 	NTSTATUS status;
 
+	if (RegistryPath == NULL || RegistryPath->Length == 0)
+		return STATUS_INVALID_PARAMETER;
+
 	RtlZeroMemory(&hw, sizeof(hw));
 	hw.HwInitializationDataSize = sizeof(HW_INITIALIZATION_DATA);
 	hw.AdapterInterfaceType = Internal;


### PR DESCRIPTION
## Resumo
Added pointer non-nullness and length sanity checks for the `RegistryPath` parameter in `DriverEntry` before continuing with initialization, returning `STATUS_INVALID_PARAMETER` if invalid.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix(kernel-win): validate RegistryPath in DriverEntry | Added guard clause to validate `RegistryPath` | To ensure that a NULL or empty `RegistryPath` does not crash the driver during `StorPortInitialize` | <details>Added `if (RegistryPath == NULL || RegistryPath->Length == 0) return STATUS_INVALID_PARAMETER;` at the beginning of `DriverEntry` in `drivers/windows/ramshared/driver.c`.</details> |

## Labels
type:kernel-win

## Validacao
Windows kernel driver compilation unavailable on Linux host. Changes were visually inspected and verified with syntax check and code review.

## Rollback trigger
If driver fails to load due to RegistryPath validation (e.g., if the OS legally provides an empty registry path in some edge cases not considered).

---
*PR created automatically by Jules for task [14776523291046298023](https://jules.google.com/task/14776523291046298023) started by @emersonbusson*