### PR TITLE
docs: report architectural mismatch for EvtDriverUnload in StorPort driver

### DIFF
--- a/docs/jules/findings/evt_driver_unload.md
+++ b/docs/jules/findings/evt_driver_unload.md
@@ -1,0 +1,19 @@
+# Finding: Architectural Mismatch for EvtDriverUnload in StorPort Driver
+
+## Task Context
+Target: `drivers/windows/ramshared/driver.c`
+Objective: Verify driver context existence before releasing global synchronization objects on unload.
+Keywords: `EvtDriverUnload context cleanup`, `EvtDriverUnload`.
+
+## Investigation
+I searched the `drivers/windows/ramshared/` directory and the `driver.c` file for `EvtDriverUnload` or `DriverUnload` routines.
+Neither `EvtDriverUnload` nor `DriverUnload` exist in this driver.
+
+The RamShared Windows driver is a **StorPort virtual miniport**.
+As specified in `drivers/windows/ramshared/driver.c`, it initializes by calling `StorPortInitialize` and sets up `HW_INITIALIZATION_DATA` hooks (e.g. `HwInitialize`, `HwStartIo`, `HwAdapterControl`, `HwFreeAdapterResources`).
+It does not expose a standard WDM `DriverUnload` (i.e. `DriverObject->DriverUnload`) nor a WDF `EvtDriverUnload` because StorPort manages the lifetime of the miniport driver and its resources.
+Teardown in a StorPort virtual miniport is handled primarily through `HwFreeAdapterResources` and other adapter control callbacks.
+
+## Conclusion
+Since the driver architecture relies on the StorPort model rather than raw WDM or WDF, `EvtDriverUnload` is structurally non-existent. A safe orthogonal slice modifying this nonexistent function is impossible.
+Therefore, in accordance with the Immutable Contract item 4: "If safe code modification is not possible, produce FINDING_ONLY with evidence in docs/jules/findings/."


### PR DESCRIPTION
## Resumo
Documented an architectural mismatch in the Windows RamShared driver. The driver uses the StorPort model (`HW_INITIALIZATION_DATA`), which manages teardown natively (via `HwFreeAdapterResources`). Standard WDF/KMDF driver unload hooks (`EvtDriverUnload`) or WDM structures (`DriverUnload`) do not apply to this architecture. In accordance with the Immutable Contract item 4, a FINDING_ONLY report is provided instead of unsafe modifications.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `<commit-hash>` | docs: report architectural mismatch for EvtDriverUnload in StorPort driver | Document finding on StorPort vs WDF/KMDF mismatch | <details>Added `evt_driver_unload.md` to findings to fulfill the rule of documenting unmodifiable constraints.</details> |

## Labels
type:docs, type:kernel-win

## Validacao
Checked the driver structure and compiled the finding document. Tested with `ls -la docs/jules/findings`. Code compilation skipped since no code was modified. 

## Rollback trigger
If the finding is inaccurate or a WDF refactor was intended, remove the `docs/jules/findings/evt_driver_unload.md` file.

---
*PR created automatically by Jules for task [5668976768459901567](https://jules.google.com/task/5668976768459901567) started by @emersonbusson*