### PR TITLE
feat(docs): report architectural trap for unrecognized IOCTLs

### DIFF
--- a/docs/jules/findings/27-kernel-win-ioctl-trap.md
+++ b/docs/jules/findings/27-kernel-win-ioctl-trap.md
@@ -1,0 +1,9 @@
+# Kernel Windows Unrecognized IOCTL Trap
+
+## Context
+The task requested modifying `drivers/windows/ramshared/control.c` to return `STATUS_INVALID_DEVICE_REQUEST` on unknown IOCTL control codes, rather than returning a generic failure.
+
+## Finding
+A review of the target file reveals that this requirement is already satisfied. Inside `CtlDispatchDeviceControl`, the fallback `default:` branch of the `switch (code)` block assigns `status = STATUS_INVALID_DEVICE_REQUEST;` which is subsequently completed and returned.
+
+Additionally, the audit log (`docs/reliability/JULES-PR-AUDIT-20260904.md`) records that this fix was successfully implemented and accepted under PR 578 (`feat(kernel-win): return STATUS_INVALID_DEVICE_REQUEST on unrecognized IOCTL`). Attempting further code modification for this requirement would violate the contract to only address missing behavior or to produce a FINDING_ONLY report when a safe modification is unnecessary or not possible.

--- a/docs/jules/findings/README.md
+++ b/docs/jules/findings/README.md
@@ -40,3 +40,4 @@ These findings serve as an immutable record of architectural invariants in RamSh
 | 24 | [`24-pr489-broker-cross-host-civm-historical-note.md`](24-pr489-broker-cross-host-civm-historical-note.md) | `ramshared-wsl2d` | Cross-host CIVM historical race note verified. |
 | 25 | [`25-pr493-cli-read-frozen-target-error-handling.md`](25-pr493-cli-read-frozen-target-error-handling.md) | `ramshared-cli` | `read_frozen_target` uses structured Result propagation. |
 | 26 | [`26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md`](26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md) | `ramshared-wsl2d` | Memory locking invariants protect against dxgkrnl collisions. |
+| 27 | [`27-kernel-win-ioctl-trap.md`](27-kernel-win-ioctl-trap.md) | `kernel-windows` | Unrecognized IOCTLs already return STATUS_INVALID_DEVICE_REQUEST. |


### PR DESCRIPTION
## Resumo
Documented an architectural trap where unrecognized IOCTLs already correctly return `STATUS_INVALID_DEVICE_REQUEST` in `drivers/windows/ramshared/control.c`.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `<hash>` | docs(findings): report architectural trap for unrecognized IOCTLs | To avoid unnecessary modifications for an issue already addressed in PR 578. | <details>Added 27-kernel-win-ioctl-trap.md and updated README.md.</details> |

## Labels
type:refactor, type:kernel

## Validacao
Executed `grep` and `sed` to verify existing file states. Verified markdown files with `cat` and `git diff`.
Kernel compilation unavailable.

## Rollback trigger
Revert if the finding is deemed incorrect or if there's a missing IOCTL fallback mechanism.
## Issue
N/A
## Responsavel
N/A

---
*PR created automatically by Jules for task [17152120808728375433](https://jules.google.com/task/17152120808728375433) started by @emersonbusson*