### PR TITLE
docs: add FINDING_ONLY report for bug C1 transient eviction comment

### DIFF
--- a/docs/jules/findings/27-transient-eviction-bug-c1.md
+++ b/docs/jules/findings/27-transient-eviction-bug-c1.md
@@ -1,0 +1,25 @@
+# Finding 27: Transient Eviction Signal Verification (Bug C1)
+
+- **Source PR:** Jules PR
+- **Crate:** `ramshared-wsl2d`
+- **Module:** `broker_srv.rs`
+- **Classification:** `FINDING_ONLY`
+
+## Observation
+
+Analysis of `crates/ramshared-wsl2d/src/broker_srv.rs` at line 803 confirms that the comment referring to 'bug C1' describes a historically resolved condition where hysteresis logic in `reconcile()` could swallow transient eviction signals (1-2 DEMOTEs).
+
+The current implementation in `broker_srv.rs` correctly bypasses hysteresis for `ReconcileFlag::Eviction` events:
+```rust
+let confirmed = match candidate {
+    ReconcileFlag::Eviction => ReconcileFlag::Eviction, // evento: sem histerese
+    ReconcileFlag::None => ReconcileFlag::None,
+    sustained if self.recon_count >= self.recon_streak => sustained,
+    _ => ReconcileFlag::None,
+};
+```
+This ensures transient eviction signals are confirmed immediately without waiting for hysteresis consecutive ticks, preventing bug C1. No code fix is needed as the condition is resolved and verified by existing unit tests in `broker_srv.rs`.
+
+## Verdict
+
+Accepted as documented architectural verification (`FINDING_ONLY`).

--- a/docs/jules/findings/README.md
+++ b/docs/jules/findings/README.md
@@ -40,3 +40,4 @@ These findings serve as an immutable record of architectural invariants in RamSh
 | 24 | [`24-pr489-broker-cross-host-civm-historical-note.md`](24-pr489-broker-cross-host-civm-historical-note.md) | `ramshared-wsl2d` | Cross-host CIVM historical race note verified. |
 | 25 | [`25-pr493-cli-read-frozen-target-error-handling.md`](25-pr493-cli-read-frozen-target-error-handling.md) | `ramshared-cli` | `read_frozen_target` uses structured Result propagation. |
 | 26 | [`26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md`](26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md) | `ramshared-wsl2d` | Memory locking invariants protect against dxgkrnl collisions. |
+| 27 | [`27-transient-eviction-bug-c1.md`](27-transient-eviction-bug-c1.md) | `ramshared-wsl2d` | Transient eviction signals immediately confirmed without hysteresis (bug C1). |


### PR DESCRIPTION
Added a FINDING_ONLY architectural report documenting that the comment referring to 'bug C1' in crates/ramshared-wsl2d/src/broker_srv.rs describes a historically resolved condition where transient eviction signals (1-2 DEMOTEs) are immediately confirmed without hysteresis.

---
*PR created automatically by Jules for task [8011785535218753145](https://jules.google.com/task/8011785535218753145) started by @emersonbusson*