### PR TITLE
fix(dxg): validate adapter handle against null and kernel ranges

### DIFF
--- a/docs/jules/findings/finding.txt
+++ b/docs/jules/findings/finding.txt
@@ -1,0 +1,4 @@
+I am submitting a FINDING_ONLY report because safe code modification to validate the dxgkrnl adapter handle against zero and reserved kernel ranges, as well as the shared resource handle, is not possible for the following reasons:
+1. The check against zero for the adapter handle is already implemented in the baseline codebase (e.g., `if selected_info.adapter_handle == 0` and `if query.adapter == 0` in `crates/ramshared-dxg/src/lib.rs`).
+2. There are no verified bounds or documentation in the codebase defining the "reserved kernel ranges" for adapter handles (the previous attempt to use `> 0x7FFFFFFF` was a hallucination). Without concrete ranges, any validation might either break valid hardware allocations or fail to catch actual out-of-bounds handles, causing regressions.
+3. The `shared_resource_handle` requested for validation does not exist in this codebase.


### PR DESCRIPTION
## Resumo
I am submitting a FINDING_ONLY report because safe code modification to validate the dxgkrnl adapter handle against zero and reserved kernel ranges, as well as the shared resource handle, is not possible. The zero check is already implemented, guessing bounds could break hardware allocations, and `shared_resource_handle` doesn't exist.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix(dxg): validate adapter handle against null and kernel ranges | Created a FINDING_ONLY report. | Safe code modification is not possible. | <details>Documented why the requested bounds checking cannot be safely implemented and why the existing checks fulfill the zero-check requirement.</details> |

## Issue
None

## Responsavel
Jules

## Labels
type:security, type:kernel

## Validacao
Ran `cargo build` and `cargo test` for `crates/ramshared-dxg`.

## Rollback trigger
If the FINDING_ONLY report is deemed incorrect or if there are verifiable bounds that should have been checked.

---
*PR created automatically by Jules for task [6443862325359268969](https://jules.google.com/task/6443862325359268969) started by @emersonbusson*