### PR TITLE
fix(c-bench): clamp benchmark buffer size to physical GPU VRAM capacity

### DIFF
--- a/tools/benchmarks/kernel_vram_bench.c
+++ b/tools/benchmarks/kernel_vram_bench.c
@@ -140,6 +140,17 @@ int main(int argc, char **argv) {
 	printf("[+] GPU Memory: %zu MiB free / %zu MiB total\n",
 	       free_b / (1024 * 1024), total_b / (1024 * 1024));
 
+	if (chunk_bytes > free_b) {
+		chunk_bytes = free_b & ~((size_t)4095);
+		chunk_mib = (int)(chunk_bytes / (1024 * 1024));
+		printf("[!] Clamping benchmark buffer to %zu bytes (%d MiB) to avoid OOM.\n", chunk_bytes, chunk_mib);
+		if (chunk_bytes == 0) {
+			fprintf(stderr, "[-] Error: Insufficient free VRAM.\n");
+			ret = -ENOMEM;
+			goto out_ctx;
+		}
+	}
+
 	// Allocate Pinned Host Memory
 	if (cuMemHostAlloc(&host_pinned, chunk_bytes, 0) != 0) {
 		fprintf(stderr, "[-] Error: cuMemHostAlloc failed (%d MiB).\n", chunk_mib);


### PR DESCRIPTION
## Resumo
Clamped the benchmark buffer size to physical GPU VRAM capacity to avoid OOM crashes.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1aa6dd5 | Clamp benchmark buffer | To prevent OOM crashes | Aligned chunk bytes to 4096 and updated chunk_mib |

## Issue
c-bench

## Responsavel
Jules

## Labels
type:refactor, type:kernel

## Validacao
Compiled with `gcc -Wall -Wextra tools/benchmarks/kernel_vram_bench.c -o tools/benchmarks/kernel_vram_bench -ldl -lrt`

## Rollback trigger
Compilation failure or crash in `kernel_vram_bench` due to improper clamping.

---
*PR created automatically by Jules for task [9927885906827327693](https://jules.google.com/task/9927885906827327693) started by @emersonbusson*