### PR TITLE
🧹 refactor(block): replace unwrap with expect in origin cache test

### DIFF
--- a/crates/ramshared-block/src/origin_cache.rs
+++ b/crates/ramshared-block/src/origin_cache.rs
@@ -919,11 +919,15 @@ mod tests {
         events.borrow_mut().clear();
 
         let payload = *b"cache-origin-round-trip-proof-32";
-        backend.write_at(0, &payload).unwrap();
+        backend
+            .write_at(0, &payload)
+            .expect("write to origin cache backend should succeed");
         assert_eq!(backend.release_cache(), 8);
 
         let mut read_back = [0; 32];
-        backend.read_at(0, &mut read_back).unwrap();
+        backend
+            .read_at(0, &mut read_back)
+            .expect("read from origin cache backend should succeed");
         assert_eq!(read_back, payload);
         assert_eq!(backend.telemetry().fallback_reads, 1);
         assert_eq!(


### PR DESCRIPTION
## Resumo
Substituição dos chamados diretos `.unwrap()` por `.expect(...)` com mensagens de erro explicativas nos testes de cache de origem em `crates/ramshared-block/src/origin_cache.rs`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| refactor(block): replace unwrap with expect in origin cache test | Substituiu chamadas unwrap() por expect() em testes unitários | Para fornecer mensagens de erro descritivas e melhorar a manutenibilidade dos testes | <details><summary>Ver detalhes</summary>Atualizou `assert_write_release_vram_read_origin_hash_matches` em `origin_cache.rs` para utilizar mensagens explicitas no `expect` ao gravar e ler do backend.</details> |

## Issue
Code Health Improvement Task: Unsafe unwrap() call in `crates/ramshared-block/src/origin_cache.rs:922`

## Responsavel
Jules

## Labels
code-health, refactoring, rust

## Validacao
- `cargo test -p ramshared-block` executado com sucesso (82 testes aprovados).

## Rollback trigger
Reverter este commit se houver alguma regressão na execução das suítes de teste de ramshared-block.

---
*PR created automatically by Jules for task [17527815207063265731](https://jules.google.com/task/17527815207063265731) started by @emersonbusson*