### PR TITLE
docs(kernel): document driver.h architectural mismatch

### DIFF
--- a/docs/jules/findings/27-windows-driver-header-trap.md
+++ b/docs/jules/findings/27-windows-driver-header-trap.md
@@ -1,0 +1,13 @@
+# Finding 27: Windows Driver Header Trap
+
+- **Source PR:** Jules PR
+- **Target File:** `drivers/windows/ramshared/driver.h`
+- **Classification:** `FINDING_ONLY`
+
+## Observation
+
+The requested modification to `drivers/windows/ramshared/driver.h` to use strict packing and fixed-width integers is an architectural mismatch. The file contains only `RAMSHARED_ADAPTER_EXT`, which is a private, in-memory StorPort device extension, not a shared structure. Converting its native kernel types (such as `PVOID`, `PDEVICE_OBJECT`) to fixed-width integers and enforcing strict packing would break kernel APIs, memory safety, and pointer alignment. All actual shared structures (e.g., `RAMSHARED_SQE`, `RAMSHARED_CQE`) reside in `drivers/windows/ramshared/protocol.h` and are already correctly packed and typed with fixed-width integers.
+
+## Verdict
+
+Accepted as documented architectural verification. No code modification required.


### PR DESCRIPTION
## Resumo
Documented that modifying `driver.h` to use fixed-width integer types and strict packing is an architectural mismatch. The file only contains `RAMSHARED_ADAPTER_EXT`, a private in-memory StorPort device extension, and modifying its native kernel types (e.g., `PVOID`, `PDEVICE_OBJECT`) would break kernel APIs. Shared structures reside in `protocol.h` and are already correctly packed and typed.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs(kernel): document driver.h architectural mismatch | Created finding report | Native kernel types cannot be strictly packed and converted to fixed-width without breaking kernel APIs | Added finding.txt in docs/jules/findings/ |

## Issue
N/A

## Responsavel
KernelC100

## Labels
type:docs, type:kernel

## Validacao
N/A (Finding only)

## Rollback trigger
If the PR documentation is inaccurate or incomplete.

---
*PR created automatically by Jules for task [3523514252766521179](https://jules.google.com/task/3523514252766521179) started by @emersonbusson*