### PR TITLE
🧹 [code health] remove unsafe unwrap in cache_read_with_reply helper

### DIFF
--- a/crates/ramshared-block/src/isolated_origin.rs
+++ b/crates/ramshared-block/src/isolated_origin.rs
@@ -707,11 +707,9 @@ mod tests {
     fn cache_read_with_reply(reply: Result<Option<Vec<u8>>, String>) -> (CacheRead, CacheState) {
         let (mut cache, worker) = isolated_cache_channel(1, Duration::from_millis(100));
         let worker = std::thread::spawn(move || {
-            let IsolatedCacheRequest::Read { reply: sender, .. } = worker.requests.recv().unwrap()
-            else {
-                panic!("expected cache read");
-            };
-            sender.send(reply).unwrap();
+            if let Ok(IsolatedCacheRequest::Read { reply: sender, .. }) = worker.requests.recv() {
+                let _ = sender.send(reply);
+            }
         });
         let result = cache.read(0, &mut [0; 4]);
         worker.join().unwrap();


### PR DESCRIPTION
## Resumo
Refactored `cache_read_with_reply` in `crates/ramshared-block/src/isolated_origin.rs` to replace `unwrap()` calls with safe pattern matching (`if let Ok(...)`).

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `d111d38` | Removed `unwrap()` in `cache_read_with_reply` | Improve code health and prevent thread panics | <details><summary>Detalhes</summary>Replaced pattern unwrap on `worker.requests.recv()` with `if let Ok(IsolatedCacheRequest::Read { reply: sender, .. })` and ignored send return value with `let _ = sender.send(reply)`.</details> |

## Issue
Code health task: remove unsafe unwrap() in `crates/ramshared-block/src/isolated_origin.rs:710`.

## Responsavel
@google-labs-jules[bot]

## Labels
- refactor
- core

## Validacao
- Ran `cargo test -p ramshared-block` (82 tests passed)

## Rollback trigger
N/A (test helper refactor)

---
*PR created automatically by Jules for task [12919680108935098931](https://jules.google.com/task/12919680108935098931) started by @emersonbusson*