### PR TITLE
🧹 fix(winsvc): propagate Mutex lock errors in test BlockBackend

### DIFF
--- a/crates/ramshared-winsvc/src/driver_link.rs
+++ b/crates/ramshared-winsvc/src/driver_link.rs
@@ -554,8 +554,14 @@ mod tests {
             Ok(())
         }
         fn write_at(&mut self, off: u64, data: &[u8]) -> Result<(), IoError> {
-            *self.writes.lock().unwrap() += 1;
-            *self.last_write.lock().unwrap() = data.to_vec();
+            *self
+                .writes
+                .lock()
+                .map_err(|e| IoError(format!("mutex poisoned: {e}")))? += 1;
+            *self
+                .last_write
+                .lock()
+                .map_err(|e| IoError(format!("mutex poisoned: {e}")))? = data.to_vec();
             let o = off as usize;
             self.data[o..o + data.len()].copy_from_slice(data);
             Ok(())


### PR DESCRIPTION
🧹 **What:** Replaced unsafe `unwrap()` calls on `Mutex` lock results in `crates/ramshared-winsvc/src/driver_link.rs` (`RamBe::write_at`).
💡 **Why:** Propagates `PoisonError` cleanly as an `IoError` using `map_err` and `?`, improving reliability and maintainability.
✅ **Verification:** Verified with `cargo test -p ramshared-winsvc` and `cargo clippy -p ramshared-winsvc`.
✨ **Result:** Eliminated potential unhandled panic on lock poisoning while preserving all existing test functionality.

---
*PR created automatically by Jules for task [1062423436423431880](https://jules.google.com/task/1062423436423431880) started by @emersonbusson*