### PR TITLE
docs: document pre-existing geometry conversion bounds checks

### DIFF
--- a/docs/jules/findings/27-geometry-macro-trap.md
+++ b/docs/jules/findings/27-geometry-macro-trap.md
@@ -1,0 +1,7 @@
+FINDING_ONLY
+
+The task requests the addition of "geometry descriptor constants and sector conversion helper macros" for "LBA to byte offset conversion with 64-bit overflow prevention" in `drivers/windows/ramshared/virtdisk.h`.
+
+Upon inspection of the baseline codebase, this functionality is already implemented. The LBA to byte offset conversion and 64-bit overflow prevention is provided by the type-safe `FORCEINLINE BOOLEAN VdCheckLbaBounds` function in `virtdisk.h`, which correctly prevents `Lba * Disk->block_size` from overflowing `MAXULONG64`. Furthermore, physical limits for SCSI Rigid Drive Geometry (e.g., clamping cylinders to 24-bit physical hardware limits) are already explicitly handled in `virtdisk.c` around line 370.
+
+Per the architectural guidelines and agent rules, since the requirement is already met in the baseline codebase (an adversarial trap), no redundant or arbitrary code changes will be made.


### PR DESCRIPTION
## Resumo
The task requested adding geometry descriptor constants and sector conversion helper macros for LBA to byte offset conversion with 64-bit overflow prevention. Upon inspection of the codebase, this requirement is already fully implemented via the `VdCheckLbaBounds` inline function in `virtdisk.h`, and physical limits for geometry (clamping to 24-bit) are present in `virtdisk.c`. No arbitrary code changes were required. A FINDING_ONLY report was created.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: document pre-existing geometry conversion bounds checks | Created FINDING_ONLY report | To document the adversarial trap. The requested geometry constants and sector bounds checks are already implemented in `virtdisk.h` and `virtdisk.c`. | Adheres to architectural constraints and agent instructions to not make redundant changes when requirements are already satisfied. |

## Labels
type:docs, type:kernel-win

## Validacao
```bash
cat docs/jules/findings/27-geometry-macro-trap.md
```

## Rollback trigger
Not applicable, docs-only trap findings.

---
*PR created automatically by Jules for task [3835067534253561407](https://jules.google.com/task/3835067534253561407) started by @emersonbusson*