### PR TITLE
🧪 [testing improvement] Add test for WindowsHostState::flush_and_dismount

### DIFF
--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1187,4 +1187,17 @@ mod tests {
             .unwrap_err();
         assert!(error.to_string().contains("malformed Get-Disk output"));
     }
+
+    #[test]
+    fn flush_and_dismount_invalid_handle_fails() {
+        let vol = LockedVolume {
+            letter: 'D',
+            disk_number: 1,
+            handle: INVALID_HANDLE_VALUE,
+        };
+        let result = WindowsHostState::flush_and_dismount(&vol);
+        let err = result.unwrap_err();
+        assert!(matches!(err, HostError::Volume(_)));
+        assert!(err.to_string().contains("FlushFileBuffers"));
+    }
 }


### PR DESCRIPTION
## Resumo
Add unit test coverage for `WindowsHostState::flush_and_dismount` in `crates/ramshared-winsvc/src/windows_host.rs`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 1 | Add unit test `flush_and_dismount_invalid_handle_fails` | Add test coverage for `WindowsHostState::flush_and_dismount` | <details>Tests that calling `flush_and_dismount` on a `LockedVolume` with `INVALID_HANDLE_VALUE` fails as expected with a `HostError::Volume` error.</details> |

## Issue
Untested public function `flush_and_dismount` in `windows_host.rs`.

## Responsavel
Jules

## Labels
testing, windows, winsvc

## Validacao
- `cargo check --target x86_64-pc-windows-gnu --tests -p ramshared-winsvc` passed.
- `cargo test -p ramshared-winsvc --lib` passed.

## Rollback trigger
Revert commit if unit test fails in CI or blocks Windows builds.

---
*PR created automatically by Jules for task [971785951053460311](https://jules.google.com/task/971785951053460311) started by @emersonbusson*