### PR TITLE
🧹 refactor(core): replace unwrap in test helper with expect

### DIFF
--- a/crates/ramshared-block/src/isolated_origin.rs
+++ b/crates/ramshared-block/src/isolated_origin.rs
@@ -707,14 +707,19 @@ mod tests {
     fn cache_read_with_reply(reply: Result<Option<Vec<u8>>, String>) -> (CacheRead, CacheState) {
         let (mut cache, worker) = isolated_cache_channel(1, Duration::from_millis(100));
         let worker = std::thread::spawn(move || {
-            let IsolatedCacheRequest::Read { reply: sender, .. } = worker.requests.recv().unwrap()
+            let IsolatedCacheRequest::Read { reply: sender, .. } = worker
+                .requests
+                .recv()
+                .expect("expected cache read request from worker channel")
             else {
-                panic!("expected cache read");
+                panic!("expected cache read request");
             };
-            sender.send(reply).unwrap();
+            sender
+                .send(reply)
+                .expect("failed to send test reply over response channel");
         });
         let result = cache.read(0, &mut [0; 4]);
-        worker.join().unwrap();
+        worker.join().expect("cache read test thread panicked");
         (result, cache.state())
     }
 


### PR DESCRIPTION
# 🧹 Code Health Improvement: Replace unwrap() calls in test helper

### 🎯 What
Replaced `.unwrap()` calls in `cache_read_with_reply` in `crates/ramshared-block/src/isolated_origin.rs` with `.expect(...)` calls containing descriptive failure messages.

### 💡 Why
In unit tests, using `.expect(...)` with descriptive messages ensures clear diagnostic output if channel communication or thread joining fails, making tests more maintainable and easier to debug without hiding errors.

### ✅ Verification
- Verified code changes using `git diff`.
- Executed `cargo test -p ramshared-block` and confirmed all 82 tests pass.

### ✨ Result
Cleaner, more descriptive error diagnostics on channel or thread failures during unit testing.

---
*PR created automatically by Jules for task [7965836810485386997](https://jules.google.com/task/7965836810485386997) started by @emersonbusson*