### PR TITLE
docs: document architectural mismatch for WDF in StorPort

### DIFF
--- a/docs/jules/findings/finding.txt
+++ b/docs/jules/findings/finding.txt
@@ -1,0 +1,7 @@
+FINDING_ONLY: Architectural Mismatch
+
+The task requests the addition of `WDF_DECLARE_CONTEXT_TYPE_WITH_NAME` for queue private context in `drivers/windows/ramshared/queue.h`.
+However, the RamShared Windows virtual miniport driver is implemented using the WDM StorPort framework (`storport.h`), as evidenced by structures and functions like `HW_INITIALIZATION_DATA` and `HwStorFindAdapter`.
+It is not a WDF (KMDF/UMDF) driver. Therefore, implementing WDF-specific macros or callbacks such as `WDF_DECLARE_CONTEXT_TYPE_WITH_NAME` is an architectural mismatch and impossible to do safely.
+
+Per the Immutable Contract and memory guidelines, I am producing this FINDING_ONLY report instead of modifying the code.


### PR DESCRIPTION
## Resumo
Documented that WDF_DECLARE_CONTEXT_TYPE_WITH_NAME cannot be implemented because RamShared uses WDM StorPort, not KMDF.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: document architectural mismatch for WDF in StorPort | Created finding.txt | WDF macros are incompatible with StorPort | FINDING_ONLY report |

## Labels
type:docs, type:kernel

## Validacao
Reviewed queue.h to verify storport.h inclusion and absence of wdf.h.

## Rollback trigger
If the repository actually transitions to KMDF and standard WDF context rules apply.

---
*PR created automatically by Jules for task [881755970315793102](https://jules.google.com/task/881755970315793102) started by @emersonbusson*