### PR TITLE
🧪 test(winsvc): add unit test for driver_complete in driver_link

### DIFF
--- a/crates/ramshared-winsvc/src/driver_link.rs
+++ b/crates/ramshared-winsvc/src/driver_link.rs
@@ -741,4 +741,35 @@ mod tests {
         assert_eq!(*writes.lock().unwrap(), 0);
         assert_eq!(link.backend_writes, 0);
     }
+
+    #[test]
+    fn driver_complete_empty_cq_and_wrapping_fifo() {
+        let mut q = InMemoryQueue::new(4, 4096, 4096).unwrap();
+
+        // 1. Empty CQ returns Ok(None)
+        assert_eq!(q.driver_complete().unwrap(), None);
+
+        // 2. Single CQE push and completion pop
+        let cqe1 = Cqe {
+            tag: 101,
+            status: ST_OK,
+            reserved: 0,
+        };
+        q.push_cqe(cqe1).unwrap();
+        assert_eq!(q.driver_complete().unwrap(), Some(cqe1));
+        assert_eq!(q.driver_complete().unwrap(), None);
+
+        // 3. FIFO order and wrapping arithmetic (queue_depth = 4)
+        for i in 1..=10u64 {
+            let cqe = Cqe {
+                tag: i,
+                status: ST_OK,
+                reserved: 0,
+            };
+            q.push_cqe(cqe).unwrap();
+            let popped = q.driver_complete().unwrap().unwrap();
+            assert_eq!(popped.tag, i);
+        }
+        assert_eq!(q.driver_complete().unwrap(), None);
+    }
 }


### PR DESCRIPTION
Added unit tests covering public function `driver_complete` in `crates/ramshared-winsvc/src/driver_link.rs`.

🎯 **What:** Tested previously untested public function `driver_complete` in `InMemoryQueue`.
📊 **Coverage:** Covered empty queue return value (`Ok(None)`), single CQE push & pop lifecycle, and multi-CQE FIFO ordering across ring buffer head wrapping arithmetic.
✨ **Result:** Increased test coverage for SPSC completion queue ring logic in `ramshared-winsvc`.

---
*PR created automatically by Jules for task [11568095436678988145](https://jules.google.com/task/11568095436678988145) started by @emersonbusson*