### PR TITLE
🧪 test(winsvc): add unit tests for driver_read_slot in driver_link

### DIFF
--- a/crates/ramshared-winsvc/src/driver_link.rs
+++ b/crates/ramshared-winsvc/src/driver_link.rs
@@ -741,4 +741,20 @@ mod tests {
         assert_eq!(*writes.lock().unwrap(), 0);
         assert_eq!(link.backend_writes, 0);
     }
+
+    #[test]
+    fn driver_read_slot_valid_and_bounds_checks() {
+        let mut queue = InMemoryQueue::new(4, 4096, 4096).unwrap();
+        let payload = vec![0x42u8; 1024];
+
+        queue.driver_write_slot(0, &payload).unwrap();
+        let read_data = queue.driver_read_slot(0, 1024).unwrap();
+        assert_eq!(read_data, payload.as_slice());
+
+        let err_slot = queue.driver_read_slot(4, 512).unwrap_err();
+        assert!(matches!(err_slot, DriverLinkError::Invalid(_)));
+
+        let err_len = queue.driver_read_slot(0, 8192).unwrap_err();
+        assert!(matches!(err_len, DriverLinkError::Invalid(_)));
+    }
 }


### PR DESCRIPTION
## Resumo
Added unit test `driver_read_slot_valid_and_bounds_checks` to `crates/ramshared-winsvc/src/driver_link.rs` covering valid reads and bounds/error checks for `driver_read_slot`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `test(winsvc): add unit tests for driver_read_slot in driver_link` | Added unit test for driver_read_slot in driver_link.rs | Increase test coverage for driver_read_slot in ramshared-winsvc | <details><summary>Detalhes</summary>Tests happy path read after write, invalid slot index, and oversize length error checks.</details> |

## Issue
N/A

## Responsavel
Jules

## Labels
testing, rust, winsvc

## Validacao
Executed `cargo test -p ramshared-winsvc` - all 130 tests passed including `driver_read_slot_valid_and_bounds_checks`.

## Rollback trigger
None required (test-only change).

---
*PR created automatically by Jules for task [4403287659788825840](https://jules.google.com/task/4403287659788825840) started by @emersonbusson*