### PR TITLE
fix: prevent file descriptor leak on benchmark initialization failure

### DIFF
--- a/tools/benchmarks/kernel_vram_bench.c
+++ b/tools/benchmarks/kernel_vram_bench.c
@@ -82,7 +82,8 @@ int main(int argc, char **argv) {
 	lib = load_cuda_driver();
 	if (!lib) {
 		fprintf(stderr, "[-] Error: CUDA driver library (libcuda.so.1) not found.\n");
-		return -ENODEV;
+		ret = -ENODEV;
+		goto out_lib;
 	}
 
 	cuInit_t cuInit = (cuInit_t)dlsym(lib, "cuInit");


### PR DESCRIPTION
## Resumo
Prevents a file descriptor leak in `tools/benchmarks/kernel_vram_bench.c` when the CUDA driver library fails to load during benchmark initialization. The direct return is changed to a proper `goto` based cleanup idiom.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| a93ecd3ed7e5818546cf34d0629266f3b76e3ed4 | Changed direct return to `goto out_lib` upon failure to load CUDA driver | Prevent file descriptors or memory handles from leaking on benchmark initialization failure | <details>Replaced `return -ENODEV;` with `ret = -ENODEV; goto out_lib;` inside `tools/benchmarks/kernel_vram_bench.c`.</details> |

## Issue
prevent file descriptor leak on benchmark initialization failure

## Responsavel
KernelC-100 / jules

## Labels
type:refactor, type:security, type:kernel

## Validacao
Compiled cleanly using `gcc -Wall -Wextra -Werror tools/benchmarks/kernel_vram_bench.c -ldl -o tools/benchmarks/kernel_vram_bench` and manually executed to ensure standard fallback works.

## Rollback trigger
If there's an impact on application initialization times or false positive error reports for valid loads on Linux.

---
*PR created automatically by Jules for task [6068922550918453987](https://jules.google.com/task/6068922550918453987) started by @emersonbusson*