### PR TITLE
⚡ cli: pre-allocate vector capacity during transition snapshot recovery

### DIFF
--- a/crates/ramshared-cli/src/workload.rs
+++ b/crates/ramshared-cli/src/workload.rs
@@ -800,7 +800,10 @@ fn quarantine_transition_snapshot(lock: &mut LedgerLock) -> Result<(), String> {
     lock.transition_file
         .seek(SeekFrom::Start(0))
         .map_err(|error| format!("read transition owner for recovery: {error}"))?;
-    let mut contents = Vec::new();
+    let capacity = fstat(&lock.transition_file)
+        .map(|stat| (stat.st_size as usize).min(MAX_LEDGER_BYTES as usize + 1))
+        .unwrap_or(0);
+    let mut contents = Vec::with_capacity(capacity);
     (&mut lock.transition_file)
         .take(MAX_LEDGER_BYTES + 1)
         .read_to_end(&mut contents)


### PR DESCRIPTION
Pre-allocated vector capacity in `quarantine_transition_snapshot` using `fstat` file size bounded by `MAX_LEDGER_BYTES + 1` to eliminate dynamic reallocations when reading file contents into memory.

---
*PR created automatically by Jules for task [11479988128885893550](https://jules.google.com/task/11479988128885893550) started by @emersonbusson*