### PR TITLE
fix(core): prevent integer overflow in capacity_bytes calculation

### DIFF
--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -9,6 +9,7 @@
 #include <linux/kernel.h>
 #include <linux/init.h>
 #include <linux/pci.h>
+#include <linux/overflow.h>
 #include "ramshared.h"
 
 MODULE_AUTHOR("Emerson Busson");
@@ -36,10 +37,17 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 	dev_info(&pdev->dev, "probing RamShared hardware (capacity=%lu MiB)\n",
 		 capacity_mb);
 
+	u64 capacity_bytes;
+
 	if (capacity_mb == 0 || capacity_mb > (1UL << 20)) {
 		dev_err(&pdev->dev, "invalid capacity_mb parameter: %lu\n",
 			capacity_mb);
 		return -EINVAL;
+	}
+
+	if (check_mul_overflow((u64)capacity_mb, 1048576ULL, &capacity_bytes)) {
+		dev_err(&pdev->dev, "capacity calculation overflow\n");
+		return -ERANGE;
 	}
 
 	if (queue_depth < 1 || queue_depth > 4096) {
@@ -52,7 +60,7 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 		return -ENOMEM;
 
 	rs_dev->dev = &pdev->dev;
-	rs_dev->capacity_bytes = (u64)capacity_mb * 1024 * 1024;
+	rs_dev->capacity_bytes = capacity_bytes;
 	mutex_init(&rs_dev->lock);
 	atomic64_set(&rs_dev->dma_transfers_total, 0);
 	atomic64_set(&rs_dev->read_bytes, 0);


### PR DESCRIPTION
## Resumo
Prevents potential integer overflow in the capacity calculation of the RamShared block driver by replacing unchecked arithmetic with `check_mul_overflow` API. Ensuring physical limits logic complies with architecture safety guarantees.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|--------|-----------|-------------|----------|
| [hash] | Adicionou check_mul_overflow na checagem de capacity_bytes | Impedir overflows na computação do limite de memoria de dispositivos RamShared. | Usa a API <linux/overflow.h> do kernel com fail-fast no caso de overflow. |

## Labels
type:security, type:kernel

## Validacao
- `make -C /lib/modules/6.8.0-139-generic/build M=$PWD/drivers/block/ramshared/`
- `./scripts/ci/check-kernel-checkpatch.sh`

## Rollback trigger
Se ocorrem warnings de compatibilidade por causa da falta de `<linux/overflow.h>` nas toolchains C antigas.

---
*PR created automatically by Jules for task [9493878797813831241](https://jules.google.com/task/9493878797813831241) started by @emersonbusson*