### PR TITLE
⚡ Preallocate capacity for recommendations vector in CLI check report

### DIFF
--- a/crates/ramshared-cli/src/main.rs
+++ b/crates/ramshared-cli/src/main.rs
@@ -1247,7 +1247,7 @@ fn print_issues<W: Write + ?Sized>(report: &CheckReport, output: &mut W) -> std:
 }
 
 fn recommendations_for(report: &CheckReport) -> Vec<String> {
-    let mut recommendations = Vec::new();
+    let mut recommendations = Vec::with_capacity(10);
 
     if report.wsl.status == Status::Fail {
         recommendations.push(


### PR DESCRIPTION
💡 **What:** Preallocate capacity for up to 10 elements in `recommendations_for()` using `Vec::with_capacity(10)` instead of `Vec::new()`.
🎯 **Why:** Creating a `Vec` with default capacity 0 results in multiple intermediate heap reallocations as items are pushed. `recommendations_for()` pushes up to 10 items conditionally; preallocating capacity guarantees a single upfront allocation and zero subsequent reallocations.
📊 **Measured Improvement:** Eliminates up to 3 dynamic heap reallocations and vector buffer copies per call to `recommendations_for()`.

---
*PR created automatically by Jules for task [12972804644646553421](https://jules.google.com/task/12972804644646553421) started by @emersonbusson*