### PR TITLE
fix(uring): Return semantic EBUSY for full submission queues

### DIFF
--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -235,7 +235,7 @@ fn submit_uring_cmd80(fd: RawFd, cmd_op: u32, cmd: [u8; 80]) -> io::Result<i32> 
     {
         let mut sq = ring.submission();
         if sq.is_full() {
-            return Err(io::Error::other("io_uring submission queue is full"));
+            return Err(io::Error::from_raw_os_error(libc::EBUSY));
         }
         // SAFETY: `cmd` is copied into the SQE before submission. Public wrappers
         // in this module pass null pointers, local stack pointers, or borrowed mutable
@@ -331,7 +331,7 @@ impl UblkFetchRing {
             // serving I/O, which requires `START_DEV` (not invoked in this path).
             let mut sq = ring.submission();
             if sq.is_full() {
-                return Err(io::Error::other("io_uring submission queue is full"));
+                return Err(io::Error::from_raw_os_error(libc::EBUSY));
             }
             unsafe {
                 let _ = sq.push(&entry);
@@ -495,7 +495,7 @@ impl UblkServer {
         // remains open. The kernel only accesses the buffer to serve I/O on this thread.
         let mut sq = self.ring.submission();
         if sq.is_full() {
-            return Err(io::Error::other("io_uring submission queue is full"));
+            return Err(io::Error::from_raw_os_error(libc::EBUSY));
         }
         unsafe {
             let _ = sq.push(&entry);
@@ -752,8 +752,7 @@ mod tests {
         let err = server
             .push(0, 2, 0, 0)
             .expect_err("expected ring full error");
-        assert_eq!(err.kind(), io::ErrorKind::Other);
-        assert_eq!(err.to_string(), "io_uring submission queue is full");
+        assert_eq!(err.raw_os_error(), Some(libc::EBUSY));
 
         drop(server);
         drop(file);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Resumo
Returns a semantic kernel error `-EBUSY` when the io_uring submission queue is full instead of a generic IO error.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix(uring): Return EBUSY for full submission queues | Returned EBUSY instead of generic error for full SQE | Conforms to semantic kernel error principles. | <details>Updated `submit_uring_cmd80`, `UblkFetchRing::submit_fetch_all`, `UblkServer::push` and unit tests</details> |

## Issue
kernel-ring-availability

## Responsavel
jules

## Labels
type:kernel, type:refactor

## Validacao
`cd crates/ramshared-uring && cargo test`

## Rollback trigger
Integration tests failing due to unhandled EBUSY from io_uring.

---
*PR created automatically by Jules for task [7919347220187833515](https://jules.google.com/task/7919347220187833515) started by @emersonbusson*