### PR TITLE
⚡ docs: add finding 27 on broker tenant test buffer allocation

### DIFF
--- a/docs/jules/findings/27-pr501-winsvc-broker-tenant-test-alloc.md
+++ b/docs/jules/findings/27-pr501-winsvc-broker-tenant-test-alloc.md
@@ -1,0 +1,20 @@
+# Finding 27: Broker Tenant Test Buffer Allocation Verification
+
+- **Source PR:** Jules PR #501
+- **Crate:** `ramshared-winsvc`
+- **Module:** `broker_tenant.rs`
+- **Classification:** `FINDING_ONLY`
+
+## Observation
+
+The prompt flagged a vector allocation in a loop at `crates/ramshared-winsvc/src/broker_tenant.rs:486`. Inspection of `broker_tenant.rs` reveals that line 486 is inside `failed_release_retains_lease_and_is_not_replayed`, a unit test function (`#[test]`):
+
+```rust
+let mut stream = FailFlush(Dual::new(Vec::new()));
+```
+
+This instantiation occurs once during test setup. There is no loop around this allocation. The test exercises release failure handling across two consecutive calls on `tenant.release(&mut stream)`. Because there is no loop or repeated execution within this test function, hoisting vector allocation or using `.clear()` is inapplicable.
+
+## Verdict
+
+Accepted as documented architectural verification. No code modification required.


### PR DESCRIPTION
## Summary
The prompt flagged a vector allocation in a loop at `crates/ramshared-winsvc/src/broker_tenant.rs:486`.

Upon analysis of `broker_tenant.rs`:
1. Line 486 (`let mut stream = FailFlush(Dual::new(Vec::new()));`) is located inside `failed_release_retains_lease_and_is_not_replayed`, which is a unit test function (`#[test]`).
2. This instantiation occurs only once during test setup. There is no surrounding loop.
3. Hoisting vector allocation or using `.clear()` is inapplicable as no repeated allocation in a loop exists.

This PR documents the finding in `docs/jules/findings/27-pr501-winsvc-broker-tenant-test-alloc.md` (`FINDING_ONLY`).

## Test Plan
- Ran `cargo test -p ramshared-winsvc` to verify all 128 tests in `ramshared-winsvc` pass.
- Verified document creation and formatting.

---
*PR created automatically by Jules for task [13921953998674587699](https://jules.google.com/task/13921953998674587699) started by @emersonbusson*