### PR TITLE
docs: produce FINDING_ONLY for non-existent EvtDeviceAdd callback

### DIFF
--- a/docs/jules/findings/28-no-evtdeviceadd.md
+++ b/docs/jules/findings/28-no-evtdeviceadd.md
@@ -1,0 +1,8 @@
+# Finding: EvtDeviceAdd callback and WDF
+The task asks to "Return STATUS_INSUFFICIENT_RESOURCES on context allocation failure and STATUS_DEVICE_CONFIGURATION_ERROR" in "semantic NTSTATUS return mapping in EvtDeviceAdd callback" in `drivers/windows/ramshared/driver.c`.
+
+However, the driver uses StorPort (`HW_INITIALIZATION_DATA`), not WDF/KMDF (`WdfDriverCreate`, `EvtDeviceAdd`).
+There is NO `EvtDeviceAdd` callback in `drivers/windows/ramshared/driver.c` or anywhere in the codebase.
+The initialization is done in `DriverEntry` mapping to `HwStorFindAdapter` and `HwStorInitialize`.
+
+Since there is no `EvtDeviceAdd` or WDF framework used, the safe code modification is not possible.


### PR DESCRIPTION
## Resumo
The task requested modifying the EvtDeviceAdd callback in drivers/windows/ramshared/driver.c. However, RamShared is a StorPort virtual miniport (STOR_FEATURE_VIRTUAL_MINIPORT), not a KMDF/WDF driver. There is no EvtDeviceAdd callback in the codebase. Therefore, a safe code modification is not possible, and a FINDING_ONLY report is produced.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: produce FINDING_ONLY for non-existent EvtDeviceAdd callback | Added finding document | Codebase doesn't use WDF | <details>Created docs/jules/findings/28-no-evtdeviceadd.md documenting the architecture difference.</details> |

## Labels
type:docs, type:kernel-win

## Validacao
Compilation and testing skipped for FINDING_ONLY report

## Rollback trigger
If the documentation is incorrect.

---
*PR created automatically by Jules for task [7880933520532148433](https://jules.google.com/task/7880933520532148433) started by @emersonbusson*