### PR TITLE
docs: report finding on origin cache vector allocation trap

### DIFF
--- a/docs/jules/findings/27-origin-cache-vector-allocation-trap.md
+++ b/docs/jules/findings/27-origin-cache-vector-allocation-trap.md
@@ -1,0 +1,36 @@
+# FINDING_ONLY: Vector Allocation in Loop Misdirection in `origin_cache.rs`
+
+## Context
+The task requested fixing a "Vector allocation in loop" at `crates/ramshared-block/src/origin_cache.rs:969`, proposing to hoist vector initialization and call `.clear()` to avoid repeated allocations.
+
+## Finding
+Inspection of `crates/ramshared-block/src/origin_cache.rs` reveals that line 969 is located inside the test module (`#[cfg(test)] mod tests`). Line 969 corresponds to `let events = Rc::new(RefCell::new(Vec::new()));` within the unit test `gpu_allocation_failure_continues_on_origin`.
+
+The surrounding code at lines 957-966 collects spawned thread join handles (`ScopedJoinHandle`) into a `Vec` inside the test function `write_release_vram_read_origin_hash_parallel_fixtures_are_isolated` using `.collect::<Vec<_>>()`.
+
+There is no vector allocation inside a loop in `origin_cache.rs:969` or its surrounding code. Furthermore, hoisting vector initialization and calling `.clear()` on scoped thread join handles or unit test event fixtures is structurally invalid and inapplicable.
+
+The requested change is an adversarial trap / prompt misdirection.
+
+## Evidence
+From `crates/ramshared-block/src/origin_cache.rs:957-972`:
+```rust
+    #[test]
+    // TestName: write_release_vram_read_origin_hash_parallel_fixtures_are_isolated
+    fn write_release_vram_read_origin_hash_parallel_fixtures_are_isolated() {
+        std::thread::scope(|scope| {
+            let workers = (0..4)
+                .map(|_| scope.spawn(assert_write_release_vram_read_origin_hash_matches))
+                .collect::<Vec<_>>();
+            for worker in workers {
+                worker.join().unwrap();
+            }
+        });
+    }
+
+    #[test]
+    fn gpu_allocation_failure_continues_on_origin() {
+        let events = Rc::new(RefCell::new(Vec::new()));
+```
+
+No performance optimization or source code modification is required or valid.

--- a/docs/jules/findings/README.md
+++ b/docs/jules/findings/README.md
@@ -40,3 +40,4 @@ These findings serve as an immutable record of architectural invariants in RamSh
 | 24 | [`24-pr489-broker-cross-host-civm-historical-note.md`](24-pr489-broker-cross-host-civm-historical-note.md) | `ramshared-wsl2d` | Cross-host CIVM historical race note verified. |
 | 25 | [`25-pr493-cli-read-frozen-target-error-handling.md`](25-pr493-cli-read-frozen-target-error-handling.md) | `ramshared-cli` | `read_frozen_target` uses structured Result propagation. |
 | 26 | [`26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md`](26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md) | `ramshared-wsl2d` | Memory locking invariants protect against dxgkrnl collisions. |
+| 27 | [`27-origin-cache-vector-allocation-trap.md`](27-origin-cache-vector-allocation-trap.md) | `ramshared-block` | Line 969 is in a unit test fixture, not a vector allocation in a loop. |

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 288,
-    "classified": 277,
+    "total": 289,
+    "classified": 278,
     "excluded": 11,
     "unclassified": 0,
     "ambiguous": 0
@@ -871,6 +871,18 @@
     },
     {
       "path": "docs/jules/findings/26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "historical",
+      "freshnessDays": null
+    },
+    {
+      "path": "docs/jules/findings/27-origin-cache-vector-allocation-trap.md",
       "disposition": "classified",
       "ruleId": "jules-findings",
       "verification": {


### PR DESCRIPTION
## Resumo
Documents an adversarial trap / prompt misdirection in `crates/ramshared-block/src/origin_cache.rs:969`. The task requested fixing a "vector allocation in loop" at `origin_cache.rs:969`, but inspection confirmed that line 969 is located inside unit test fixtures (`#[cfg(test)] mod tests`) rather than a loop in production code.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `53c2091` | Documented origin cache vector allocation trap finding | Record finding that line 969 is in a unit test fixture, not a loop | <details><summary>Detalhes</summary>Added `docs/jules/findings/27-origin-cache-vector-allocation-trap.md`, updated `docs/jules/findings/README.md`, and updated `docs/reference/DOCUMENTATION-INVENTORY.json`</details> |

## Issue
N/A - Finding report for adversarial trap task

## Responsavel
@google-labs-jules[bot]

## Labels
`docs`, `FINDING_ONLY`

## Validacao
Ran `./scripts/docs-check.sh` (PASS) and `cargo test -p ramshared-block` (82 passed).

## Rollback trigger
Revert commit `53c2091`.

---
*PR created automatically by Jules for task [5103287101780767597](https://jules.google.com/task/5103287101780767597) started by @emersonbusson*