### PR TITLE
🧹 refactor(core): remove unsafe unwrap call in isolated_origin test helper

### DIFF
--- a/crates/ramshared-block/src/isolated_origin.rs
+++ b/crates/ramshared-block/src/isolated_origin.rs
@@ -711,7 +711,7 @@ mod tests {
             else {
                 panic!("expected cache read");
             };
-            sender.send(reply).unwrap();
+            let _ = sender.send(reply);
         });
         let result = cache.read(0, &mut [0; 4]);
         worker.join().unwrap();


### PR DESCRIPTION
🧹 Refactoring unsafe unwrap() call in `crates/ramshared-block/src/isolated_origin.rs`

🎯 **What:**
Replaced `sender.send(reply).unwrap();` with `let _ = sender.send(reply);` in `cache_read_with_reply`.

💡 **Why:**
Using `unwrap()` when sending through a channel thread could panic if the receiver end is dropped or disconnected early. Handling the result gracefully improves reliability.

✅ **Verification:**
Ran `cargo test -p ramshared-block isolated_origin`, `cargo clippy -p ramshared-block`, and `cargo fmt --check`.

✨ **Result:**
Improved code health and test harness resilience without changing any product behavior or introduces warnings.

---
*PR created automatically by Jules for task [6729284720636350223](https://jules.google.com/task/6729284720636350223) started by @emersonbusson*