### PR TITLE
🧪 test(winsvc): add test coverage for connect_product_pipe and connect_status_pipe

### DIFF
--- a/crates/ramshared-winsvc/src/ipc.rs
+++ b/crates/ramshared-winsvc/src/ipc.rs
@@ -234,4 +234,18 @@ mod tests {
         let result = retry_until(Instant::now(), || Err(2));
         assert_eq!(result, Err(BrokerConnectError::Deadline));
     }
+
+    #[cfg(windows)]
+    #[test]
+    fn connect_product_and_status_pipe_deadline() {
+        let deadline = Instant::now();
+        assert_eq!(
+            NamedPipeBrokerStream::connect_product_pipe(deadline),
+            Err(BrokerConnectError::Deadline)
+        );
+        assert_eq!(
+            NamedPipeBrokerStream::connect_status_pipe(deadline),
+            Err(BrokerConnectError::Deadline)
+        );
+    }
 }


### PR DESCRIPTION
## Resumo
Added unit test coverage for `NamedPipeBrokerStream::connect_product_pipe` and `connect_status_pipe` in `crates/ramshared-winsvc/src/ipc.rs`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| test(winsvc): add test for connect_product_pipe | Added `connect_product_and_status_pipe_deadline` unit test in `crates/ramshared-winsvc/src/ipc.rs` | Increase test coverage for previously untested public methods `connect_product_pipe` and `connect_status_pipe` | <details><summary>Detalhes</summary>Verified that calling `connect_product_pipe` or `connect_status_pipe` with an immediate deadline returns `Err(BrokerConnectError::Deadline)` on Windows target.</details> |

## Issue
N/A

## Responsavel
@jules

## Labels
testing, winsvc

## Validacao
Ran `cargo test -p ramshared-winsvc` with 128 tests passing.

## Rollback trigger
N/A

---
*PR created automatically by Jules for task [4805108784868848178](https://jules.google.com/task/4805108784868848178) started by @emersonbusson*