### PR TITLE
🧹 refactor(winsvc): replace panic calls in test mock pagefile gates

### DIFF
--- a/crates/ramshared-winsvc/src/service.rs
+++ b/crates/ramshared-winsvc/src/service.rs
@@ -475,11 +475,11 @@ mod tests {
         }
 
         fn active_pagefiles(&self) -> Result<Vec<String>, String> {
-            panic!("Gate A must not run after identity refusal")
+            Err("Gate A must not run after identity refusal".into())
         }
 
         fn lock_volume(&mut self, _: char) -> Result<(), String> {
-            panic!("volume lock must not run after identity refusal")
+            Err("volume lock must not run after identity refusal".into())
         }
 
         fn unlock_volume(&mut self) -> Result<(), String> {
@@ -487,7 +487,7 @@ mod tests {
         }
 
         fn flush_and_dismount(&mut self) -> Result<(), String> {
-            panic!("dismount must not run after identity refusal")
+            Err("dismount must not run after identity refusal".into())
         }
 
         fn volume_locked(&self) -> bool {
@@ -514,15 +514,15 @@ mod tests {
         }
 
         fn lock_volume(&mut self, _: char) -> Result<(), String> {
-            panic!("an exact RAW disk has no volume to lock")
+            Err("an exact RAW disk has no volume to lock".into())
         }
 
         fn unlock_volume(&mut self) -> Result<(), String> {
-            panic!("an exact RAW disk has no volume to unlock")
+            Err("an exact RAW disk has no volume to unlock".into())
         }
 
         fn flush_and_dismount(&mut self) -> Result<(), String> {
-            panic!("an exact RAW disk has no filesystem to dismount")
+            Err("an exact RAW disk has no filesystem to dismount".into())
         }
 
         fn volume_locked(&self) -> bool {


### PR DESCRIPTION
🎯 What: Replace panic!() calls in test mock pagefile gates in crates/ramshared-winsvc/src/service.rs with error returns.
💡 Why: Improves test mock safety and reliability by returning Result::Err instead of triggering panics in mock implementations.
✅ Verification: Ran cargo test -p ramshared-winsvc, cargo clippy -p ramshared-winsvc, and cargo fmt -- --check.
✨ Result: Clean, panic-free test mocks in service.rs.

---
*PR created automatically by Jules for task [5385828613515361980](https://jules.google.com/task/5385828613515361980) started by @emersonbusson*