### PR TITLE
refactor: flatten CLI argument parsing in benchmark harness with guard clauses

### DIFF
--- a/tools/benchmarks/kernel_vram_bench.c
+++ b/tools/benchmarks/kernel_vram_bench.c
@@ -60,13 +60,12 @@ int main(int argc, char **argv) {
 	void *read_pinned = NULL;
 	uint64_t dev_ptr = 0;
 
-	if (argc > 1) {
-		int val = atoi(argv[1]);
-		if (val <= 0 || val > 4096) {
-			fprintf(stderr, "[-] Error: Invalid chunk_mib size (must be 1-4096).\n");
-			return -EINVAL;
-		}
-		chunk_mib = val;
+	if (argc > 1)
+		chunk_mib = atoi(argv[1]);
+
+	if (chunk_mib <= 0 || chunk_mib > 4096) {
+		fprintf(stderr, "[-] Error: Invalid chunk_mib size (must be 1-4096).\n");
+		return -EINVAL;
 	}
 	size_t chunk_bytes = MIB_TO_BYTES(chunk_mib);
 


### PR DESCRIPTION
## Resumo
Refactored the CLI argument parsing logic in `tools/benchmarks/kernel_vram_bench.c` to use flat guard clauses instead of nested if/else statements. This aligns with the C/Kernel Clean Architecture principles, improving readability and maintainability while preserving correct semantic kernel error returns (-EINVAL).

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor: flatten CLI argument parsing in benchmark harness with guard clauses | Removed nested if/else condition for `argc > 1` and applied the bounds-checking guard clause at the root indentation level. | To adhere to the architectural principle of preferring linear guard clauses over deeply nested pyramids of if/else logic in C code. | Evaluates `argc > 1` first to conditionally assign `chunk_mib`, then performs an unconditional validation `chunk_mib <= 0 || chunk_mib > 4096`, returning `-EINVAL` on error. |

## Labels
type:refactor, type:kernel

## Validacao
Executed `gcc -Wall -Wextra -Werror tools/benchmarks/kernel_vram_bench.c -o tools/benchmarks/kernel_vram_bench -ldl` successfully without warnings or errors.

## Rollback trigger
Revert this commit if the benchmark tool fails to parse valid command line arguments or crashes when provided with invalid inputs.

---
*PR created automatically by Jules for task [6071770610252391723](https://jules.google.com/task/6071770610252391723) started by @emersonbusson*