### PR TITLE
test: add unit tests for uring_smoke run function

### DIFF
--- a/crates/ramshared-wsl2d/src/uring_smoke.rs
+++ b/crates/ramshared-wsl2d/src/uring_smoke.rs
@@ -9,3 +9,22 @@ pub use ramshared_uring::SmokeReport;
 pub fn run(entries: u32) -> std::io::Result<SmokeReport> {
     ramshared_uring::smoke(entries)
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn test_uring_smoke_run_valid_entries() {
+        let report = run(4).expect("io_uring smoke should succeed for valid entries");
+        assert_eq!(report.entries, 4);
+        assert_eq!(report.submitted, 0);
+    }
+
+    #[test]
+    fn test_uring_smoke_run_zero_entries_fails() {
+        let err = run(0).expect_err("io_uring smoke should fail for 0 entries");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+}


### PR DESCRIPTION
## Resumo
This PR adds unit test coverage for the public function `run` in `crates/ramshared-wsl2d/src/uring_smoke.rs`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `332c9d7` | Added unit tests for `uring_smoke::run` | To increase test coverage and ensure `run` function reliability on both happy paths and edge error cases | <details><summary>Detalhes</summary>Tests `run(4)` returning valid `SmokeReport` and `run(0)` returning `std::io::ErrorKind::InvalidInput` error.</details> |

## Issue
Untested public function `run` in `crates/ramshared-wsl2d/src/uring_smoke.rs:9`.

## Responsavel
@google-labs-jules

## Labels
testing, rust, wsl2d

## Validacao
- `cargo test -p ramshared-wsl2d --lib uring_smoke` (2 passed)
- `cargo test -p ramshared-wsl2d` (87 passed)

## Rollback trigger
None. Pure unit test additions under `#[cfg(test)]`.

---
*PR created automatically by Jules for task [12833541036590203084](https://jules.google.com/task/12833541036590203084) started by @emersonbusson*