### PR TITLE
feat(kernel-win): enforce security descriptor ACL validation on administrative IOCTLs

### DIFF
--- a/drivers/windows/ramshared/control.c
+++ b/drivers/windows/ramshared/control.c
@@ -124,6 +124,14 @@ CtlDispatchDeviceControl(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp)
 		return STATUS_INVALID_PARAMETER;
 	}
 
+	status = IoValidateDeviceIoControlAccess(Irp, FILE_READ_ACCESS | FILE_WRITE_ACCESS);
+	if (!NT_SUCCESS(status)) {
+		Irp->IoStatus.Status = status;
+		Irp->IoStatus.Information = 0;
+		IoCompleteRequest(Irp, IO_NO_INCREMENT);
+		return status;
+	}
+
 	switch (code) {
 	case IOCTL_RAMSHARED_REGISTER_QUEUE:
 		if (inLen != sizeof(RAMSHARED_REGISTER) || buf == NULL) {


### PR DESCRIPTION
## Resumo
Enforce access control (caller privilege and device security descriptors) before processing reconfiguration IOCTLs on the virtual miniport Windows driver.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(kernel-win): enforce security descriptor ACL validation on administrative IOCTLs | Added `IoValidateDeviceIoControlAccess` guard check. | Required to verify device security descriptor and ACL access for administrative IOCTL codes. | <details><summary>Detalhes</summary>Included standard `IoValidateDeviceIoControlAccess` API check before `switch (code)` in `CtlDispatchDeviceControl`. Rejects unauthorized administrative requests early with precise NTSTATUS errors.</details> |

## Issue
N/A

## Responsavel
KernelC100

## Labels
type:security, type:kernel-win

## Validacao
Kernel compilation unavailable

## Rollback trigger
Driver bugchecks during Driver Verifier soak or unhandled access denied on legitimate control connections.

---
*PR created automatically by Jules for task [15740478891995697223](https://jules.google.com/task/15740478891995697223) started by @emersonbusson*