### PR TITLE
docs(findings): report architectural mismatch for CRC32 FFI in hash.rs

### DIFF
--- a/docs/jules/findings/27-crc32-ffi-trap.md
+++ b/docs/jules/findings/27-crc32-ffi-trap.md
@@ -1,0 +1,12 @@
+# FINDING_ONLY: Architectural Mismatch for CRC32 FFI in hash.rs
+
+## Context
+Task requested auditing of C SIMD CRC32 acceleration FFI bindings and buffer alignment in `crates/ramshared-integrity/src/hash.rs`.
+
+## Finding
+The requested C SIMD CRC32 acceleration FFI bindings do not exist in `crates/ramshared-integrity/src/hash.rs`.
+Instead, the file implements a pure-Rust FNV-1a 64-bit hashing algorithm (`block_hash`), which inherently guarantees memory safety without requiring FFI bindings.
+The implementation uses a safe Rust loop relying on safe `[u8]` slices, meaning memory alignment for SIMD and C FFI risks are not applicable.
+Furthermore, the module uses `#![forbid(unsafe_code)]` at the crate level (`lib.rs`), which explicitly prohibits raw pointers and unsafe FFI calls.
+
+Implementing C SIMD CRC32 FFI would introduce unnecessary `unsafe` blocks, breaking the crate-level security invariants and adding unneeded complexity when the current pure-Rust FNV-1a implementation completely fulfills the requirements for detecting memory corruption.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 288,
-    "classified": 277,
+    "total": 289,
+    "classified": 278,
     "excluded": 11,
     "unclassified": 0,
     "ambiguous": 0
@@ -871,6 +871,18 @@
     },
     {
       "path": "docs/jules/findings/26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "historical",
+      "freshnessDays": null
+    },
+    {
+      "path": "docs/jules/findings/27-crc32-ffi-trap.md",
       "disposition": "classified",
       "ruleId": "jules-findings",
       "verification": {


### PR DESCRIPTION
## Resumo
Report architectural mismatch for CRC32 FFI in hash.rs.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs(findings): report architectural mismatch for CRC32 FFI in hash.rs | Generated FINDING_ONLY report | To document why CRC32 FFI bindings are unnecessary and break safe Rust invariants | <details>The target file `hash.rs` implements a pure-Rust FNV-1a hashing function for memory verification, protected by a crate-level `#![forbid(unsafe_code)]`. Attempting to implement C SIMD CRC32 FFI would violate this safety invariant and introduce unnecessary complexity.</details> |
## Issue
N/A
## Responsavel
Jules
## Labels
type:docs, category:ffi-abi
## Validacao
echo 'Compilation skipped'
## Rollback trigger
Revert if the documentation is factually incorrect or breaks CI formatting.

1. RULES 2. MAIN_DIFF 3. FILES 4. INVARIANTS 5. COUNTERFACTUAL 6. RED_TEST 7. COVERAGE 8. REAL_PROOF 9. ROLLBACK 10. PR_BOUNDARY ("do not merge")

---
*PR created automatically by Jules for task [16329918033106643423](https://jules.google.com/task/16329918033106643423) started by @emersonbusson*