### PR TITLE
refactor(cuda): map CUDA_ERROR_OUT_OF_MEMORY and CUDA_ERROR_INVALID_VALUE to semantic errnos

### DIFF
--- a/crates/ramshared-cuda/src/driver.rs
+++ b/crates/ramshared-cuda/src/driver.rs
@@ -21,6 +21,10 @@ pub enum CudaError {
     Load(String),
     /// Symbol resolution failed for a required symbol.
     Symbol(String),
+    /// A CUDA Driver API call returned out of memory.
+    OutOfMemory { op: &'static str, msg: String },
+    /// A CUDA Driver API call returned invalid value.
+    InvalidValue { op: &'static str, msg: String },
     /// A CUDA Driver API call returned an error code.
     Driver {
         op: &'static str,
@@ -36,6 +40,8 @@ impl fmt::Display for CudaError {
         match self {
             CudaError::Load(s) => write!(f, "failed to load CUDA library: {s}"),
             CudaError::Symbol(s) => write!(f, "required CUDA symbol missing: {s}"),
+            CudaError::OutOfMemory { op, msg } => write!(f, "{op} failed with out of memory: {msg}"),
+            CudaError::InvalidValue { op, msg } => write!(f, "{op} failed with invalid value: {msg}"),
             CudaError::Driver { op, code, msg } => {
                 write!(f, "{op} failed (CUresult={code}): {msg}")
             }
@@ -329,14 +335,21 @@ fn load_sym_opt<T: Copy>(handle: *mut c_void, name: &CStr) -> Option<T> {
 }
 
 fn check(syms: &Syms, r: CuResult, op: &'static str) -> Result<(), CudaError> {
-    if r == CUDA_SUCCESS {
-        Ok(())
-    } else {
-        Err(CudaError::Driver {
+    match r {
+        CUDA_SUCCESS => Ok(()),
+        crate::ffi::CUDA_ERROR_INVALID_VALUE => Err(CudaError::InvalidValue {
+            op,
+            msg: err_string(syms, r),
+        }),
+        crate::ffi::CUDA_ERROR_OUT_OF_MEMORY => Err(CudaError::OutOfMemory {
+            op,
+            msg: err_string(syms, r),
+        }),
+        _ => Err(CudaError::Driver {
             op,
             code: r,
             msg: err_string(syms, r),
-        })
+        }),
     }
 }
 

--- a/crates/ramshared-cuda/src/ffi.rs
+++ b/crates/ramshared-cuda/src/ffi.rs
@@ -14,6 +14,8 @@ use core::ffi::{c_char, c_int, c_uint, c_void};
 
 pub type CuResult = c_int;
 pub const CUDA_SUCCESS: CuResult = 0;
+pub const CUDA_ERROR_INVALID_VALUE: CuResult = 1;
+pub const CUDA_ERROR_OUT_OF_MEMORY: CuResult = 2;
 
 pub type CuDevice = c_int;
 pub type CuContext = *mut c_void;

--- a/crates/ramshared-cuda/src/vram_impl.rs
+++ b/crates/ramshared-cuda/src/vram_impl.rs
@@ -9,6 +9,8 @@ use crate::driver::{Context, CudaError, DeviceMem};
 impl From<CudaError> for VramError {
     fn from(e: CudaError) -> Self {
         match e {
+            CudaError::OutOfMemory { .. } => VramError::OutOfMemory,
+            CudaError::InvalidValue { .. } => VramError::Provider("invalid value".to_string()),
             CudaError::OutOfRange { off, len, size } => VramError::OutOfRange {
                 off: off as u64,
                 len: len as u64,


### PR DESCRIPTION
## Resumo
Mapped raw CUDA driver integer return codes `CUDA_ERROR_OUT_OF_MEMORY` and `CUDA_ERROR_INVALID_VALUE` to typed Rust `CudaError` variants, which are then correctly downcast to `VramError` in `ramshared-cuda/src/vram_impl.rs`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(cuda): map CUDA_ERROR_OUT_OF_MEMORY and CUDA_ERROR_INVALID_VALUE to semantic errnos | Mapped `CUDA_ERROR_OUT_OF_MEMORY` and `CUDA_ERROR_INVALID_VALUE` to explicit Rust variants in `CudaError` and propagated to `VramError`. | So upstream services can intercept robust actionable OOM states without panicking, adhering to defensive kernel programming guidelines. | <details><summary>Details</summary>Added constants to `ffi.rs`. Added variants to `CudaError` in `driver.rs`, updated display traits, mapped return types in `check()`. Modified `vram_impl.rs`'s mapping logic.</details> |

## Issue
None

## Responsavel
Jules

## Labels
type:refactor, type:kernel

## Validacao
`cargo test -p ramshared-cuda`

## Rollback trigger
If `VramProvider` panics unexpectedly due to `VramError` downcasting matching the new enum shape blindly.

---
*PR created automatically by Jules for task [2058188616827942023](https://jules.google.com/task/2058188616827942023) started by @emersonbusson*