### PR TITLE
🧪 test(winsvc): add unit test for driver_read_slot

### DIFF
--- a/crates/ramshared-winsvc/src/driver_link.rs
+++ b/crates/ramshared-winsvc/src/driver_link.rs
@@ -741,4 +741,18 @@ mod tests {
         assert_eq!(*writes.lock().unwrap(), 0);
         assert_eq!(link.backend_writes, 0);
     }
+
+    #[test]
+    fn test_driver_read_slot_direct_and_errors() {
+        let mut queue = InMemoryQueue::new(4, 4096, 4096).unwrap();
+        let payload = vec![0x42u8; 1024];
+
+        queue.driver_write_slot(0, &payload).unwrap();
+
+        let read_data = queue.driver_read_slot(0, 1024).unwrap();
+        assert_eq!(read_data, payload.as_slice());
+
+        assert!(queue.driver_read_slot(4, 1024).is_err());
+        assert!(queue.driver_read_slot(0, 4097).is_err());
+    }
 }


### PR DESCRIPTION
## Resumo
Add unit tests in `crates/ramshared-winsvc/src/driver_link.rs` to cover `driver_read_slot`. The new test `test_driver_read_slot_direct_and_errors` checks happy path reading as well as out-of-bounds slot index and slot length error conditions.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| b620311 | Added unit test for `driver_read_slot` | Ensure test coverage for previously untested public function `driver_read_slot` | <details>Added `test_driver_read_slot_direct_and_errors` to test reading bounce slots and error conditions.</details> |

## Issue
N/A

## Responsavel
Jules

## Labels
testing, winsvc

## Validacao
- Ran `cargo test -p ramshared-winsvc` (129 passed, 1 ignored)

## Rollback trigger
None

---
*PR created automatically by Jules for task [8194205728896343967](https://jules.google.com/task/8194205728896343967) started by @emersonbusson*