### PR TITLE
docs(wsl2d): document dxgkrnl collision kernel BUG incident safeguards

### DIFF
--- a/docs/jules/findings/27-wsl2d-dxgkrnl-collision-kernel-bug-incident.md
+++ b/docs/jules/findings/27-wsl2d-dxgkrnl-collision-kernel-bug-incident.md
@@ -1,0 +1,18 @@
+# Finding 27: WSL2 dxgkrnl Collision Kernel BUG Analysis
+
+- **Crate:** `ramshared-wsl2d`
+- **Module:** `main.rs`
+- **Classification:** `FINDING_ONLY`
+
+## Observation
+
+The item refers to an inline context note regarding incident 2026-07-03, where a host `kernel BUG` occurred due to memory locking collisions with `dxgkrnl` during `MCL_FUTURE` / asynchronous CUDA worker initialization.
+
+Analysis of `crates/ramshared-wsl2d/src/main.rs` confirms:
+1. `run_ublk_with_runtime` enforces `runtime.lock_memory(force, false)?` (`MCL_CURRENT` only).
+2. The `arm_future_lock` logic was previously removed to prevent racing asynchronous CUDA initialization.
+3. The codebase already implements the necessary safeguards, and all unit tests in `ramshared-wsl2d` pass cleanly.
+
+## Verdict
+
+Accepted as documented historical incident note and architectural verification. No code modification required.

--- a/docs/jules/findings/README.md
+++ b/docs/jules/findings/README.md
@@ -40,3 +40,4 @@ These findings serve as an immutable record of architectural invariants in RamSh
 | 24 | [`24-pr489-broker-cross-host-civm-historical-note.md`](24-pr489-broker-cross-host-civm-historical-note.md) | `ramshared-wsl2d` | Cross-host CIVM historical race note verified. |
 | 25 | [`25-pr493-cli-read-frozen-target-error-handling.md`](25-pr493-cli-read-frozen-target-error-handling.md) | `ramshared-cli` | `read_frozen_target` uses structured Result propagation. |
 | 26 | [`26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md`](26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md) | `ramshared-wsl2d` | Memory locking invariants protect against dxgkrnl collisions. |
+| 27 | [`27-wsl2d-dxgkrnl-collision-kernel-bug-incident.md`](27-wsl2d-dxgkrnl-collision-kernel-bug-incident.md) | `ramshared-wsl2d` | Verified historical dxgkrnl collision incident safeguards in wsl2d. |


### PR DESCRIPTION
Documented analysis of historical dxgkrnl collision incident and verified that wsl2d memory locking safeguards (MCL_CURRENT enforcement) are active and unit tests pass.

---
*PR created automatically by Jules for task [7360773203288635464](https://jules.google.com/task/7360773203288635464) started by @emersonbusson*