### PR TITLE
docs(findings): report finding on architectural mismatch for multi-threaded benchmark

### DIFF
--- a/docs/jules/findings/finding-c-bench-pthread.txt
+++ b/docs/jules/findings/finding-c-bench-pthread.txt
@@ -1,0 +1,7 @@
+RamShared — Architectural Report
+Target: tools/benchmarks/kernel_vram_bench.c
+Task: multi-threaded benchmark worker synchronization using pthread barriers
+
+The requested codebase target (`tools/benchmarks/kernel_vram_bench.c`) is a strictly single-threaded, sequential benchmark application measuring Direct DMA Host-to-Device and Device-to-Host throughput via the CUDA Driver API. It does not contain any multi-threaded workers, thread pools, or `pthread_create` logic.
+
+Implementing `pthread_barrier_t` synchronization would require artificially inventing a multi-threaded architecture that does not exist in the baseline, violating the Immutable Contract ("Implement only the smallest safe orthogonal slice" and "If safe code modification is not possible, produce FINDING_ONLY"). Therefore, no code modification has been made to `kernel_vram_bench.c`. This finding satisfies the requirement.


### PR DESCRIPTION
## Resumo
Report finding that `tools/benchmarks/kernel_vram_bench.c` is strictly single-threaded and lacks the multi-threaded workers required for `pthread_barrier_t` synchronization.
## Commits table (| Commit | O que fez | Por que fez | Detalhes |)
| docs(findings): report finding on architectural mismatch for multi-threaded benchmark | Created finding report | The benchmark is single-threaded; adding pthread barriers would require inventing unverified multi-threaded logic | N/A |
## Issue
multi-threaded benchmark worker synchronization using pthread barriers
## Responsavel
Jules
## Labels
type:docs
## Validacao
Exploration via `grep` confirmed the absence of `pthread_create` and multi-threaded logic in the target file.
## Rollback trigger
N/A (Documentation only)

---
*PR created automatically by Jules for task [10183386804284004028](https://jules.google.com/task/10183386804284004028) started by @emersonbusson*