### PR TITLE
🧪 test: add direct unit test for driver_complete in InMemoryQueue

### DIFF
--- a/crates/ramshared-winsvc/src/driver_link.rs
+++ b/crates/ramshared-winsvc/src/driver_link.rs
@@ -741,4 +741,52 @@ mod tests {
         assert_eq!(*writes.lock().unwrap(), 0);
         assert_eq!(link.backend_writes, 0);
     }
+
+    #[test]
+    fn driver_complete_direct_and_wrapping() {
+        let mut q = InMemoryQueue::new(4, 4096, 4096).unwrap();
+
+        // Empty CQ returns Ok(None)
+        assert_eq!(q.driver_complete().unwrap(), None);
+
+        // Push CQEs into CQ
+        let cqe1 = Cqe {
+            tag: 101,
+            status: ST_OK,
+            reserved: 0,
+        };
+        let cqe2 = Cqe {
+            tag: 102,
+            status: ST_EINVAL,
+            reserved: 0,
+        };
+        q.push_cqe(cqe1).unwrap();
+        q.push_cqe(cqe2).unwrap();
+
+        // Pop first CQE
+        let popped1 = q.driver_complete().unwrap().unwrap();
+        assert_eq!(popped1.tag, 101);
+        assert_eq!(popped1.status, ST_OK);
+
+        // Pop second CQE
+        let popped2 = q.driver_complete().unwrap().unwrap();
+        assert_eq!(popped2.tag, 102);
+        assert_eq!(popped2.status, ST_EINVAL);
+
+        // Queue is empty again
+        assert_eq!(q.driver_complete().unwrap(), None);
+
+        // Wrapping behavior over queue_depth
+        for i in 0..10 {
+            let cqe = Cqe {
+                tag: i,
+                status: ST_OK,
+                reserved: 0,
+            };
+            q.push_cqe(cqe).unwrap();
+            let popped = q.driver_complete().unwrap().unwrap();
+            assert_eq!(popped.tag, i);
+        }
+        assert_eq!(q.driver_complete().unwrap(), None);
+    }
 }


### PR DESCRIPTION
🧪 **What:** Add direct unit test coverage for the public function `InMemoryQueue::driver_complete` in `crates/ramshared-winsvc/src/driver_link.rs`.
📊 **Coverage:** Tests empty completion queue returning `Ok(None)`, popping pushed completion queue entries (CQEs) in FIFO order with tag and status verification, and ring buffer index wrapping across queue depth limits.
✨ **Result:** Ensures reliable CQ popping and ring index wrapping logic for service-side SPSC ring completion processing.

---
*PR created automatically by Jules for task [4936478436761477037](https://jules.google.com/task/4936478436761477037) started by @emersonbusson*