### PR TITLE
fix(ramshared-uring): prevent use-after-free on cancelled io_uring SQE requests

### DIFF
--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -364,19 +364,22 @@ impl Drop for UblkFetchRing {
         let queue_depth = self._buffers.len() as u16;
         let mut sq = self.ring.submission();
         for tag in 0..queue_depth {
-            let cancel = opcode::AsyncCancel::new(tag as u64).build().user_data(u64::MAX);
+            let cancel = opcode::AsyncCancel::new(tag as u64)
+                .build()
+                .user_data(u64::MAX);
             let cancel_entry: squeue::Entry128 = cancel.into();
             if !sq.is_full() {
                 // SAFETY: The kernel will process the cancellation and generate a CQE.
-                unsafe { let _ = sq.push(&cancel_entry); }
+                unsafe {
+                    let _ = sq.push(&cancel_entry);
+                }
             }
         }
         drop(sq);
         let _ = self.ring.submit_and_wait(queue_depth as usize);
-        while let Some(_) = self.ring.completion().next() {}
+        while self.ring.completion().next().is_some() {}
     }
 }
-
 
 /// Packs a `struct ublksrv_io_cmd` (16 B: q_id, tag, result, addr) into the
 /// first bytes of the SQE's 80 B `UringCmd80` buffer; the remaining bytes are zeroed.
@@ -527,19 +530,22 @@ impl Drop for UblkServer {
     fn drop(&mut self) {
         let mut sq = self.ring.submission();
         for tag in 0..self.queue_depth {
-            let cancel = opcode::AsyncCancel::new(tag as u64).build().user_data(u64::MAX);
+            let cancel = opcode::AsyncCancel::new(tag as u64)
+                .build()
+                .user_data(u64::MAX);
             let cancel_entry: squeue::Entry128 = cancel.into();
             if !sq.is_full() {
                 // SAFETY: The kernel will process the cancellation and generate a CQE.
-                unsafe { let _ = sq.push(&cancel_entry); }
+                unsafe {
+                    let _ = sq.push(&cancel_entry);
+                }
             }
         }
         drop(sq);
         let _ = self.ring.submit_and_wait(self.queue_depth as usize);
-        while let Some(_) = self.ring.completion().next() {}
+        while self.ring.completion().next().is_some() {}
     }
 }
-
 
 #[cfg(test)]
 #[allow(clippy::expect_used)]

--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -359,6 +359,25 @@ impl UblkFetchRing {
     }
 }
 
+impl Drop for UblkFetchRing {
+    fn drop(&mut self) {
+        let queue_depth = self._buffers.len() as u16;
+        let mut sq = self.ring.submission();
+        for tag in 0..queue_depth {
+            let cancel = opcode::AsyncCancel::new(tag as u64).build().user_data(u64::MAX);
+            let cancel_entry: squeue::Entry128 = cancel.into();
+            if !sq.is_full() {
+                // SAFETY: The kernel will process the cancellation and generate a CQE.
+                unsafe { let _ = sq.push(&cancel_entry); }
+            }
+        }
+        drop(sq);
+        let _ = self.ring.submit_and_wait(queue_depth as usize);
+        while let Some(_) = self.ring.completion().next() {}
+    }
+}
+
+
 /// Packs a `struct ublksrv_io_cmd` (16 B: q_id, tag, result, addr) into the
 /// first bytes of the SQE's 80 B `UringCmd80` buffer; the remaining bytes are zeroed.
 fn io_cmd80(q_id: u16, tag: u16, result: i32, addr: u64) -> [u8; 80] {
@@ -503,6 +522,24 @@ impl UblkServer {
         Ok(())
     }
 }
+
+impl Drop for UblkServer {
+    fn drop(&mut self) {
+        let mut sq = self.ring.submission();
+        for tag in 0..self.queue_depth {
+            let cancel = opcode::AsyncCancel::new(tag as u64).build().user_data(u64::MAX);
+            let cancel_entry: squeue::Entry128 = cancel.into();
+            if !sq.is_full() {
+                // SAFETY: The kernel will process the cancellation and generate a CQE.
+                unsafe { let _ = sq.push(&cancel_entry); }
+            }
+        }
+        drop(sq);
+        let _ = self.ring.submit_and_wait(self.queue_depth as usize);
+        while let Some(_) = self.ring.completion().next() {}
+    }
+}
+
 
 #[cfg(test)]
 #[allow(clippy::expect_used)]


### PR DESCRIPTION
## Resumo
Implemented `Drop` for `UblkFetchRing` and `UblkServer` in `crates/ramshared-uring/src/lib.rs` to cancel pending `io_uring` requests. This prevents use-after-free vulnerabilities where the kernel accesses freed userspace buffers when dropping the io_uring.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| fix-use-after-free | Implemented `Drop` for `UblkFetchRing` and `UblkServer`. | Prevent UAF by cancelling pending IO and waiting for CQEs before freeing buffers. | <details>Added `impl Drop` for both structs. `drop` iterates through all tags up to `queue_depth`, builds an `AsyncCancel` operation, pushes it into the submission queue, calls `submit_and_wait`, and then drains the completion queue.</details> |

## Issue
N/A

## Responsavel
KernelC-100

## Labels
type:kernel, type:security

## Validacao
`cd crates/ramshared-uring && cargo test`
`cd crates/ramshared-wsl2d && cargo test`

## Rollback trigger
Any tests timing out or panicking related to io_uring completion queue processing during server/ring shutdown.

---
*PR created automatically by Jules for task [3867698071695594602](https://jules.google.com/task/3867698071695594602) started by @emersonbusson*