### PR TITLE
fix(poolstress): return STATUS_NO_MEMORY with diagnostics on allocation failure

### DIFF
--- a/drivers/windows/tools/poolstress/poolstress.c
+++ b/drivers/windows/tools/poolstress/poolstress.c
@@ -105,7 +105,8 @@ PoolstressDispatch(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp)
 			bytes = (SIZE_T)in->NGb << 30;
 			g_Pool = ExAllocatePool2(POOL_FLAG_PAGED, bytes, 'ssPR');
 			if (!g_Pool) {
-				status = STATUS_INSUFFICIENT_RESOURCES;
+				DbgPrintEx(DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "Poolstress: STATUS_NO_MEMORY - Exhausted allocating %Iu bytes (%lu GB)\n", bytes, in->NGb);
+				status = STATUS_NO_MEMORY;
 				goto out_unlock;
 			}
 			g_PoolSize = bytes;
@@ -116,6 +117,7 @@ PoolstressDispatch(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp)
 				volatile UCHAR *p = (PUCHAR)g_Pool + i * PAGE_SIZE;
 				*p = *p;
 			}
+			DbgPrintEx(DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL, "Poolstress: STATUS_SUCCESS - Allocated %Iu bytes, touched %Iu pages\n", bytes, i);
 		} else if (code == IOCTL_POOLSTRESS_READBACK) {
 			SIZE_T i;
 			volatile UCHAR sum = 0;


### PR DESCRIPTION
## Resumo
Modified `poolstress.c` to return `STATUS_NO_MEMORY` instead of `STATUS_INSUFFICIENT_RESOURCES` when `ExAllocatePool2` fails during the `ALLOC` IOCTL processing. Added diagnostic logging using `DbgPrintEx` for both failure (exhaustion) and success scenarios to print bounded evaluations of `bytes` and `in->NGb`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 63afb79 | fix(poolstress): return STATUS_NO_MEMORY with diagnostics on allocation failure | Requested to return STATUS_NO_MEMORY or STATUS_SUCCESS with detailed diagnostic summary. | <details>Swapped STATUS_INSUFFICIENT_RESOURCES for STATUS_NO_MEMORY and added `DbgPrintEx` in both allocation failure and success paths.</details> |

## Issue
c-bench-063

## Responsavel
Jules

## Labels
type:kernel

## Validacao
Attempted compilation using `x86_64-w64-mingw32-gcc -I/usr/include/w32api -shared -nostdlib -Wl,--entry=DriverEntry drivers/windows/tools/poolstress/poolstress.c || echo 'Compilation skipped'` (Skipped due to missing toolchain).

## Rollback trigger
Kernel panic or driver load failure.

---
*PR created automatically by Jules for task [11568225112400803461](https://jules.google.com/task/11568225112400803461) started by @emersonbusson*