### PR TITLE
🧹 [code health] replace unsafe panic calls in IdentityFailGates mock with Err

### DIFF
--- a/crates/ramshared-winsvc/src/service.rs
+++ b/crates/ramshared-winsvc/src/service.rs
@@ -475,11 +475,11 @@ mod tests {
         }
 
         fn active_pagefiles(&self) -> Result<Vec<String>, String> {
-            panic!("Gate A must not run after identity refusal")
+            Err("Gate A must not run after identity refusal".into())
         }
 
         fn lock_volume(&mut self, _: char) -> Result<(), String> {
-            panic!("volume lock must not run after identity refusal")
+            Err("volume lock must not run after identity refusal".into())
         }
 
         fn unlock_volume(&mut self) -> Result<(), String> {
@@ -487,7 +487,7 @@ mod tests {
         }
 
         fn flush_and_dismount(&mut self) -> Result<(), String> {
-            panic!("dismount must not run after identity refusal")
+            Err("dismount must not run after identity refusal".into())
         }
 
         fn volume_locked(&self) -> bool {


### PR DESCRIPTION
## Resumo
Replaced unsafe panic!() calls in IdentityFailGates test mock methods in crates/ramshared-winsvc/src/service.rs with standard Err(...) return values matching the PagefileGates trait signatures.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 7f25f16 | Replaced panic! calls in IdentityFailGates with Err | Improve code health and prevent unhandled panics in test mocks | <details><summary>Detalhes</summary>Updated active_pagefiles, lock_volume, and flush_and_dismount methods on IdentityFailGates in service.rs to return Err(...) instead of panicking.</details> |

## Issue
Code Health Improvement: Unsafe panic!() call in crates/ramshared-winsvc/src/service.rs

## Responsavel
Jules

## Labels
code-health, rust, ramshared-winsvc

## Validacao
Ran cargo test -p ramshared-winsvc with 128 tests passing cleanly.

## Rollback trigger
Revert commit if any downstream trait consumer relies on panic behavior.

---
*PR created automatically by Jules for task [1116041962510490142](https://jules.google.com/task/1116041962510490142) started by @emersonbusson*