### PR TITLE
feat: validate CUDA driver function pointer table non-nullness before invocation

### DIFF
--- a/crates/ramshared-cuda/src/driver.rs
+++ b/crates/ramshared-cuda/src/driver.rs
@@ -29,6 +29,8 @@ pub enum CudaError {
     },
     /// VRAM memory region access out of bounds (offset + len > size).
     OutOfRange { off: usize, len: usize, size: usize },
+    /// Internal driver state is invalid (e.g. null function pointers).
+    InvalidState(&'static str),
 }
 
 impl fmt::Display for CudaError {
@@ -42,6 +44,7 @@ impl fmt::Display for CudaError {
             CudaError::OutOfRange { off, len, size } => {
                 write!(f, "out of bounds access: off={off} len={len} > size={size}")
             }
+            CudaError::InvalidState(s) => write!(f, "invalid driver state: {s}"),
         }
     }
 }
@@ -116,6 +119,10 @@ impl Cuda {
             }
         };
 
+        if !syms.validate_pointers() {
+            return Err(CudaError::InvalidState("resolved CUDA driver symbols table contains null pointers"));
+        }
+
         // SAFETY: init symbol resolved successfully.
         let r = unsafe { (syms.init)(0) };
         check(&syms, r, "cuInit")?;
@@ -125,6 +132,9 @@ impl Cuda {
 
     /// Returns the number of CUDA-capable devices visible to the system.
     pub fn device_count(&self) -> Result<i32, CudaError> {
+        if !self.syms.validate_pointers() {
+            return Err(CudaError::InvalidState("driver pointers corrupted"));
+        }
         let mut count: i32 = 0;
         // SAFETY: count points to a valid local memory location.
         let r = unsafe { (self.syms.device_get_count)(&mut count) };
@@ -134,6 +144,9 @@ impl Cuda {
 
     /// Gets the device handle for the specified `ordinal` index, resolving its name.
     pub fn device(&self, ordinal: i32) -> Result<Device, CudaError> {
+        if !self.syms.validate_pointers() {
+            return Err(CudaError::InvalidState("driver pointers corrupted"));
+        }
         let mut raw: CuDevice = 0;
         // SAFETY: raw points to a valid local memory location.
         let r = unsafe { (self.syms.device_get)(&mut raw, ordinal) };
@@ -156,6 +169,9 @@ impl Cuda {
 
     /// Creates a CUDA context on the specified device (becomes current on the calling thread).
     pub fn create_context<'a>(&'a self, device: &Device) -> Result<Context<'a>, CudaError> {
+        if !self.syms.validate_pointers() {
+            return Err(CudaError::InvalidState("driver pointers corrupted"));
+        }
         let mut raw: CuContext = core::ptr::null_mut();
         // SAFETY: raw points to a valid local; device.raw is a valid CUdevice handle.
         let r = unsafe { (self.syms.ctx_create)(&mut raw, 0, device.raw) };
@@ -197,6 +213,9 @@ pub struct Context<'a> {
 impl<'a> Context<'a> {
     /// Returns the free and total VRAM capacities in bytes (`cuMemGetInfo`).
     pub fn mem_info(&self) -> Result<(usize, usize), CudaError> {
+        if !self.cuda.syms.validate_pointers() {
+            return Err(CudaError::InvalidState("driver pointers corrupted"));
+        }
         let (mut free, mut total) = (0_usize, 0_usize);
         // SAFETY: out-parameters are valid local pointers; CUDA context is current on the calling thread.
         let r = unsafe { (self.cuda.syms.mem_get_info)(&mut free, &mut total) };
@@ -206,6 +225,9 @@ impl<'a> Context<'a> {
 
     /// Allocates `bytes` of VRAM. The allocation is released when the returned `DeviceMem` is dropped.
     pub fn alloc(&self, bytes: usize) -> Result<DeviceMem<'_, 'a>, CudaError> {
+        if !self.cuda.syms.validate_pointers() {
+            return Err(CudaError::InvalidState("driver pointers corrupted"));
+        }
         let mut ptr: CuDevicePtr = 0;
         // SAFETY: ptr points to a valid local; CUDA context is current.
         let r = unsafe { (self.cuda.syms.mem_alloc)(&mut ptr, bytes) };
@@ -220,6 +242,9 @@ impl<'a> Context<'a> {
 
 impl Drop for Context<'_> {
     fn drop(&mut self) {
+        if !self.cuda.syms.validate_pointers() {
+            return;
+        }
         // SAFETY: raw handle was returned by cuCtxCreate and has not been destroyed yet. Best-effort drop.
         unsafe {
             let _ = (self.cuda.syms.ctx_destroy)(self.raw);
@@ -245,6 +270,9 @@ impl DeviceMem<'_, '_> {
 
     /// Fills the entire region with zeroes (`cuMemsetD8` + synchronize). SPEC §6.2/§11.
     pub fn zero(&mut self) -> Result<(), CudaError> {
+        if !self.ctx.cuda.syms.validate_pointers() {
+            return Err(CudaError::InvalidState("driver pointers corrupted"));
+        }
         let syms = &self.ctx.cuda.syms;
         // SAFETY: ptr and len accurately describe the region allocated for this memory object.
         let r = unsafe { (syms.memset_d8)(self.ptr, 0, self.len) };
@@ -256,6 +284,9 @@ impl DeviceMem<'_, '_> {
 
     /// Copies `src` bytes into VRAM at the specified `off` offset (Host->Device, synchronous).
     pub fn write_at(&mut self, off: usize, src: &[u8]) -> Result<(), CudaError> {
+        if !self.ctx.cuda.syms.validate_pointers() {
+            return Err(CudaError::InvalidState("driver pointers corrupted"));
+        }
         self.bounds(off, src.len())?;
         let syms = &self.ctx.cuda.syms;
         // SAFETY: offset and length validated by bounds(); src is a valid memory slice.
@@ -271,6 +302,9 @@ impl DeviceMem<'_, '_> {
 
     /// Copies bytes from VRAM at `off` into the `dst` buffer (Device->Host, synchronous).
     pub fn read_at(&self, off: usize, dst: &mut [u8]) -> Result<(), CudaError> {
+        if !self.ctx.cuda.syms.validate_pointers() {
+            return Err(CudaError::InvalidState("driver pointers corrupted"));
+        }
         self.bounds(off, dst.len())?;
         let syms = &self.ctx.cuda.syms;
         // SAFETY: offset and length validated by bounds(); dst is a valid mutable slice.
@@ -298,6 +332,9 @@ impl DeviceMem<'_, '_> {
 
 impl Drop for DeviceMem<'_, '_> {
     fn drop(&mut self) {
+        if !self.ctx.cuda.syms.validate_pointers() {
+            return;
+        }
         // SAFETY: ptr was returned by a successful cuMemAlloc call and has not been freed.
         unsafe {
             let _ = (self.ctx.cuda.syms.mem_free)(self.ptr);

--- a/crates/ramshared-cuda/src/ffi.rs
+++ b/crates/ramshared-cuda/src/ffi.rs
@@ -52,3 +52,38 @@ pub struct Syms {
     pub mem_get_info: FnMemGetInfo,
     pub get_error_string: Option<FnGetErrorString>,
 }
+
+impl Syms {
+    /// Validates that all mandatory driver function pointers in the table are non-null.
+    /// Does not enforce non-nullness for optional symbols (e.g., `get_error_string`).
+    pub fn validate_pointers(&self) -> bool {
+        // We cast the function pointers to *const () to check for null
+        let init_ptr: *const () = self.init as *const ();
+        let dgc_ptr: *const () = self.device_get_count as *const ();
+        let dg_ptr: *const () = self.device_get as *const ();
+        let dgn_ptr: *const () = self.device_get_name as *const ();
+        let cc_ptr: *const () = self.ctx_create as *const ();
+        let cd_ptr: *const () = self.ctx_destroy as *const ();
+        let cs_ptr: *const () = self.ctx_synchronize as *const ();
+        let ma_ptr: *const () = self.mem_alloc as *const ();
+        let mf_ptr: *const () = self.mem_free as *const ();
+        let mhtod_ptr: *const () = self.memcpy_htod as *const ();
+        let mdtoh_ptr: *const () = self.memcpy_dtoh as *const ();
+        let msd8_ptr: *const () = self.memset_d8 as *const ();
+        let mgi_ptr: *const () = self.mem_get_info as *const ();
+
+        !init_ptr.is_null()
+            && !dgc_ptr.is_null()
+            && !dg_ptr.is_null()
+            && !dgn_ptr.is_null()
+            && !cc_ptr.is_null()
+            && !cd_ptr.is_null()
+            && !cs_ptr.is_null()
+            && !ma_ptr.is_null()
+            && !mf_ptr.is_null()
+            && !mhtod_ptr.is_null()
+            && !mdtoh_ptr.is_null()
+            && !msd8_ptr.is_null()
+            && !mgi_ptr.is_null()
+    }
+}


### PR DESCRIPTION
## Resumo
Adiciona uma verificação defensiva que garante que a tabela de ponteiros de função FFI (`Syms`) do CUDA não contém ponteiros nulos antes de qualquer invocação. Isso mitiga riscos de chamadas inválidas devido a corrupção de memória ou inicialização incompleta.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| f2b6d6a | Implementou validação de ponteiros não-nulos e guard clauses no driver. | Para atender ao princípio de programação de kernel defensiva (Sanity Checks). | <details>Modificou `ffi.rs` para incluir o método `validate_pointers()` e `driver.rs` para invocar a validação antes de qualquer uso, retornando o código de erro semântico `InvalidState` caso a validação falhe.</details> |

## Issue
N/A

## Responsavel
KernelC100

## Labels
type:kernel, type:security, type:refactor

## Validacao
Os seguintes comandos foram executados com sucesso:
`cargo build --manifest-path crates/ramshared-cuda/Cargo.toml`
`cargo test --manifest-path crates/ramshared-cuda/Cargo.toml`

## Rollback trigger
Se os testes de integração em instâncias com GPU real no CI falharem, ou se houver alertas de performance críticos gerados pela verificação recorrente.

---
*PR created automatically by Jules for task [12063360838051005298](https://jules.google.com/task/12063360838051005298) started by @emersonbusson*