### PR TITLE
fix(kernel): zero-copy memcpy bounds validation in ramshared_queue_transfer

### DIFF
--- a/drivers/block/ramshared/queue.c
+++ b/drivers/block/ramshared/queue.c
@@ -21,11 +21,30 @@ static blk_status_t ramshared_process_bio(struct ramshared_device *rs_dev,
 	struct bio_vec bvec;
 	struct bvec_iter iter;
 	unsigned int op = bio_op(bio);
-	void __iomem *vram_ptr = rs_dev->dma.cpu_addr + pos;
 
 	bio_for_each_segment(bvec, bio, iter) {
-		void *src_or_dst = bvec_kmap_local(&bvec);
+		void *src_or_dst;
 		size_t len = bvec.bv_len;
+		void __iomem *vram_ptr;
+
+		if (unlikely(pos > rs_dev->dma.size ||
+			     len > rs_dev->dma.size - pos ||
+			     pos + len > rs_dev->capacity_bytes)) {
+			dev_err_ratelimited(rs_dev->dev,
+				"Bio bounds violation: pos=%lld, len=%zu\n",
+				pos, len);
+			return BLK_STS_IOERR;
+		}
+
+		if (unlikely(len > PAGE_SIZE || bvec.bv_offset + len > PAGE_SIZE)) {
+			dev_err_ratelimited(rs_dev->dev,
+				"Bio page bounds violation: offset=%u, len=%zu\n",
+				bvec.bv_offset, len);
+			return BLK_STS_IOERR;
+		}
+
+		vram_ptr = rs_dev->dma.cpu_addr + pos;
+		src_or_dst = bvec_kmap_local(&bvec);
 
 		if (op == REQ_OP_READ) {
 			dma_rmb();
@@ -38,7 +57,7 @@ static blk_status_t ramshared_process_bio(struct ramshared_device *rs_dev,
 			atomic64_add(len, &rs_dev->write_bytes);
 		}
 		kunmap_local(src_or_dst);
-		vram_ptr += len;
+		pos += len;
 	}
 
 	atomic64_inc(&rs_dev->dma_transfers_total);
@@ -117,10 +136,10 @@ static int ramshared_bdev_rw_page(struct block_device *bdev, sector_t sector,
 	int is_write = op_is_write(op);
 
 	if (unlikely(!rs_dev || !rs_dev->dma.cpu_addr))
-		return -EIO;
+		return -ENODEV;
 
 	if (unlikely(check_shl_overflow((loff_t)sector, RAMSHARED_SECTOR_SHIFT, &pos)))
-		return -EIO;
+		return -EINVAL;
 
 	if (unlikely(pos > rs_dev->dma.size ||
 		     len > rs_dev->dma.size - pos ||


### PR DESCRIPTION
## Resumo
Adiciona verificações rigorosas de limites de VRAM (PCIe DMA allocation) e das margens de página do `bio` (buffer sizes) no loop de segmentos do bloco para evitar bounds violation no kernel, adotando os tipos de falha semânticos (`-ENODEV`, `-EINVAL`).

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| b794d67 | fix(kernel-linux): validate zero-copy memcpy bounds | Para garantir que ponteiros de VRAM não excedam a capacidade e evitar kernel panics ao mapear buffers que não cabem no segmento `bio_vec`. | <details>Verificações incluídas para bio boundaries (capacidade mapeada, length) com `dev_err_ratelimited` e retornos `BLK_STS_IOERR` e também erros semânticos (-ENODEV/-EINVAL) para `ramshared_bdev_rw_page`.</details> |

## Labels
type:kernel, type:security, type:refactor

## Validacao
- Testes sintáticos (inspeção) devido a `linux-headers` ausentes no contêiner (`Kernel compilation unavailable`).
- `git diff` e `request_code_review` efetuados com sucesso.

## Rollback trigger
Se esta PR induzir regressões em instâncias de leitura/escrita do bloco simulado gerando pânicos isolados ou kernel IOERR para requisições em buffers saudáveis.

---
*PR created automatically by Jules for task [8050953708722204085](https://jules.google.com/task/8050953708722204085) started by @emersonbusson*