### PR TITLE
🧪 test(winsvc): add unit tests for public entry function in windows_svc

### DIFF
--- a/crates/ramshared-winsvc/src/main.rs
+++ b/crates/ramshared-winsvc/src/main.rs
@@ -1096,6 +1096,28 @@ mod windows_svc {
             }
         }
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::entry;
+
+        #[test]
+        fn test_entry_invalid_args() {
+            let code = entry(vec!["ramshared-winsvc.exe".into(), "invalid_cmd".into()]);
+            assert_eq!(code, 2);
+        }
+
+        #[test]
+        fn test_entry_scm_default_duplicate_config() {
+            let _ = super::SCM_CONFIG.set("C:\\Program Files\\RamShared\\versions\\v1\\winsvc.toml".into());
+            let code = entry(vec![
+                "ramshared-winsvc.exe".into(),
+                "--config".into(),
+                "C:\\Program Files\\RamShared\\versions\\v1\\winsvc.toml".into(),
+            ]);
+            assert_eq!(code, 2);
+        }
+    }
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
🎯 **What:** Add unit test coverage for the public function `entry` in `crates/ramshared-winsvc/src/main.rs`.
📊 **Coverage:** Tested invalid CLI arguments and duplicate SCM configuration setup error paths.
✨ **Result:** Improved unit test coverage for `windows_svc::entry`.

---
*PR created automatically by Jules for task [5300283996696826846](https://jules.google.com/task/5300283996696826846) started by @emersonbusson*