### PR TITLE
🧹 refactor(winsvc): return Err instead of panic in RawGates volume methods

### DIFF
--- a/crates/ramshared-winsvc/src/service.rs
+++ b/crates/ramshared-winsvc/src/service.rs
@@ -514,15 +514,15 @@ mod tests {
         }
 
         fn lock_volume(&mut self, _: char) -> Result<(), String> {
-            panic!("an exact RAW disk has no volume to lock")
+            Err("an exact RAW disk has no volume to lock".into())
         }
 
         fn unlock_volume(&mut self) -> Result<(), String> {
-            panic!("an exact RAW disk has no volume to unlock")
+            Err("an exact RAW disk has no volume to unlock".into())
         }
 
         fn flush_and_dismount(&mut self) -> Result<(), String> {
-            panic!("an exact RAW disk has no filesystem to dismount")
+            Err("an exact RAW disk has no filesystem to dismount".into())
         }
 
         fn volume_locked(&self) -> bool {


### PR DESCRIPTION
🧹 Code Health Improvement Task:

- Target: `crates/ramshared-winsvc/src/service.rs`
- Issue: Replaced unsafe `panic!()` calls in `RawGates` implementations of `lock_volume`, `unlock_volume`, and `flush_and_dismount` with explicit `Result::Err` returns.
- Verification: Ran `cargo test -p ramshared-winsvc` (128 passed, 0 failed).

---
*PR created automatically by Jules for task [13557640784799075476](https://jules.google.com/task/13557640784799075476) started by @emersonbusson*