### PR TITLE
fix(kernel-win): set AUTOSENSE_VALID on LBA bounds check

### DIFF
--- a/drivers/windows/ramshared/virtdisk.c
+++ b/drivers/windows/ramshared/virtdisk.c
@@ -619,7 +619,7 @@ VdTranslateSrb(
 			len = Srb->DataTransferLength;
 
 			if (!VdCheckLbaBounds(Disk, lba, len, &offset)) {
-				Srb->SrbStatus = SRB_STATUS_INVALID_REQUEST;
+				Srb->SrbStatus = (UCHAR)(SRB_STATUS_ERROR | SRB_STATUS_AUTOSENSE_VALID);
 				Srb->ScsiStatus = SCSISTAT_CHECK_CONDITION;
 				if (Srb->SenseInfoBuffer && Srb->SenseInfoBufferLength >= 18) {
 					UCHAR *sense = (UCHAR *)Srb->SenseInfoBuffer;


### PR DESCRIPTION
## Resumo
Set `SRB_STATUS_AUTOSENSE_VALID` along with `SRB_STATUS_ERROR` when `VdCheckLbaBounds` fails in `virtdisk.c` to ensure the Windows storage stack reads the SCSI sense data (ILLEGAL_REQUEST) rather than ignoring it as a generic `INVALID_REQUEST`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| d256e3c | Set AUTOSENSE_VALID on LBA bounds check | Allows Windows storage stack to read the provided SCSI sense data for boundary violation | `<details><summary>Detalhes</summary>Updated VdTranslateSrb to set SrbStatus to (SRB_STATUS_ERROR \| SRB_STATUS_AUTOSENSE_VALID) instead of SRB_STATUS_INVALID_REQUEST.</details>` |

## Issue
EVD-0037

## Responsavel
Jules

## Labels
type:kernel

## Validacao
Compilation skipped/failed due to missing headers.

## Rollback trigger
driver instability or BSOD

---
*PR created automatically by Jules for task [10799532549213931523](https://jules.google.com/task/10799532549213931523) started by @emersonbusson*