### PR TITLE
fix: prevent double-free on failed disk addition in probe error path

### DIFF
--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -93,6 +93,8 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 	ret = add_disk(rs_dev->disk);
 	if (ret) {
 		dev_err(&pdev->dev, "failed to add block disk (err=%d)\n", ret);
+		put_disk(rs_dev->disk);
+		rs_dev->disk = NULL;
 		goto err_queue_cleanup;
 	}
 


### PR DESCRIPTION
## Resumo
Add `put_disk(rs_dev->disk); rs_dev->disk = NULL;` in the error path of `add_disk()` in `ramshared_pci_probe()` to avoid a double-free on disk removal if `add_disk` fails. 

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Prevent double-free in add_disk error path | Avoid memory corruption on hardware initialization failure | <details>Added put_disk and nulled disk pointer</details> |

## Issue
N/A

## Validacao
echo 'Kernel compilation unavailable'

## Rollback trigger
If the kernel driver fails to load or crashes due to NULL pointer dereferences in the cleanup path.

---
*PR created automatically by Jules for task [4087939899828126007](https://jules.google.com/task/4087939899828126007) started by @emersonbusson*