### PR TITLE
refactor(kernel): map VkResult codes to VulkanError

### DIFF
--- a/crates/ramshared-vulkan/src/lib.rs
+++ b/crates/ramshared-vulkan/src/lib.rs
@@ -151,7 +151,8 @@ impl VulkanProvider {
     /// otherwise the ordinal), and sets up logical device + transfer queue + staging. RF-V1.
     pub fn open(ordinal: u32) -> Result<Self, VramError> {
         // SAFETY: loads libvulkan.so.1 via libloading; symbols remain valid as long as `entry` lives.
-        let entry = unsafe { ash::Entry::load() }.map_err(|e| VramError::Provider(format!("vulkan load: {e:?}")))?;
+        let entry = unsafe { ash::Entry::load() }
+            .map_err(|e| VramError::Provider(format!("vulkan load: {e:?}")))?;
         let app = vk::ApplicationInfo::default().api_version(vk::API_VERSION_1_1);
         let ci = vk::InstanceCreateInfo::default().application_info(&app);
         // SAFETY: `ci`/`app` valid during call; `None` = default allocator.

--- a/crates/ramshared-vulkan/src/lib.rs
+++ b/crates/ramshared-vulkan/src/lib.rs
@@ -22,8 +22,14 @@ use ramshared_vram::{VramError, VramMemory, VramProvider};
 /// Single staging buffer per provider (no alloc on hot path, DT-8): 1 MiB. Larger I/O is sliced.
 const STAGING_BYTES: u64 = 1 << 20;
 
-fn vk_err(ctx: &str, e: impl std::fmt::Debug) -> VramError {
-    VramError::Provider(format!("vulkan {ctx}: {e:?}"))
+fn vk_err(ctx: &str, e: vk::Result) -> VramError {
+    match e {
+        vk::Result::ERROR_OUT_OF_HOST_MEMORY | vk::Result::ERROR_OUT_OF_DEVICE_MEMORY => {
+            VramError::OutOfMemory
+        }
+        vk::Result::ERROR_DEVICE_LOST => VramError::Provider(format!("vulkan {ctx}: device lost")),
+        _ => VramError::Provider(format!("vulkan {ctx}: {e:?}")),
+    }
 }
 
 /// Selects a transfer queue family (prefers explicit `TRANSFER`; falls back to `GRAPHICS`/`COMPUTE`, which imply transfer per spec). Returns the family index.
@@ -145,7 +151,7 @@ impl VulkanProvider {
     /// otherwise the ordinal), and sets up logical device + transfer queue + staging. RF-V1.
     pub fn open(ordinal: u32) -> Result<Self, VramError> {
         // SAFETY: loads libvulkan.so.1 via libloading; symbols remain valid as long as `entry` lives.
-        let entry = unsafe { ash::Entry::load() }.map_err(|e| vk_err("load", e))?;
+        let entry = unsafe { ash::Entry::load() }.map_err(|e| VramError::Provider(format!("vulkan load: {e:?}")))?;
         let app = vk::ApplicationInfo::default().api_version(vk::API_VERSION_1_1);
         let ci = vk::InstanceCreateInfo::default().application_info(&app);
         // SAFETY: `ci`/`app` valid during call; `None` = default allocator.


### PR DESCRIPTION
## Resumo
Implemented exact mapping of specific `VkResult` error codes (`VK_ERROR_OUT_OF_HOST_MEMORY`, `VK_ERROR_DEVICE_LOST`, etc.) to semantic `VramError` variants in the Vulkan backend, adhering to Defensive Kernel Programming principles. Replaced unspecific string formatting with precise semantic returns.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| d346ef0 | Mapped `VkResult` codes to `VulkanError` | Provide precise semantic kernel errors instead of generic strings | <details>Modified `vk_err` to strictly accept `vk::Result` and map `ERROR_OUT_OF_HOST_MEMORY`/`ERROR_OUT_OF_DEVICE_MEMORY` to `VramError::OutOfMemory`, and `ERROR_DEVICE_LOST` to a descriptive error. Updated `ash::Entry::load` callsite to explicitly map generic `LoadingError` to maintain API integrity.</details> |

## Issue
jules/ffi-abi-078

## Responsavel
Jules

## Labels
type:refactor, type:kernel

## Validacao
- `cargo check -p ramshared-vulkan`
- `cargo test -p ramshared-vulkan`

## Rollback trigger
driver panic or memory allocation failure regressions.

---
*PR created automatically by Jules for task [15485603743154904193](https://jules.google.com/task/15485603743154904193) started by @emersonbusson*