### PR TITLE
⚡ perf(agent): eliminate unnecessary clone in Msg::DemoteAll handler

### DIFF
--- a/crates/ramshared-agent/src/main.rs
+++ b/crates/ramshared-agent/src/main.rs
@@ -486,12 +486,9 @@ fn handle_msg(
         }
         Msg::DemoteAll => {
             eprintln!("[agent] DemoteAll: releasing {} slice(s)", active.len());
-            for (slice, dev) in active.iter() {
+            for (slice, dev) in active.drain() {
                 if cmd_tx
-                    .send(ExecCmd::Off {
-                        slice: *slice,
-                        dev: dev.clone(),
-                    })
+                    .send(ExecCmd::Off { slice, dev })
                     .is_err()
                 {
                     return false;


### PR DESCRIPTION
## Resumo
Eliminated unnecessary string allocation (`dev.clone()`) inside the loop for handling `Msg::DemoteAll` in `crates/ramshared-agent/src/main.rs`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 87d2671 | Replaced `active.iter()` with `active.drain()` in `Msg::DemoteAll` handler | To avoid cloning `dev` string allocations when releasing all active slices | <details><summary>Detalhes</summary>By draining `active`, `slice` and `dev` are moved directly into `ExecCmd::Off { slice, dev }` without allocation.</details> |

## Issue
Unnecessary Clone in Loop (`crates/ramshared-agent/src/main.rs:493`)

## Responsavel
@google-labs-jules[bot]

## Labels
performance, rust, agent

## Validacao
Ran `cargo test -p ramshared-agent` and confirmed all 78 tests pass.

## Rollback trigger
Rollback if session teardown or slice demotion fails to release active slices.

---
*PR created automatically by Jules for task [6792784808063959385](https://jules.google.com/task/6792784808063959385) started by @emersonbusson*