### PR TITLE
feat(kernel): add guard clauses and compat for devm_ioremap_wc

### DIFF
--- a/drivers/block/ramshared/compat.h
+++ b/drivers/block/ramshared/compat.h
@@ -14,6 +14,39 @@
 #include <linux/blkdev.h>
 #include <linux/blk-mq.h>
 
+/**
+ * ramshared_devm_ioremap_wc - Fallback compatibility wrapper for devm_ioremap_wc
+ * @dev: Pointer to struct device
+ * @offset: Physical address offset (PCIe BAR start)
+ * @size: Size of the allocation
+ * @out_addr: Output pointer for mapped virtual address
+ *
+ * Returns: 0 on success, semantic errno on failure
+ */
+static inline int ramshared_devm_ioremap_wc(struct device *dev,
+					    resource_size_t offset,
+					    resource_size_t size,
+					    void __iomem **out_addr)
+{
+	if (!dev || !out_addr || size == 0)
+		return -EINVAL;
+
+	/* Physical Sanity Checks: Enforce 4096-byte page alignment */
+	if (offset & 4095)
+		return -EINVAL;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
+	*out_addr = devm_ioremap_wc(dev, offset, size);
+#else
+	*out_addr = devm_ioremap(dev, offset, size);
+#endif
+
+	if (!*out_addr)
+		return -ENOMEM;
+
+	return 0;
+}
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
 /* Linux 6.11+ Paradigm: Features embedded in struct queue_limits */
 #define RAMSHARED_HAVE_QUEUE_LIMITS_FEATURES	1

--- a/drivers/block/ramshared/dma.c
+++ b/drivers/block/ramshared/dma.c
@@ -11,11 +11,13 @@
 #include <linux/dma-mapping.h>
 #include <linux/io.h>
 #include "ramshared.h"
+#include "compat.h"
 
 int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
 {
 	int bar = 0;
 	resource_size_t bar_start, bar_len;
+	int ret;
 
 	if (!rs_dev || !pdev)
 		return -EINVAL;
@@ -32,12 +34,12 @@ int ramshared_dma_init(struct ramshared_device *rs_dev, struct pci_dev *pdev)
 	rs_dev->dma.size = min_t(size_t, bar_len, rs_dev->capacity_bytes);
 
 	/* Map PCIe VRAM BAR using Write-Combining for peak throughput */
-	rs_dev->dma.cpu_addr = devm_ioremap_wc(&pdev->dev, rs_dev->dma.pci_addr,
-					       rs_dev->dma.size);
-	if (!rs_dev->dma.cpu_addr) {
+	ret = ramshared_devm_ioremap_wc(&pdev->dev, rs_dev->dma.pci_addr,
+					rs_dev->dma.size, &rs_dev->dma.cpu_addr);
+	if (ret) {
 		dev_err(&pdev->dev, "failed to ioremap_wc VRAM BAR0 (%zu bytes)\n",
 			rs_dev->dma.size);
-		return -ENOMEM;
+		return ret;
 	}
 
 	dev_info(&pdev->dev, "DMA engine mapped %zu MB VRAM at %pa\n",


### PR DESCRIPTION
## Resumo
Introduces a fallback compatibility wrapper (`ramshared_devm_ioremap_wc`) for `devm_ioremap_wc` to safely handle physical hardware boundaries (PCIe BAR mapping) with clean guard clauses and precise kernel semantics. It enforces 4096-byte page alignment and translates errors into strict kernel return values (`-EINVAL` and `-ENOMEM`).

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat(kernel): add guard clauses and compat for devm_ioremap_wc | Implemented a clean orthogonal wrapper for PCIe VRAM BAR mapping across varying kernel releases in `compat.h` and integrated it in `dma.c`. | To eliminate deeply nested logic, defensively enforce physical hardware bounds checking early, and satisfy semantic kernel error returns mapping safely across varying supported kernel APIs. | <details>Added inline integer-returning function taking `void __iomem **` pointer to elegantly avoid macro checks/casting, injected `PAGE_ALIGNED` fallback check with arithmetic mask, mapped precise `-ENOMEM` and `-EINVAL` errnos, and maintained strictly compliant C89 declaration scopes.</details> |

## Labels
type:kernel

## Validacao
Kernel compilation unavailable (skip simulated runtime via syntax echo fallback wrapper compilation test evaluation).

## Rollback trigger
Any unhandled mapping panics, PCIe resource memory leakages, or driver init regressions due to incorrectly propagated error values.

---
*PR created automatically by Jules for task [13968472570124458469](https://jules.google.com/task/13968472570124458469) started by @emersonbusson*