### PR TITLE
docs: document missing IOCTL allocation for overflow check

### DIFF
--- a/docs/jules/findings/finding.txt
+++ b/docs/jules/findings/finding.txt
@@ -1,0 +1,12 @@
+FINDING_ONLY: Architectural Mismatch / Non-existent Allocation
+Target File: drivers/windows/ramshared/control.c
+Task: prevent integer overflow in IOCTL memory allocation size calculation using RtlULongLongAdd
+
+Evidence:
+1. The driver does not manually allocate kernel pool memory for IOCTLs in control.c.
+2. The IOCTLs (e.g., IOCTL_RAMSHARED_REGISTER_QUEUE) are explicitly defined using METHOD_BUFFERED (e.g., in control.c:15).
+3. Under METHOD_BUFFERED, the Windows I/O Manager automatically allocates the Irp->AssociatedIrp.SystemBuffer before the driver's dispatch routine is called.
+4. Searches for allocation functions (like ExAllocatePool, ExAllocatePoolWithTag) within control.c return no results.
+
+Conclusion:
+Because the driver relies on the I/O Manager for IOCTL buffer allocation and does not perform its own dynamic memory allocation for IOCTL payloads, it is impossible to apply RtlULongLongAdd prior to an allocation in this context. No code modification can safely satisfy this objective without hallucinating code.


### PR DESCRIPTION
## Resumo
Created a FINDING_ONLY report because safe code modification is impossible for this task. The request asked to use `RtlULongLongAdd` to prevent integer overflow in IOCTL memory allocation size calculation within `drivers/windows/ramshared/control.c`. However, exploration of the codebase revealed that the IOCTLs are defined using `METHOD_BUFFERED`. Under this method, the Windows I/O Manager automatically allocates the buffer (`Irp->AssociatedIrp.SystemBuffer`) before invoking the driver's dispatch routine. There are no manual kernel pool allocations (e.g., `ExAllocatePool`) made for IOCTLs in this file. Therefore, applying an arithmetic check prior to an allocation the driver does not make is an architectural mismatch. The findings are documented with evidence in `docs/jules/findings/finding.txt`.

## Commits table

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: document missing IOCTL allocation for overflow check | Generated FINDING_ONLY report in docs/jules/findings/finding.txt | Prevented unsafe hallucination of code; documented architectural mismatch | The driver uses METHOD_BUFFERED for IOCTLs, so allocation happens in the I/O Manager, not the driver itself. |

## Labels
type:docs, type:kernel

## Validacao
Verified creation of the report. Kernel compilation skipped as dependencies are unavailable.

## Rollback trigger
Revert if the finding document incorrectly describes the IOCTL allocation mechanism or if a valid manual allocation was overlooked.

---
*PR created automatically by Jules for task [7529020078633370467](https://jules.google.com/task/7529020078633370467) started by @emersonbusson*