### PR TITLE
docs: document finding for reported clone in workload.rs

### DIFF
--- a/docs/jules/findings/unnecessary-clone-in-loop-workload.md
+++ b/docs/jules/findings/unnecessary-clone-in-loop-workload.md
@@ -1,0 +1,13 @@
+# Finding: Unnecessary Clone in Loop in workload.rs
+
+## Executive Summary
+The task requested fixing an "Unnecessary Clone in Loop" at `crates/ramshared-cli/src/workload.rs:1985`.
+
+## Investigation & Findings
+1. Line 1985 of `crates/ramshared-cli/src/workload.rs` resides within `StartPublishingRunner::launch`, which is part of unit test mock fixtures in `mod tests`.
+2. `StartPublishingRunner::launch` is not executing inside a loop. It constructs a test fixture execution object `StartPublishingExecution` upon launch.
+3. In `SystemScopeExecution::wait_for_completion` (the actual production polling loop around line 1491), `self.invocation_id` is cloned only once on initial assignment (`None => self.invocation_id = Some(status.invocation_id.clone())`) and is skipped on all subsequent loop iterations once populated (`Some(_) => {}`).
+4. Replacing `.clone()` on test fields or `Arc` pointers in test fixtures does not yield any measurable performance improvement or affect production execution paths.
+
+## Conclusion
+The issue is a non-impacting finding located within unit test fixtures. No production code modification is required.


### PR DESCRIPTION
Document finding regarding reported unnecessary clone in loop in workload.rs test fixture.

---
*PR created automatically by Jules for task [66575938152023234](https://jules.google.com/task/66575938152023234) started by @emersonbusson*