### PR TITLE
🧹 refactor(block): replace unwrap with expect in test helper

### DIFF
--- a/crates/ramshared-block/src/origin_cache.rs
+++ b/crates/ramshared-block/src/origin_cache.rs
@@ -900,7 +900,8 @@ mod tests {
         provider: &'a FakeProvider,
         origin: ScriptedOrigin,
     ) -> WriteThroughCacheBackend<'a, FakeProvider, ScriptedOrigin> {
-        WriteThroughCacheBackend::with_chunk_bytes(provider, origin, 32, 4, 8).unwrap()
+        WriteThroughCacheBackend::with_chunk_bytes(provider, origin, 32, 4, 8)
+            .expect("valid test backend geometry")
     }
 
     fn grow_one<O: OriginStorage>(backend: &mut WriteThroughCacheBackend<'_, FakeProvider, O>) {


### PR DESCRIPTION
## Resumo
Replaced `unwrap()` with `.expect("valid test backend geometry")` in the test helper function `backend()` in `crates/ramshared-block/src/origin_cache.rs`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| ec62abe | Replaced `.unwrap()` with `.expect("valid test backend geometry")` | Improved test code health and failure message quality | <details><summary>See details</summary>Replaced `.unwrap()` in test helper `backend()` at line 903 with `.expect("valid test backend geometry")` to ensure explicit error context if test initialization ever fails.</details> |

## Issue
Code Health Improvement Task: Unsafe `unwrap()` call in `crates/ramshared-block/src/origin_cache.rs:903`.

## Responsavel
@google-labs-jules[bot]

## Labels
- code-health
- refactor

## Validacao
- Ran `cargo test -p ramshared-block` (82 tests passed).

## Rollback trigger
Rollback if tests fail or if test initialization behavior is compromised.


---
*PR created automatically by Jules for task [9969535336233242560](https://jules.google.com/task/9969535336233242560) started by @emersonbusson*