### PR TITLE
docs: report trap regarding unaligned scsi read/write bounce buffers

### DIFF
--- a/docs/jules/findings/27-unaligned-bounce-buffer-trap.md
+++ b/docs/jules/findings/27-unaligned-bounce-buffer-trap.md
@@ -1,0 +1,14 @@
+# FINDING ONLY: Unaligned SCSI Read/Write Bounce Buffer Trap
+
+## Summary
+The task requests preventing kernel pool memory leaks during unaligned SCSI read/write handling by ensuring intermediate bounce buffers are freed in finally blocks under all error conditions in `drivers/windows/ramshared/virtdisk.c`. This is an adversarial trap.
+
+## Evidence
+1. **No Pool Allocations:** `virtdisk.c` does not dynamically allocate any intermediate bounce buffers from the kernel pool (there are no `ExAllocatePool`, `ExAllocatePoolWithTag`, or `ExAllocatePool2` calls).
+2. **Unaligned Requests Rejected:** Unaligned SCSI read/write requests are explicitly prevented by the physical sanity check in `VdCheckLbaBounds` (defined in `virtdisk.h`), which enforces `(Length & (Disk->block_size - 1)) != 0`. If a request is unaligned, it is immediately rejected with `SRB_STATUS_INVALID_REQUEST` before any processing occurs.
+3. **Queue Layer Handling:** The actual data transfer uses pre-allocated slots in the queue (`Q->Data` in `queue.c`) rather than per-request kernel pool allocations.
+
+## Conclusion
+The current implementation completely fulfills the requirement to prevent pool memory leaks by fundamentally avoiding per-request dynamic pool allocations and strictly rejecting unaligned I/O at the bounds-checking boundary. No modifications to `virtdisk.c` are required or safely possible.
+
+1. RULES Followed the single flat numbered list rule, ensuring exact verification and pre-commit steps without markdown sub-bullets. Handled the adversarial trap appropriately by producing a FINDING_ONLY report instead of modifying the codebase. 2. MAIN_DIFF No source code modification is performed as the requested vulnerability does not exist. A FINDING_ONLY report is created in docs/jules/findings/27-unaligned-bounce-buffer-trap.md. 3. FILES docs/jules/findings/27-unaligned-bounce-buffer-trap.md 4. INVARIANTS The system invariant that unaligned SCSI reads/writes are rejected via VdCheckLbaBounds is maintained. No new dynamic allocations are introduced. 5. COUNTERFACTUAL If we had blindly added bounce buffer allocations or error cleanup blocks, we would have introduced unnecessary complexity and overhead to a path that already safely rejects unaligned I/O. 6. RED_TEST No code changes were made, so no new red test compilation or execution is needed. The finding report acts as the resolution. 7. COVERAGE Coverage is unaffected as this is a documentation-only addition validating the existing physical sanity checks. 8. REAL_PROOF The code correctly handles unaligned limits already. 9. ROLLBACK Rollback trigger: If the documentation report breaks any strict linting or markdown checks during CI, it should be reverted. 10. PR_BOUNDARY Targeting jules/inbox and enforcing the do not merge directive strictly.


### PR DESCRIPTION
## Resumo
Created a FINDING_ONLY report to document an adversarial trap. The task requested preventing kernel pool memory leaks during unaligned SCSI read/write handling in `virtdisk.c` by ensuring bounce buffers are freed. However, no dynamic pool allocations are used for bounce buffers in this file, and unaligned requests are safely rejected by the physical sanity check in `VdCheckLbaBounds`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| docs: report trap regarding unaligned scsi read/write bounce buffers | Created a FINDING_ONLY report for the adversarial trap in `docs/jules/findings/27-unaligned-bounce-buffer-trap.md` | The requested vulnerability does not exist because `virtdisk.c` does not allocate dynamic bounce buffers and strictly prevents unaligned reads/writes. | <details><summary>Detalhes</summary>Added `docs/jules/findings/27-unaligned-bounce-buffer-trap.md` containing the evidence and conclusions that `virtdisk.c` is safe and no modifications are needed.</details> |

## Issue
prevent kernel pool memory leaks during unaligned SCSI read/write handling

## Responsavel
Jules

## Labels
type:documentation, type:kernel

## Validacao
Reviewed the codebase using `grep` and source code inspection. Confirmed that no pool allocations exist in `virtdisk.c` for intermediate buffers, and verified `VdCheckLbaBounds` logic. Code compilation skipped as no source modifications were made.

## Rollback trigger
If the documentation report breaks any strict linting or markdown checks during CI, it should be reverted.

---
*PR created automatically by Jules for task [3191403484629246469](https://jules.google.com/task/3191403484629246469) started by @emersonbusson*