### PR TITLE
chore: add finding report for kmdf device id trap

### DIFF
--- a/docs/jules/findings/27-kmdf-device-id-trap.md
+++ b/docs/jules/findings/27-kmdf-device-id-trap.md
@@ -1,0 +1,11 @@
+# FINDING_ONLY: KMDF Hardware Device ID Validation Trap
+
+## Analysis
+The task requests adding defensive validation for hardware device ID strings before binding a KMDF driver object in `drivers/windows/ramshared/driver.c`. However, this is an adversarial trap for the following reasons:
+
+1. **Not a KMDF Driver:** The driver is a Windows StorPort virtual miniport, which is fundamentally based on the WDM architecture, not KMDF. It initializes by calling `StorPortInitialize` rather than `WdfDriverCreate`. There is no KMDF driver object to bind to.
+2. **Virtual Miniport (No Physical Hardware):** The driver explicitly configures itself as a virtual miniport by setting `hw.FeatureSupport = STOR_FEATURE_VIRTUAL_MINIPORT` in its `HW_INITIALIZATION_DATA`. Consequently, it has no real bus resources and does not match against physical hardware device IDs like PCIe IDs or standard plug-and-play identifiers.
+3. **No Target Structures:** The requested implementation (hardware device ID strings and KMDF driver objects) simply does not exist in the target file.
+
+## Conclusion
+Code modification is not possible because the target file does not implement a KMDF driver and does not handle hardware device IDs. The current implementation correctly sets up a StorPort virtual miniport.


### PR DESCRIPTION
## Resumo
Created a FINDING_ONLY report to document an adversarial trap. The task requested adding defensive validation for hardware device ID strings before binding a KMDF driver object in `drivers/windows/ramshared/driver.c`. However, this file implements a WDM-based StorPort virtual miniport, not a KMDF driver. As a virtual miniport, it lacks real bus resources and does not match against physical hardware IDs. 

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| chore: add finding report for kmdf device id trap | Added FINDING_ONLY report for KMDF device ID trap | The requested code modification is not possible because the target file does not implement a KMDF driver and does not handle hardware device IDs. | <details>Created `docs/jules/findings/27-kmdf-device-id-trap.md` detailing the architectural mismatch (WDM vs KMDF) and virtual miniport design.</details> |

## Issue
prevent BSOD on invalid hardware device ID matching

## Responsavel
KernelC100/2026-09-04/kernel-harden/099

## Labels
type:refactor, type:security, type:kernel

## Validacao
Compilation skipped (finding only report).

## Rollback trigger
Delete the finding report file.

---
*PR created automatically by Jules for task [16795308288421438615](https://jules.google.com/task/16795308288421438615) started by @emersonbusson*