### PR TITLE
⚡ optimize workload scope status parser to eliminate unnecessary clone in loop

### DIFF
--- a/crates/ramshared-cli/src/workload.rs
+++ b/crates/ramshared-cli/src/workload.rs
@@ -1372,9 +1372,10 @@ fn parse_scope_status(unit: &str, output: &str) -> Result<ScopeStatus, String> {
             "ExecMainStatus" => &mut exec_main_status,
             _ => return Err(format!("unexpected exact scope status field {name}")),
         };
-        if slot.replace(value.to_string()).is_some() {
+        if slot.is_some() {
             return Err(format!("duplicate exact scope status field {name}"));
         }
+        *slot = Some(value.to_string());
     }
     let id = id.ok_or("exact scope status omitted Id")?;
     if id != unit {


### PR DESCRIPTION
Optimized `parse_scope_status` in `crates/ramshared-cli/src/workload.rs` to check `if slot.is_some()` before allocating `value.to_string()`. This eliminates unnecessary heap string allocations during status line parsing.

---
*PR created automatically by Jules for task [6547875327420994195](https://jules.google.com/task/6547875327420994195) started by @emersonbusson*