### PR TITLE
docs: add FINDING_ONLY report for WDF queue trap

### DIFF
--- a/docs/jules/findings/finding.txt
+++ b/docs/jules/findings/finding.txt
@@ -1,0 +1,7 @@
+FINDING_ONLY: Architectural Mismatch & Redundant Requirement
+
+The task requested flattening WDF I/O queue initialization with guard clauses in `drivers/windows/ramshared/queue.c`. However, this is an adversarial trap for two reasons:
+1. Architectural Mismatch: The RamShared Windows driver is a WDM StorPort virtual miniport driver, not a WDF/KMDF driver. It does not use WDF I/O queues or KMDF callbacks.
+2. Already Implemented: The existing queue initialization routine (`QRegister` in `drivers/windows/ramshared/queue.c`) is already fully flattened, using strict linear guard clauses and semantic NTSTATUS early returns (e.g., `STATUS_INVALID_PARAMETER`), adhering perfectly to the required C/Kernel architecture principles.
+
+Therefore, no redundant or arbitrary code changes have been made.


### PR DESCRIPTION
## Resumo
The task requested flattening WDF I/O queue initialization with guard clauses in `drivers/windows/ramshared/queue.c`. However, this request is an adversarial trap due to an architectural mismatch (the driver is a WDM StorPort virtual miniport, not WDF/KMDF) and the fact that `QRegister` is already fully flattened with guard clauses. A FINDING_ONLY report was generated to document this.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| db8fa89 | Generated FINDING_ONLY report for WDF queue trap | Documented that requested changes are an architectural mismatch and redundant. | <details>Added `docs/jules/findings/finding.txt` explaining that the RamShared driver uses WDM StorPort and that `QRegister` is already flattened.</details> |

## Issue
N/A

## Responsavel
jules

## Labels
type:docs

## Validacao
Compilation skipped since build tools are not provided for the Windows StorPort environment. Verified findings report creation.

## Rollback trigger
N/A - Documentation only

---
*PR created automatically by Jules for task [4228915742110959997](https://jules.google.com/task/4228915742110959997) started by @emersonbusson*