### PR TITLE
docs: add finding 27 for QEMU ublk teardown bug explanation

### DIFF
--- a/docs/jules/findings/27-qemu-ublk-teardown-bug-explanation.md
+++ b/docs/jules/findings/27-qemu-ublk-teardown-bug-explanation.md
@@ -1,0 +1,21 @@
+# Finding 27: QEMU ublk Teardown Bug Explanation Verification
+
+- **Source PR:** Jules PR #501
+- **Crate:** `ramshared-wsl2d`
+- **Module:** `main.rs`
+- **Classification:** `FINDING_ONLY`
+
+## Observation
+
+The comment on `BackendKind::Ram` in `crates/ramshared-wsl2d/src/main.rs` ("Ram exists to validate the lifecycle/teardown of the ublk daemon in QEMU...; the teardown bug that hung WSL2 is independent of the backend") refers to a resolved historical bug in the ublk daemon teardown lifecycle.
+
+The `Ram` backend enables testing and verifying ublk daemon initialization, signal handling, swapoff ordering, and teardown rollback semantics in GPU-less QEMU test environments.
+
+The teardown sequence is fully implemented and covered by unit tests in `ramshared-wsl2d`:
+- `daemon_ublk_runtime_orders_lifecycle_and_rolls_back_without_device`
+- `daemon_ublk_runtime_failures_delete_only_after_fresh_absence_proof`
+- `daemon_ublk_shutdown_is_swapoff_first_and_preserves_on_uncertainty`
+
+## Verdict
+
+Accepted as documented architectural verification.

--- a/docs/jules/findings/README.md
+++ b/docs/jules/findings/README.md
@@ -40,3 +40,4 @@ These findings serve as an immutable record of architectural invariants in RamSh
 | 24 | [`24-pr489-broker-cross-host-civm-historical-note.md`](24-pr489-broker-cross-host-civm-historical-note.md) | `ramshared-wsl2d` | Cross-host CIVM historical race note verified. |
 | 25 | [`25-pr493-cli-read-frozen-target-error-handling.md`](25-pr493-cli-read-frozen-target-error-handling.md) | `ramshared-cli` | `read_frozen_target` uses structured Result propagation. |
 | 26 | [`26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md`](26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md) | `ramshared-wsl2d` | Memory locking invariants protect against dxgkrnl collisions. |
+| 27 | [`27-qemu-ublk-teardown-bug-explanation.md`](27-qemu-ublk-teardown-bug-explanation.md) | `ramshared-wsl2d` | Teardown bug comment refers to a resolved historical issue. |


### PR DESCRIPTION
Added Finding 27 to document architectural verification of the QEMU ublk teardown bug comment in crates/ramshared-wsl2d/src/main.rs. The comment references a historical ublk daemon teardown issue that is resolved and verified by existing unit tests in ramshared-wsl2d.

---
*PR created automatically by Jules for task [5352078838128810628](https://jules.google.com/task/5352078838128810628) started by @emersonbusson*