### PR TITLE
docs: generate FINDING_ONLY report for dma scope trap

### DIFF
--- a/docs/jules/findings/27-dma-memory-barrier-scope-trap.md
+++ b/docs/jules/findings/27-dma-memory-barrier-scope-trap.md
@@ -1,0 +1,11 @@
+# FINDING_ONLY: drivers/block/ramshared/dma.c scope trap
+
+## Executive Summary
+The prompt requested to audit PCIe Write-Combining memory barrier synchronization in DMA writes and ensure `wmb()` memory barrier is invoked before signalling completion on PCIe Write-Combining mappings in `drivers/block/ramshared/dma.c`.
+
+However, `drivers/block/ramshared/dma.c` strictly contains the DMA initialization and cleanup routines (`ramshared_dma_init` and `ramshared_dma_cleanup`). There are no DMA write operations or completion signalling implemented within this file.
+
+## Details
+Modifying `drivers/block/ramshared/dma.c` to add a memory barrier for DMA writes would violate the abstraction design and strict file-scope constraints, as the actual write operations (`ramshared_process_bio`, `ramshared_queue_rq`, `ramshared_bdev_rw_page`) are implemented in `drivers/block/ramshared/queue.c`.
+
+As per the immutable contract, since the targeted logic does not exist and safe code modification within the target scope is impossible to fulfill the request, a `FINDING_ONLY` report is generated.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 288,
-    "classified": 277,
+    "total": 289,
+    "classified": 278,
     "excluded": 11,
     "unclassified": 0,
     "ambiguous": 0
@@ -871,6 +871,18 @@
     },
     {
       "path": "docs/jules/findings/26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "historical",
+      "freshnessDays": null
+    },
+    {
+      "path": "docs/jules/findings/27-dma-memory-barrier-scope-trap.md",
       "disposition": "classified",
       "ruleId": "jules-findings",
       "verification": {


### PR DESCRIPTION
## Resumo

O prompt solicitou a auditoria e implementação de memory barriers (wmb()) para operações de DMA write e PCIe Write-Combining no arquivo `drivers/block/ramshared/dma.c`. No entanto, o arquivo `dma.c` é responsável estritamente pelas rotinas de inicialização e cleanup (`ramshared_dma_init` e `ramshared_dma_cleanup`). As operações reais de I/O em DMA residem em `drivers/block/ramshared/queue.c`.

Como qualquer alteração no `dma.c` para este propósito violaria o design de abstração da arquitetura e as responsabilidades restritas ao escopo do arquivo (scope trap), não é possível fazer modificações seguras no escopo requisitado. Em cumprimento à regra 4 do contrato imutável, foi gerado um documento FINDING_ONLY reportando esta armadilha de escopo no diretório `docs/jules/findings/` e o inventário da documentação foi atualizado deterministicamente.

## Commits table

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `f01403f` | Gerou um relatorio de FINDING_ONLY para uma violacao de responsabilidade | O arquivo dma.c não possui código de DMA Write ou completion signal, eles ficam em queue.c | <details><summary>detalhes</summary>**Arquivos:** docs/jules/findings/27-dma-memory-barrier-scope-trap.md, docs/reference/DOCUMENTATION-INVENTORY.json<br>**Validacao:** ./scripts/docs-check.sh<br>**Risco/rollback:** Nenhum risco estrutural. Rollback caso a documentação gerada esteja incorreta.</details> |

## Issue
Closes #N/A

## Responsavel
@jules

## Labels
type:docs, area:kernel

## Validacao
- [x] Gates de build/test do escopo tocado
- [x] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)
- [x] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)

## Rollback trigger
Nenhum arquivo de código C do kernel foi modificado, não sendo possível causar Kernel Panics. Um rollback só será triggado caso haja quebra nos parsers markdown que não tenha sido pega pelo `docs-check`.

---
*PR created automatically by Jules for task [4258045154987506597](https://jules.google.com/task/4258045154987506597) started by @emersonbusson*