### PR TITLE
fix(vulkan): validate vkCreateInstance presence before ICD dispatch

### DIFF
--- a/crates/ramshared-vulkan/src/lib.rs
+++ b/crates/ramshared-vulkan/src/lib.rs
@@ -149,6 +149,14 @@ impl VulkanProvider {
         let app = vk::ApplicationInfo::default().api_version(vk::API_VERSION_1_1);
         let ci = vk::InstanceCreateInfo::default().application_info(&app);
         // SAFETY: `ci`/`app` valid during call; `None` = default allocator.
+        let cname = std::ffi::CStr::from_bytes_with_nul(b"vkCreateInstance\0").unwrap();
+        let proc_addr = unsafe {
+            (entry.static_fn().get_instance_proc_addr)(vk::Instance::null(), cname.as_ptr())
+        };
+        if proc_addr.is_none() {
+            return Err(VramError::Provider("vulkan loader is missing vkCreateInstance".into()));
+        }
+
         let instance = unsafe { entry.create_instance(&ci, None) }
             .map_err(|e| vk_err("create_instance", e))?;
 


### PR DESCRIPTION
## Resumo
Fix missing `vkCreateInstance` function pointer validation that caused panics when Vulkan ICD is missing.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix(vulkan): validate vkCreateInstance presence before ICD dispatch | Adicionada validação de ponteiro usando get_instance_proc_addr | Para evitar kernel panics ao carregar funções ICD não suportadas pelo driver Vulkan | <details>Modifica `crates/ramshared-vulkan/src/lib.rs` para extrair e validar o ponteiro de função `vkCreateInstance` antes de usá-lo, retornando um erro semântico amigável caso não esteja carregado.</details> |

## Issue
N/A

## Responsavel
Jules

## Labels
type:kernel, type:refactor, type:vulkan

## Validacao
Compilado com `cargo check -p ramshared-vulkan`. Testes rodados com `cargo test -p ramshared-vulkan -- --ignored` sem regressões.

## Rollback trigger
Revert if the ICD loading process incorrectly rejects valid driver configurations.

---
*PR created automatically by Jules for task [11964770509498385947](https://jules.google.com/task/11964770509498385947) started by @emersonbusson*