### PR TITLE
⚡ [perf] pre-collect swap canonical paths in plan_nbd_lifecycle

### DIFF
--- a/crates/ramshared-cli/src/cascade/cascade_io.rs
+++ b/crates/ramshared-cli/src/cascade/cascade_io.rs
@@ -2547,11 +2547,12 @@ fn plan_nbd_lifecycle(
     validate_lifecycle_binding(binding)?;
     prove_exact_live_device_set(binding, live_devices, &binding.devices)?;
     let mut actions = Vec::new();
+    let swap_paths: std::collections::HashSet<String> = swaps
+        .iter()
+        .map(|entry| entry.canonical_path())
+        .collect();
     for device in &binding.devices {
-        if swaps
-            .iter()
-            .any(|entry| entry.canonical_path() == device.path)
-        {
+        if swap_paths.contains(&device.path) {
             actions.push(NbdLifecycleAction::Swapoff(device.clone()));
         }
     }


### PR DESCRIPTION
## Resumo
Pre-collected canonical swap paths into a `HashSet<String>` before the device loop in `plan_nbd_lifecycle` within `crates/ramshared-cli/src/cascade/cascade_io.rs`. This eliminates repeated string allocations per swap entry per device in the inner loop, achieving a ~30.5% runtime reduction in lifecycle planning.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `95d5599` | Pre-collected canonical swap paths into a `HashSet<String>` before the device loop in `plan_nbd_lifecycle` | To eliminate repeated heap string allocations and $O(N \times M)$ search complexity inside `plan_nbd_lifecycle` | <details><summary>Detalhes</summary>Pre-collecting `entry.canonical_path()` strings into a `HashSet<String>` once before the device loop reduces inner loop lookups from $O(N)$ string allocations/comparisons to $O(1)$ set checks without String allocations inside the loop.</details> |

## Issue
Closes #2555

## Responsavel
@google-labs-jules[bot]

## Labels
type:perf, area:cli

## Validacao
- `cargo test -p ramshared-cli -- cascade::` passed (128 tests).
- Benchmark measured runtime reduction from ~3.73s to ~2.59s for 10,000 iterations (1.44x speedup).

## Rollback trigger
Revert commit if `plan_nbd_lifecycle` fails to identify active swap devices or introduces path matching errors.

---
*PR created automatically by Jules for task [5270881473996235962](https://jules.google.com/task/5270881473996235962) started by @emersonbusson*