### PR TITLE
🧹 refactor(winsvc): handle Mutex lock errors in driver link unit tests

### DIFF
--- a/crates/ramshared-winsvc/src/driver_link.rs
+++ b/crates/ramshared-winsvc/src/driver_link.rs
@@ -554,8 +554,8 @@ mod tests {
             Ok(())
         }
         fn write_at(&mut self, off: u64, data: &[u8]) -> Result<(), IoError> {
-            *self.writes.lock().unwrap() += 1;
-            *self.last_write.lock().unwrap() = data.to_vec();
+            *self.writes.lock().map_err(|e| IoError(e.to_string()))? += 1;
+            *self.last_write.lock().map_err(|e| IoError(e.to_string()))? = data.to_vec();
             let o = off as usize;
             self.data[o..o + data.len()].copy_from_slice(data);
             Ok(())


### PR DESCRIPTION
🧹 [code health improvement description]

🎯 **What:** Replaced unsafe `.unwrap()` calls on Mutex lock locks in `RamBe::write_at` (`crates/ramshared-winsvc/src/driver_link.rs:557`) with error propagation (`.map_err(|e| IoError(e.to_string()))?`).

💡 **Why:** Propagating lock failures gracefully prevents potential thread panics on lock poisoning and improves readability and code health consistency across driver link unit tests.

✅ **Verification:** Verified with `cargo test -p ramshared-winsvc` (all 128 unit tests pass) and passed code review.

✨ **Result:** Improved maintainability, error safety, and reliability in `driver_link.rs`.

---
*PR created automatically by Jules for task [10225765746847994123](https://jules.google.com/task/10225765746847994123) started by @emersonbusson*