### PR TITLE
docs(kernel): document dma transfer bounds trap as FINDING_ONLY

### DIFF
--- a/docs/jules/findings/27-dma-transfer-bounds-trap.md
+++ b/docs/jules/findings/27-dma-transfer-bounds-trap.md
@@ -1,0 +1,20 @@
+# FINDING_ONLY: DMA Transfer Bounds Trap
+
+## Observation
+The task instructs to enforce a strict bounds check on PCIe BAR offset and transfer length (rejecting DMA transfer requests if offset + length exceeds mapped VRAM buffer size) specifically in the target file `drivers/block/ramshared/dma.c`.
+
+## Analysis
+Upon reviewing the target file `drivers/block/ramshared/dma.c`, it only contains initialization (`ramshared_dma_init`) and cleanup (`ramshared_dma_cleanup`) functions for the DMA mappings. It does not handle any DMA transfer requests.
+
+The logic for handling DMA transfer requests (I/O operations) is located in the sibling module `drivers/block/ramshared/queue.c`. In `queue.c`, the requested physical limits and sanity checks are already robustly implemented. For example, in both `ramshared_queue_rq` and `ramshared_bdev_rw_page`, the following checks exist:
+
+```c
+	if (unlikely(pos > rs_dev->dma.size ||
+		     len > rs_dev->dma.size - pos ||
+		     pos + len > rs_dev->capacity_bytes)) {
+```
+
+These checks correctly reject out-of-bounds requests before they can access the VRAM buffer.
+
+## Conclusion
+This is a file-misdirection adversarial trap. Arbitrarily injecting code to handle DMA transfer bounds in `dma.c` is incorrect, as the file does not process transfer requests. The required logic is already correctly implemented in `drivers/block/ramshared/queue.c`. Therefore, no code modifications are necessary.


### PR DESCRIPTION
## Resumo
Documented an adversarial trap involving DMA transfer bounds. The task requested adding strict bounds checks on PCIe BAR offset and transfer length in `drivers/block/ramshared/dma.c`. However, `dma.c` is only responsible for DMA mappings (initialization/cleanup) and does not process I/O transfer requests. The bounds checking logic is already robustly implemented in `drivers/block/ramshared/queue.c`. Thus, this PR creates a `FINDING_ONLY` report as per the immutable contract, avoiding arbitrary and incorrect code injection.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 202c97a | Created FINDING_ONLY report for DMA bounds trap | To document why the requested code modification in dma.c is an adversarial file-misdirection trap. | <details><p>Created `docs/jules/findings/27-dma-transfer-bounds-trap.md` explaining that `dma.c` doesn't handle I/O requests and the bounds checks are already correctly implemented in `queue.c`.</p></details> |

## Issue
KernelC-100/2026-09-04/kernel-harden/096

## Responsavel
Jules

## Labels
type:documentation, type:kernel-harden, status:finding-only

## Validacao
Compilation skipped as no C code modifications were made.

## Rollback trigger
Revert if the findings regarding `dma.c` not processing I/O requests or `queue.c` already containing the required bounds checks are proven incorrect by future architectural reviews.

---
*PR created automatically by Jules for task [11356695435980957402](https://jules.google.com/task/11356695435980957402) started by @emersonbusson*