### PR TITLE
fix(uring): validate fixed buffer registration bounds against kernel page size

### DIFF
--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -266,13 +266,14 @@ pub struct UblkCompletion {
     pub result: i32,
 }
 
-/// Validates that fixed buffer parameters are aligned to 4096 bytes and that the
+/// Validates that fixed buffer parameters are aligned to the kernel page size and that the
 /// total allocation (`queue_depth * buf_size`) does not exceed `RLIMIT_MEMLOCK`.
 pub fn validate_fixed_buffer_params(queue_depth: u16, buf_size: usize) -> io::Result<()> {
-    if buf_size == 0 || !buf_size.is_multiple_of(4096) {
+    let ps = page_size();
+    if buf_size == 0 || !buf_size.is_multiple_of(ps) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "buffer size must be > 0 and a multiple of 4096 bytes",
+            "buffer size must be > 0 and a multiple of kernel page size",
         ));
     }
 
@@ -510,12 +511,13 @@ mod tests {
 
     #[test]
     fn test_validate_fixed_buffer_alignment_and_limits() {
+        let ps = page_size();
         // Test invalid alignment
-        let err = validate_fixed_buffer_params(2, 4095).expect_err("invalid alignment should fail");
+        let err = validate_fixed_buffer_params(2, ps - 1).expect_err("invalid alignment should fail");
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
 
         // Test valid alignment
-        assert!(validate_fixed_buffer_params(2, 4096).is_ok());
+        assert!(validate_fixed_buffer_params(2, ps).is_ok());
 
         // Test buffer size 0
         let err_zero = validate_fixed_buffer_params(2, 0).expect_err("zero size should fail");
@@ -531,7 +533,7 @@ mod tests {
         if res == 0 && rlim.rlim_cur != libc::RLIM_INFINITY {
             // we create a massive buffer
             // wait, if we pass u16::MAX for queue depth and rlim_cur for buf size...
-            let massive_buf_size = (((rlim.rlim_cur / 4096) + 2) * 4096) as usize;
+            let massive_buf_size = (((rlim.rlim_cur / ps as u64) + 2) * ps as u64) as usize;
             let huge_err = validate_fixed_buffer_params(2, massive_buf_size)
                 .expect_err("massive buffer should fail");
             assert_eq!(huge_err.raw_os_error(), Some(libc::ERANGE));
@@ -632,13 +634,13 @@ mod tests {
         assert!(ublk_start_dev(fd, 9, std::process::id()).is_err());
         assert!(ublk_stop_dev(fd, 9).is_err());
 
-        let mut server = UblkServer::new(fd, 1, 4096).expect("regular-file server fixture");
+        let mut server = UblkServer::new(fd, 1, page).expect("regular-file server fixture");
         assert_eq!(
             server.io_desc_snapshot(0).expect("zero descriptor"),
             [0u8; 24]
         );
         assert!(server.io_desc_snapshot(1).is_err());
-        assert_eq!(server.buffer_mut(0).expect("tag zero buffer").len(), 4096);
+        assert_eq!(server.buffer_mut(0).expect("tag zero buffer").len(), page);
         assert!(server.buffer_mut(1).is_err());
         assert!(server.commit_and_fetch(1, 0).is_err());
         server
@@ -655,8 +657,9 @@ mod tests {
 
     #[test]
     fn regular_file_fetch_ring_drains_refusal_without_a_device() {
-        let (path, file) = regular_file_fixture("ublk-fetch-refusal", page_size());
-        let mut ring = UblkFetchRing::submit_fetch_all(file.as_raw_fd(), 2, 4096)
+        let page = page_size();
+        let (path, file) = regular_file_fixture("ublk-fetch-refusal", page);
+        let mut ring = UblkFetchRing::submit_fetch_all(file.as_raw_fd(), 2, page)
             .expect("submit regular-file fetches");
         let deadline = Instant::now() + Duration::from_secs(2);
         let completions = loop {
@@ -676,10 +679,11 @@ mod tests {
 
     #[test]
     fn test_io_uring_worker_timeout_and_cancellation() {
-        let (path, file) = regular_file_fixture("ublk-timeout-cancel", page_size());
+        let page = page_size();
+        let (path, file) = regular_file_fixture("ublk-timeout-cancel", page);
         let fd = file.as_raw_fd();
 
-        let mut server = UblkServer::new(fd, 2, 4096).expect("server fixture");
+        let mut server = UblkServer::new(fd, 2, page).expect("server fixture");
 
         // Simulate a Timeout directly in the server's ring
         let ts = types::Timespec::new().sec(0).nsec(1_000_000); // 1ms
@@ -743,8 +747,9 @@ mod tests {
     }
     #[test]
     fn ublk_server_push_guard_clause_rejects_full_ring() {
-        let (path, file) = regular_file_fixture("ublk-full-ring", page_size());
-        let mut server = UblkServer::new(file.as_raw_fd(), 2, 4096).expect("server fixture");
+        let page = page_size();
+        let (path, file) = regular_file_fixture("ublk-full-ring", page);
+        let mut server = UblkServer::new(file.as_raw_fd(), 2, page).expect("server fixture");
 
         // Ring capacity is 2. Push 2 items, 3rd should fail.
         assert!(server.push(0, 0, 0, 0).is_ok());


### PR DESCRIPTION
## Resumo
Validate fixed buffer bounds and constraints using the kernel's actual dynamic page size instead of a hardcoded 4096-byte assumption. This ensures portability on architectures with 16KB/64KB pages and fulfills the physical limits requirements.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix(uring): validate fixed buffer registration bounds against kernel page size | Changed `validate_fixed_buffer_params` to use `page_size()` and updated test fixtures. | A hardcoded 4096 limit causes io_uring setup errors on systems with larger physical page sizes. | <details><summary>Detalhes</summary>Modified `lib.rs` boundary validation logic and injected dynamic page sizes into the mock test servers (`UblkServer::new`).</details> |

## Issue
none

## Responsavel
Jules

## Labels
type:kernel, type:refactor

## Validacao
Executed `cargo test -p ramshared-uring` and `cargo clippy -p ramshared-uring -- -D warnings`.

## Rollback trigger
If there are io_uring registration errors on non-4k page systems

---
*PR created automatically by Jules for task [13815761604250782515](https://jules.google.com/task/13815761604250782515) started by @emersonbusson*