### PR TITLE
docs(kernel): report FINDING_ONLY for IOCTL macro definitions

### DIFF
--- a/docs/jules/findings/finding.txt
+++ b/docs/jules/findings/finding.txt
@@ -1,0 +1,3 @@
+FINDING_ONLY
+
+The objective to define kernel standard _IOW / _IOR / _IOWR IOCTL macros with unique magic type byte in drivers/block/ramshared/ramshared.h cannot be safely implemented. Exploration revealed that there are no existing raw IOCTL functions, macros, or payload structs (e.g. ramshared_register) currently implemented or defined in the drivers/block/ramshared/ directory for the Linux kernel. Synthesizing these macros using Windows-specific structs (from drivers/windows/ramshared/protocol.h) causes strict sizeof compilation errors due to incomplete types. Therefore, no safe code modification is possible.


### PR DESCRIPTION
## Resumo

Generated a FINDING_ONLY report to document the inability to safely define Linux IOCTL macros (`_IOW`, `_IOR`) in `drivers/block/ramshared/ramshared.h`. The necessary Linux-specific payload structs or pre-existing IOCTL functions do not exist in the repository's Linux driver codebase. Utilizing the structs from the Windows codebase (`drivers/windows/ramshared/protocol.h`) introduces incomplete type `sizeof` compilation errors on Linux. Thus, no safe modification was applied.

## Commits table

| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| c322d55 | docs: FINDING_ONLY missing IOCTL struct payloads | Safe code modification was not possible. | Generated the required FINDING_ONLY report documenting missing struct payload types. |

## Labels

type:kernel, type:refactor

## Validacao

`cat docs/jules/findings/finding.txt` to verify report creation.
`echo 'Kernel build headers are unavailable to compile ramshared.h, and no code modification was made (FINDING_ONLY).'`

## Rollback trigger

Revert if the findings report causes any documentation rendering or parsing errors during pipeline checks.

---
*PR created automatically by Jules for task [13605928452861506183](https://jules.google.com/task/13605928452861506183) started by @emersonbusson*