### PR TITLE
⚡ perf(winsvc): remove string clone in startup lun wait loop

### DIFF
--- a/crates/ramshared-winsvc/src/product_online.rs
+++ b/crates/ramshared-winsvc/src/product_online.rs
@@ -276,10 +276,11 @@ pub fn run_product_online(
     let mut dlink = DriverLink::from_queue(q);
     let startup_lun_deadline = Duration::from_secs(60);
     let startup_lun_started = Instant::now();
+    let serial_arc: Arc<str> = Arc::from(serial_str.as_str());
     loop {
         // The startup LUN identity wait must pump I/O: Windows disk
         // enumeration may issue READs before Get-Disk exposes the device.
-        let want_serial = serial_str.clone();
+        let want_serial = Arc::clone(&serial_arc);
         let want_size = cfg.size_bytes;
         let startup_lun = readonly_host_call_with_io_pump(
             &mut link,


### PR DESCRIPTION
## Resumo

This PR optimizes performance in `crates/ramshared-winsvc/src/product_online.rs` by eliminating a heap `String` allocation inside the startup LUN wait loop. Before the loop, `serial_str` is converted into an `Arc<str>`, and `Arc::clone(&serial_arc)` is used inside the loop, performing a cheap atomic reference count increment instead of allocating a `String` on every iteration.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `e6759d0` | Avoid heap allocation in startup LUN wait loop | Convert string to `Arc<str>` outside loop | <details><summary>detalhes</summary>**Arquivos:** `crates/ramshared-winsvc/src/product_online.rs`<br>**Validacao:** `cargo check -p ramshared-winsvc --target x86_64-pc-windows-gnu` && `cargo test -p ramshared-winsvc`<br>**Risco/rollback:** Low risk. Revert commit if regression observed.</details> |

## Issue

Closes #0

## Responsavel

@google-labs-jules[bot]

## Labels

type:perf, area:winsvc

## Validacao

- [x] `cargo check -p ramshared-winsvc --target x86_64-pc-windows-gnu`
- [x] `cargo test -p ramshared-winsvc` (128 passed)

## Rollback trigger

Revert if startup LUN identification fails during Windows service startup.

---
*PR created automatically by Jules for task [14629693698524599734](https://jules.google.com/task/14629693698524599734) started by @emersonbusson*