### PR TITLE
🧹 Refactor RawGates to return Err instead of panic

### DIFF
--- a/crates/ramshared-winsvc/src/service.rs
+++ b/crates/ramshared-winsvc/src/service.rs
@@ -514,15 +514,15 @@ mod tests {
         }
 
         fn lock_volume(&mut self, _: char) -> Result<(), String> {
-            panic!("an exact RAW disk has no volume to lock")
+            Err("an exact RAW disk has no volume to lock".into())
         }
 
         fn unlock_volume(&mut self) -> Result<(), String> {
-            panic!("an exact RAW disk has no volume to unlock")
+            Err("an exact RAW disk has no volume to unlock".into())
         }
 
         fn flush_and_dismount(&mut self) -> Result<(), String> {
-            panic!("an exact RAW disk has no filesystem to dismount")
+            Err("an exact RAW disk has no filesystem to dismount".into())
         }
 
         fn volume_locked(&self) -> bool {


### PR DESCRIPTION
Refactor RawGates trait implementation in service.rs to return Err instead of calling panic!() when attempting volume lock/unlock/dismount on RAW disks.

---
*PR created automatically by Jules for task [6497750665780428043](https://jules.google.com/task/6497750665780428043) started by @emersonbusson*