### PR TITLE
fix: guard clauses for open file descriptor and ioctl readiness in bench harness

### DIFF
--- a/tools/benchmarks/kernel_vram_bench.c
+++ b/tools/benchmarks/kernel_vram_bench.c
@@ -13,6 +13,10 @@
 #include <time.h>
 #include <dlfcn.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <linux/fs.h>
 
 #define DEFAULT_CHUNK_MIB 256
 #define MIB_TO_BYTES(mib) ((size_t)(mib) * 1024 * 1024)
@@ -78,6 +82,20 @@ int main(int argc, char **argv) {
 	printf("=================================================================\n");
 	printf("   RamShared Hardware DMA & PCIe Bandwidth Benchmark Tool         \n");
 	printf("=================================================================\n");
+
+	int fd = open("/dev/ramshared", O_RDWR);
+	if (fd < 0) {
+		fprintf(stderr, "[-] Error: Character device /dev/ramshared not found or permission denied.\n");
+		return -ENODEV;
+	}
+
+	uint64_t size_bytes = 0;
+	if (ioctl(fd, BLKGETSIZE64, &size_bytes) < 0) {
+		fprintf(stderr, "[-] Error: Failed to query device capability (ioctl BLKGETSIZE64).\n");
+		close(fd);
+		return -EINVAL;
+	}
+	close(fd);
 
 	lib = load_cuda_driver();
 	if (!lib) {


### PR DESCRIPTION
## Resumo
Added early validation checks (guard clauses) to the `kernel_vram_bench.c` benchmark harness to verify that the `/dev/ramshared` character device can be opened and queried successfully before executing the main timing loop.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| <details>fix: validate character device and query capability in bench harness</details> | Added `open` and `ioctl(BLKGETSIZE64)` checks for `/dev/ramshared` before CUDA initialization. | To enforce clean C architecture principles by returning early and providing precise semantic kernel errnos (`-ENODEV` and `-EINVAL`) if the hardware device is not ready. | The harness now correctly queries device readiness via `BLKGETSIZE64`, preventing silent or delayed failures. |

## Labels
type:refactor, type:kernel

## Validacao
1. Compiled successfully via: `gcc -Wall -Wextra tools/benchmarks/kernel_vram_bench.c -o tools/benchmarks/kernel_vram_bench`
2. Executed binary `kernel_vram_bench` to observe expected precise errors (`-ENODEV`) when device is unavailable.

## Rollback trigger
Any compilation failures or regressions indicating the benchmark tool fails to execute correctly on systems where `/dev/ramshared` is actually present and configured.

---
*PR created automatically by Jules for task [10679293761440081211](https://jules.google.com/task/10679293761440081211) started by @emersonbusson*