### PR TITLE
feat(kernel-win): define version handshake protocol header

### DIFF
--- a/crates/ramshared-winsvc/src/proto.rs
+++ b/crates/ramshared-winsvc/src/proto.rs
@@ -8,6 +8,7 @@ pub const ABI_VERSION: u32 = 1;
 pub const MAX_QD: u32 = 256;
 pub const MAX_IO: u32 = 1 << 20;
 pub const RING_MAGIC: u32 = 0x5253_5244; // 'RSRD'
+pub const PROTOCOL_MAGIC: u32 = 0x5241_4D53; // 'RAMS'
 
 pub const OP_READ: u32 = 0;
 pub const OP_WRITE: u32 = 1;
@@ -53,6 +54,14 @@ pub struct RingHdr {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
+pub struct ProtocolHdr {
+    pub magic: u32,
+    pub major_version: u32,
+    pub minor_version: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
 pub struct Register {
     pub abi_version: u32,
     pub disk_id: u32,
@@ -82,6 +91,7 @@ const _: () = {
     assert!(core::mem::align_of::<Sqe>() <= 8);
     assert!(core::mem::size_of::<Cqe>() == 16);
     assert!(core::mem::size_of::<RingHdr>() == 16);
+    assert!(core::mem::size_of::<ProtocolHdr>() == 12);
     assert!(core::mem::size_of::<Register>() == 72);
     assert!(core::mem::size_of::<DiskParams>() == 32);
 };
@@ -131,5 +141,6 @@ mod tests {
         assert_eq!(MAX_QD, 256);
         assert_eq!(MAX_IO, 1 << 20);
         assert_eq!(RING_MAGIC, 0x5253_5244);
+        assert_eq!(PROTOCOL_MAGIC, 0x5241_4D53);
     }
 }

--- a/drivers/windows/ramshared/protocol.h
+++ b/drivers/windows/ramshared/protocol.h
@@ -33,6 +33,7 @@ typedef uint8_t ramshared_u8;
 #define RAMSHARED_MAX_QD 256u	/* queue_depth max; power of two */
 #define RAMSHARED_MAX_IO (1u << 20) /* 1 MiB per bounce slot */
 #define RAMSHARED_RING_MAGIC 0x52535244u /* 'RSRD' */
+#define RAMSHARED_PROTOCOL_MAGIC 0x52414D53u /* 'RAMS' */
 
 enum ramshared_op {
 	RAMSHARED_OP_READ = 0,
@@ -44,6 +45,13 @@ enum ramshared_op {
 #define RAMSHARED_ST_OK 0
 #define RAMSHARED_ST_EIO 5
 #define RAMSHARED_ST_EINVAL 22
+
+/* version handshake protocol header */
+typedef struct _RAMSHARED_PROTOCOL_HDR {
+	ramshared_u32 magic;
+	ramshared_u32 major_version;
+	ramshared_u32 minor_version;
+} RAMSHARED_PROTOCOL_HDR, *PRAMSHARED_PROTOCOL_HDR;
 
 /* driver -> service, 32 bytes */
 typedef struct _RAMSHARED_SQE {
@@ -109,6 +117,7 @@ typedef struct _RAMSHARED_DISK_PARAMS {
 #define RAMSHARED_IOCTL_FN_DESTROY_DISK 4u
 
 #ifdef __cplusplus
+static_assert(sizeof(RAMSHARED_PROTOCOL_HDR) == 12, "RAMSHARED_PROTOCOL_HDR size");
 static_assert(sizeof(RAMSHARED_SQE) == 32, "RAMSHARED_SQE size");
 static_assert(sizeof(RAMSHARED_CQE) == 16, "RAMSHARED_CQE size");
 static_assert(sizeof(RAMSHARED_RING_HDR) == 16, "RAMSHARED_RING_HDR size");


### PR DESCRIPTION
## Resumo
Defined protocol header struct with magic signature 0x52414D53 (RAMS) and version fields in C header and Rust mirror.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| feat(kernel-win): define version handshake protocol header | Added `RAMSHARED_PROTOCOL_HDR` and `ProtocolHdr` with RAMS magic. | Required for version handshake. | Size 12 bytes. |

## Labels
type:kernel

## Validacao
Ran `cargo test` in `crates/ramshared-winsvc` and verified C `static_assert`.

## Rollback trigger
Build failures or struct layout mismatch.

---
*PR created automatically by Jules for task [4121933682011030203](https://jules.google.com/task/4121933682011030203) started by @emersonbusson*