### PR TITLE
docs: add analysis report for workload test fixture clones

### DIFF
--- a/FINDING_ONLY.md
+++ b/FINDING_ONLY.md
@@ -1,0 +1,26 @@
+# Analysis of Performance Task: Unnecessary Clone in Loop (`TransitionBlockingRunner`)
+
+## Executive Summary
+The task description points to `crates/ramshared-cli/src/workload.rs:1946`:
+```rust
+    impl ScopeRunner for TransitionBlockingRunner {
+        fn launch(
+            &self,
+            _unit: &str,
+            _runner_args: &[String],
+            _command: &[String],
+        ) -> Result<Box<dyn ScopeExecution>, String> {
+            *self.calls.borrow_mut() += 1;
+            Ok(Box::new(TransitionBlockingExecution {
+                ledger_root: self.ledger_root.clone(),
+                supervisor: self.supervisor.clone(),
+            }))
+        }
+    }
+```
+
+However, detailed investigation of the codebase reveals that:
+1. `TransitionBlockingRunner` and `TransitionBlockingExecution` are test fixtures defined inside `#[cfg(test)] mod tests` in `crates/ramshared-cli/src/workload.rs`.
+2. They are used exclusively in unit test cases (specifically in `workload_start_serializes_against_close_admission_transition`) to test transition synchronization.
+3. Neither `TransitionBlockingRunner` nor `TransitionBlockingExecution` is used in any production loop, daemon loop, or hot code path.
+4. Refactoring `TransitionBlockingExecution` to store references (`&'a Path` and `'a OwnerIdentity`) or lifetime-bound trait objects would require altering the `ScopeRunner` trait interface (`ScopeRunner::launch<'a>`), propagating lifetime parameters throughout all test runners (`FakeRunner`, `StartPublishingRunner`, `SystemExecutionRunner`) and production implementations (`SystemScopeRunner`), thereby adding unnecessary trait complexity for zero runtime or performance gain in production.


### PR DESCRIPTION
⚡ **What:** Documented performance analysis of `TransitionBlockingRunner` in `crates/ramshared-cli/src/workload.rs`.

🎯 **Why:** The flagged `self.ledger_root.clone()` and `self.supervisor.clone()` occur inside a test double fixture (`TransitionBlockingRunner`) within `#[cfg(test)] mod tests`, used solely in unit tests (`workload_start_serializes_against_close_admission_transition`). It is not executed in any production loop or hot code path.

📊 **Measured Improvement:** No production code or runtime overhead is affected. Refactoring the test runner to use references would require introducing lifetime annotations (`ScopeRunner::launch<'a>`) across the entire `ScopeRunner` interface and all implementations (`SystemScopeRunner`, `FakeRunner`, `StartPublishingRunner`, `SystemExecutionRunner`), adding interface complexity without any production performance benefit. Documented the findings in `FINDING_ONLY.md`.

---
*PR created automatically by Jules for task [16710844163181008795](https://jules.google.com/task/16710844163181008795) started by @emersonbusson*