### PR TITLE
🧪 test(winsvc): add unit test for WindowsHostState::lock_volume

### DIFF
--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1187,4 +1187,12 @@ mod tests {
             .unwrap_err();
         assert!(error.to_string().contains("malformed Get-Disk output"));
     }
+
+    #[test]
+    fn lock_volume_invalid_letter_is_refused() {
+        let err_c = WindowsHostState::lock_volume('C').unwrap_err();
+        assert!(err_c.to_string().contains("letter must be D..=Z"));
+        let err_a = WindowsHostState::lock_volume('a').unwrap_err();
+        assert!(err_a.to_string().contains("letter must be D..=Z"));
+    }
 }


### PR DESCRIPTION
### 🎯 What
Adds unit test coverage for `WindowsHostState::lock_volume` in `crates/ramshared-winsvc/src/windows_host.rs`.

### 📊 Coverage
Verifies that `lock_volume` properly validates drive letter bounds and returns `HostError::Volume("letter must be D..=Z")` for invalid drive letters (`'C'` and lower-case `'a'`).

### ✨ Result
Improves unit test coverage for host-side volume locking functions in `ramshared-winsvc`.

---
*PR created automatically by Jules for task [9368360976081098282](https://jules.google.com/task/9368360976081098282) started by @emersonbusson*