### PR TITLE
fix: implement detailed memory corruption verification

### DIFF
--- a/tools/benchmarks/kernel_vram_bench.c
+++ b/tools/benchmarks/kernel_vram_bench.c
@@ -198,7 +198,16 @@ int main(int argc, char **argv) {
 	       d2h_speed, d2h_speed / 1024.0, t1 - t0);
 
 	// 3. Bit-by-bit Verification
-	int match = (memcmp(host_pinned, read_pinned, chunk_bytes) == 0);
+	int match = 1;
+	uint32_t *rp_ptr32 = (uint32_t *)read_pinned;
+	for (size_t i = 0; i < num_words; i++) {
+		if (rp_ptr32[i] != hp_ptr32[i]) {
+			fprintf(stderr, "[-] Corruption detected at byte offset 0x%zx: expected 0x%08x, got 0x%08x\n",
+				i * sizeof(uint32_t), hp_ptr32[i], rp_ptr32[i]);
+			match = 0;
+			break;
+		}
+	}
 	printf("\n[+] Data Integrity Proof: %s\n",
 	       match ? "PASS (100% Bit-Exact Match, Zero Corruption)" : "FAIL");
 


### PR DESCRIPTION
## Resumo
Replaced the simple `memcmp` based integrity verification in `tools/benchmarks/kernel_vram_bench.c` with a detailed `uint32_t` bit-by-bit loop that checks element by element. It stops at the first error printing the offset, expected, and actual values.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix: implement detailed memory corruption verification | Implemented detailed memory corruption verification | To accurately detect and report memory corruption patterns on readback over the PCIe bus | <details>Replaced `memcmp` with a `for` loop that checks each `uint32_t` element and prints corruption details (byte offset, expected value, actual value) if a mismatch occurs.</details> |

## Issue
- None

## Responsavel
- @jules

## Labels
type:refactor, type:kernel

## Validacao
- Ran `gcc -Wall -Wextra tools/benchmarks/kernel_vram_bench.c -o tools/benchmarks/kernel_vram_bench -ldl -lrt`
- Ran `./tools/benchmarks/kernel_vram_bench`

## Rollback trigger
Revert this change if the benchmark output incorrectly flags data corruption or if there is a compilation error in different environments.

---
*PR created automatically by Jules for task [12199832911101050695](https://jules.google.com/task/12199832911101050695) started by @emersonbusson*