### PR TITLE
⚡ perf: cache system_max_backlog using OnceLock

### DIFF
--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -3558,17 +3558,20 @@ impl Drop for OwnedUnixSocketPath {
 
 /// Retorna o menor entre somaxconn e tcp_max_syn_backlog, fallback 128.
 fn system_max_backlog() -> i32 {
-    let somaxconn: i32 = std::fs::read_to_string("/proc/sys/net/core/somaxconn")
-        .unwrap_or_default()
-        .trim()
-        .parse()
-        .unwrap_or(128);
-    let syn_backlog: i32 = std::fs::read_to_string("/proc/sys/net/ipv4/tcp_max_syn_backlog")
-        .unwrap_or_default()
-        .trim()
-        .parse()
-        .unwrap_or(128);
-    std::cmp::min(somaxconn, syn_backlog)
+    static CACHED: std::sync::OnceLock<i32> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        let somaxconn: i32 = std::fs::read_to_string("/proc/sys/net/core/somaxconn")
+            .unwrap_or_default()
+            .trim()
+            .parse()
+            .unwrap_or(128);
+        let syn_backlog: i32 = std::fs::read_to_string("/proc/sys/net/ipv4/tcp_max_syn_backlog")
+            .unwrap_or_default()
+            .trim()
+            .parse()
+            .unwrap_or(128);
+        std::cmp::min(somaxconn, syn_backlog)
+    })
 }
 
 fn apply_listen_backlog<Fd: std::os::fd::AsFd>(fd: Fd) -> std::io::Result<()> {


### PR DESCRIPTION
## Resumo
Cached `system_max_backlog()` using `std::sync::OnceLock<i32>` in `crates/ramshared-wsl2d/src/main.rs`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 4b05d5c | Cached system_max_backlog using OnceLock | To eliminate repeated blocking file reads on listener socket setup | <details><summary>Detalhes</summary>Replaces `/proc/sys` file parsing on every listen setup with static OnceLock initialization.</details> |

## Issue
⚡ Performance Optimization: Synchronous IO in `system_max_backlog`

## Responsavel
google-labs-jules[bot]

## Labels
performance, rust

## Validacao
- Ran unit tests: `cargo test -p ramshared-wsl2d --bin ramsharedd`
- Ran lint & format checks: `cargo fmt --check && cargo clippy -p ramshared-wsl2d`

## Rollback trigger
Rollback if system max backlog dynamically changes at runtime and cached values prevent binding desired listen queues.

---
*PR created automatically by Jules for task [13326710665045290231](https://jules.google.com/task/13326710665045290231) started by @emersonbusson*