### PR TITLE
🧹 Remove unsafe unwrap() in broker_tenant test helper

### DIFF
--- a/crates/ramshared-winsvc/src/broker_tenant.rs
+++ b/crates/ramshared-winsvc/src/broker_tenant.rs
@@ -259,15 +259,18 @@ mod tests {
     use std::io::Cursor;
     use std::time::Duration;
 
-    use ramshared_broker::protocol::{Msg, write_msg};
+    use ramshared_broker::protocol::{Msg, ProtocolError, write_msg};
 
-    fn with_reply(request: Msg, reply: Msg) -> (Cursor<Vec<u8>>, Vec<u8>) {
+    fn with_reply(
+        request: Msg,
+        reply: Msg,
+    ) -> Result<(Cursor<Vec<u8>>, Vec<u8>), ProtocolError> {
         let mut out = Vec::new();
-        write_msg(&mut out, &reply).unwrap();
+        write_msg(&mut out, &reply)?;
         let mut in_buf = Vec::new();
-        write_msg(&mut in_buf, &request).unwrap(); // not used; stream is reply-only for read
+        write_msg(&mut in_buf, &request)?; // not used; stream is reply-only for read
         let _ = in_buf;
-        (Cursor::new(out), Vec::new())
+        Ok((Cursor::new(out), Vec::new()))
     }
 
     #[test]
@@ -396,7 +399,7 @@ mod tests {
     // silence unused helper
     #[test]
     fn dual_with_reply_helper_compiles() {
-        let _ = with_reply(Msg::Ack, Msg::Registered { tenant_id: 1 });
+        assert!(with_reply(Msg::Ack, Msg::Registered { tenant_id: 1 }).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
🧹 **What:** Replaced unsafe `.unwrap()` calls in `with_reply` with `?` error propagation returning `Result<(Cursor<Vec<u8>>, Vec<u8>), ProtocolError>`.
💡 **Why:** Avoids potential panic in unit tests/test helper functions and improves code health and reliability.
✅ **Verification:** Verified via `cargo test -p ramshared-winsvc` where all 128 tests pass.
✨ **Result:** Improved test code maintainability and error handling.

---
*PR created automatically by Jules for task [4297275588836708489](https://jules.google.com/task/4297275588836708489) started by @emersonbusson*