### PR TITLE
feat: map ublk control ioctl return codes to semantic storage errors

### DIFF
--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -216,12 +216,18 @@ fn ctrl_cmd(dev_id: u32, len: u16, addr: u64) -> [u8; 80] {
 }
 
 fn expect_zero(result: i32, context: &str) -> io::Result<()> {
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::other(format!(
+    match result {
+        0 => Ok(()),
+        -12 => Err(io::Error::from_raw_os_error(12)),
+        -14 => Err(io::Error::from_raw_os_error(14)),
+        -16 => Err(io::Error::from_raw_os_error(16)),
+        -19 => Err(io::Error::from_raw_os_error(19)),
+        -22 => Err(io::Error::from_raw_os_error(22)),
+        -34 => Err(io::Error::from_raw_os_error(34)),
+        -95 => Err(io::Error::from_raw_os_error(95)),
+        _ => Err(io::Error::other(format!(
             "{context} returned unexpected result {result}"
-        )))
+        ))),
     }
 }
 


### PR DESCRIPTION
## Resumo

Modify crates/ramshared-uring/src/lib.rs in the expect_zero function to match against the specific negative ioctl error codes returned by the kernel instead of returning a generic other IO error for any non-zero result. This ensures calling functions that depend on matching exact IO error types do not fail or panic.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: map ublk control ioctl return codes to semantic storage errors | Map ublk control ioctl negative return codes to the correct semantic storage `io::Error` equivalents | The system must map kernel error codes explicitly such as EINVAL, ENODEV, ENOMEM, EFAULT, EBUSY, ERANGE, and EOPNOTSUPP | <details>Modifies `expect_zero` in `crates/ramshared-uring/src/lib.rs` to match raw OS errors instead of generic `io::Error::other`.</details> |

## Issue

- Issue ffi-abi: semantic error mapping for ublk control device ioctls (-EINVAL, -ENODEV)

## Responsavel

- Jules

## Labels

type:kernel, type:refactor

## Validacao

`cargo test -p ramshared-uring`
`cargo build`

## Rollback trigger

Revert if the changes cause test suite failures or introduce memory leaks.

---
*PR created automatically by Jules for task [8216256815356302276](https://jules.google.com/task/8216256815356302276) started by @emersonbusson*