### PR TITLE
🧹 [code health improvement] Replace unwrap() with ? operator in broker_tenant test helper

### DIFF
--- a/crates/ramshared-winsvc/src/broker_tenant.rs
+++ b/crates/ramshared-winsvc/src/broker_tenant.rs
@@ -261,13 +261,16 @@ mod tests {
 
     use ramshared_broker::protocol::{Msg, write_msg};
 
-    fn with_reply(request: Msg, reply: Msg) -> (Cursor<Vec<u8>>, Vec<u8>) {
+    fn with_reply(
+        request: Msg,
+        reply: Msg,
+    ) -> Result<(Cursor<Vec<u8>>, Vec<u8>), ramshared_broker::protocol::ProtocolError> {
         let mut out = Vec::new();
-        write_msg(&mut out, &reply).unwrap();
+        write_msg(&mut out, &reply)?;
         let mut in_buf = Vec::new();
-        write_msg(&mut in_buf, &request).unwrap(); // not used; stream is reply-only for read
+        write_msg(&mut in_buf, &request)?; // not used; stream is reply-only for read
         let _ = in_buf;
-        (Cursor::new(out), Vec::new())
+        Ok((Cursor::new(out), Vec::new()))
     }
 
     #[test]
@@ -395,8 +398,9 @@ mod tests {
 
     // silence unused helper
     #[test]
-    fn dual_with_reply_helper_compiles() {
-        let _ = with_reply(Msg::Ack, Msg::Registered { tenant_id: 1 });
+    fn dual_with_reply_helper_compiles() -> Result<(), ramshared_broker::protocol::ProtocolError> {
+        let _ = with_reply(Msg::Ack, Msg::Registered { tenant_id: 1 })?;
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
🧹 [code health improvement] Replace unwrap() with ? operator in broker_tenant test helper

🎯 **What:** Replace `unwrap()` calls on `write_msg` with the `?` operator in the `with_reply` helper function and update caller unit test `dual_with_reply_helper_compiles` in `crates/ramshared-winsvc/src/broker_tenant.rs`.

💡 **Why:** Eliminates panic risks during test setup, improving error propagation and maintainability.

✅ **Verification:** Ran `cargo test -p ramshared-winsvc` and verified all unit tests pass.

✨ **Result:** Clean error propagation without `unwrap()` panics in `broker_tenant` tests.

---
*PR created automatically by Jules for task [1217234607075428775](https://jules.google.com/task/1217234607075428775) started by @emersonbusson*