### PR TITLE
🧹 refactor(agent): return Result from test parse_config helper

### DIFF
--- a/crates/ramshared-agent/src/main.rs
+++ b/crates/ramshared-agent/src/main.rs
@@ -570,10 +570,10 @@ mod tests {
         v.iter().map(|s| s.to_string()).collect()
     }
 
-    fn parse_config(v: &[&str]) -> Config {
-        match parse_args(&args(v)).expect("arguments must parse as a configuration") {
-            ParsedArgs::Config(config) => config,
-            ParsedArgs::Help => panic!("test expected configuration, not help"),
+    fn parse_config(v: &[&str]) -> Result<Config, String> {
+        match parse_args(&args(v))? {
+            ParsedArgs::Config(config) => Ok(config),
+            ParsedArgs::Help => Err("test expected configuration, not help".to_string()),
         }
     }
 
@@ -618,7 +618,8 @@ mod tests {
 
     #[test]
     fn parse_minimal_agent() {
-        let c = parse_config(&["--broker", "10.0.0.1:7000", "--tenant", "wsl2"]);
+        let c = parse_config(&["--broker", "10.0.0.1:7000", "--tenant", "wsl2"])
+            .expect("valid configuration");
         assert_eq!(c.broker, "10.0.0.1:7000");
         assert_eq!(c.tenant, "wsl2");
         assert_eq!(c.nbd_base, "/dev/nbd");
@@ -643,7 +644,8 @@ mod tests {
             "unix",
             "--watchdog-secs",
             "30",
-        ]);
+        ])
+        .expect("valid configuration");
         assert_eq!(c.swap_prio, Some(-3));
         assert!(matches!(c.transport, TransportKind::NbdUnix));
         assert_eq!(c.watchdog, Duration::from_secs(30));
@@ -651,7 +653,7 @@ mod tests {
 
     #[test]
     fn status_mode_needs_no_tenant() {
-        let c = parse_config(&["--broker", "h:1", "--status"]);
+        let c = parse_config(&["--broker", "h:1", "--status"]).expect("valid configuration");
         assert!(c.status_only);
         assert!(c.tenant.is_empty());
     }


### PR DESCRIPTION
## Resumo
Refactored the `parse_config` test helper function in `crates/ramshared-agent/src/main.rs` to return `Result<Config, String>` instead of calling `panic!()` when encountering `ParsedArgs::Help`. Updated call sites to expect valid test configuration.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| a16aba0 | Refactored `parse_config` to return `Result` | Eliminate unsafe `panic!()` call in test helper | <details>Updated `parse_config` signature to `Result<Config, String>` and updated callers in `tests` module.</details> |

## Issue
Code health improvement: Unsafe panic!() call at crates/ramshared-agent/src/main.rs:576

## Responsavel
google-labs-jules[bot]

## Labels
code-health, rust

## Validacao
Ran `cargo test -p ramshared-agent` successfully (78 tests passed).

## Rollback trigger
N/A (test helper refactoring only).

---
*PR created automatically by Jules for task [17936711902833448581](https://jules.google.com/task/17936711902833448581) started by @emersonbusson*