### PR TITLE
🧹 refactor(winsvc): return Err instead of panic in RawGates

### DIFF
--- a/crates/ramshared-winsvc/src/service.rs
+++ b/crates/ramshared-winsvc/src/service.rs
@@ -514,15 +514,15 @@ mod tests {
         }
 
         fn lock_volume(&mut self, _: char) -> Result<(), String> {
-            panic!("an exact RAW disk has no volume to lock")
+            Err("an exact RAW disk has no volume to lock".into())
         }
 
         fn unlock_volume(&mut self) -> Result<(), String> {
-            panic!("an exact RAW disk has no volume to unlock")
+            Err("an exact RAW disk has no volume to unlock".into())
         }
 
         fn flush_and_dismount(&mut self) -> Result<(), String> {
-            panic!("an exact RAW disk has no filesystem to dismount")
+            Err("an exact RAW disk has no filesystem to dismount".into())
         }
 
         fn volume_locked(&self) -> bool {


### PR DESCRIPTION
## Resumo
Replaced `panic!()` invocations with proper `Err("...".into())` error propagation in the `RawGates` test mock structure within `crates/ramshared-winsvc/src/service.rs`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 9d396b7 | Replaced panic!() calls in RawGates mock | Avoid panic in tests and return Result Err instead | <details><summary>Detalhes</summary>Converted lock_volume, unlock_volume, and flush_and_dismount panics in RawGates to return Err.</details> |

## Issue
Code health improvement: eliminate unsafe panic!() calls in service.rs.

## Responsavel
Jules

## Labels
code-health, rust, refactoring

## Validacao
- Ran `cargo test -p ramshared-winsvc` and verified all 129 unit tests pass cleanly.

## Rollback trigger
Revert commit if any downstream tests rely on panicking behavior in RawGates.

---
*PR created automatically by Jules for task [9881909792948518320](https://jules.google.com/task/9881909792948518320) started by @emersonbusson*