### PR TITLE
⚡ perf(cascade): avoid repeated allocations in nbd lifecycle loop

### DIFF
--- a/crates/ramshared-cli/src/cascade/cascade_io.rs
+++ b/crates/ramshared-cli/src/cascade/cascade_io.rs
@@ -2546,12 +2546,10 @@ fn plan_nbd_lifecycle(
 ) -> Result<NbdLifecyclePlan, CascadeError> {
     validate_lifecycle_binding(binding)?;
     prove_exact_live_device_set(binding, live_devices, &binding.devices)?;
+    let active_swaps: Vec<String> = swaps.iter().map(SwapEntry::canonical_path).collect();
     let mut actions = Vec::new();
     for device in &binding.devices {
-        if swaps
-            .iter()
-            .any(|entry| entry.canonical_path() == device.path)
-        {
+        if active_swaps.iter().any(|path| path == &device.path) {
             actions.push(NbdLifecycleAction::Swapoff(device.clone()));
         }
     }


### PR DESCRIPTION
## Resumo
Pre-calculates canonical swap paths into a `Vec<String>` before the device loop in `plan_nbd_lifecycle`, avoiding repeated `entry.canonical_path()` string allocations inside the loop.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `cfae308` | Pre-collected `active_swaps` before iterating `binding.devices` in `plan_nbd_lifecycle` | To eliminate $O(M \times N)$ string allocations per lifecycle plan construction | <details><summary>Detalhes</summary>Extracted `swaps.iter().map(SwapEntry::canonical_path).collect()` before `binding.devices` loop.</details> |

## Issue
N/A

## Responsavel
@emersonbusson

## Labels
performance, cli

## Validacao
Ran `cargo test -p ramshared-cli --bin ramshared cascade::` (all 128 tests passed). Verified `bench_plan_nbd_lifecycle` performance improvement.

## Rollback trigger
Revert commit if any issue occurs with `plan_nbd_lifecycle`.

---
*PR created automatically by Jules for task [13348309396454034763](https://jules.google.com/task/13348309396454034763) started by @emersonbusson*