### PR TITLE
fix(wsl2d): standardize dxgkrnl anti-bug marker in binary and preflight

### DIFF
--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -4614,7 +4614,10 @@ fn run_ublk_with_runtime(
             .into());
     }
     runtime.guard_not_wsl2()?;
-    // MCL_CURRENT only: MCL_FUTURE races dxgkrnl mapping and can hang the host.
+    // dxgkrnl ANTI-BUG: MCL_CURRENT-only in ublk+vram path (MCL_FUTURE races dxgkrnl mapping and can hang the host).
+    #[used]
+    static ANTI_BUG_MARKER: &str = "dxgkrnl ANTI-BUG: MCL_CURRENT-only in ublk+vram path";
+    let _ = core::hint::black_box(ANTI_BUG_MARKER);
     runtime.lock_memory(force, false)?;
     runtime.install_shutdown_handler()?;
 

--- a/scripts/safety/preflight.sh
+++ b/scripts/safety/preflight.sh
@@ -15,7 +15,7 @@ set -uo pipefail
 
 REPO="${RAMSHARED_REPO:-$(cd "$(dirname "$0")/../.." && pwd)}"
 BIN="${1:-$REPO/target/debug/ramsharedd}"
-FIX_MARKER='MCL_CURRENT-only no caminho ublk+vram'   # string do fix anti-dxgkrnl-BUG (#1)
+FIX_MARKER='MCL_CURRENT-only in ublk+vram path'   # string do fix anti-dxgkrnl-BUG (#1)
 MIN_VRAM_FREE_MIB="${RAMSHARED_MIN_VRAM_FREE_MIB:-256}"
 
 # nvidia-smi in WSL2 is located in /usr/lib/wsl/lib, which is NOT in systemd's minimal PATH.


### PR DESCRIPTION
## Resumo
Standardizes the `dxgkrnl ANTI-BUG` marker string in `crates/ramshared-wsl2d/src/main.rs` and `scripts/safety/preflight.sh` to ensure preflight binary verification succeeds.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `a1b2c3d` | Standardized dxgkrnl ANTI-BUG marker string | Fixed preflight script string matching on ramsharedd binary | <details><summary>Detalhes</summary>Added a static string constant using black_box in `run_ublk_with_runtime` and updated `FIX_MARKER` in `preflight.sh` to match in English.</details> |

## Issue
Fixes dxgkrnl ANTI-BUG reference string matching in binary preflight check.

## Responsavel
Jules

## Labels
bug, safety

## Validacao
Ran `cargo build -p ramshared-wsl2d --bin ramsharedd`, verified string present via `strings target/debug/ramsharedd | grep "MCL_CURRENT-only in ublk+vram path"`, ran `./scripts/safety/preflight.sh target/debug/ramsharedd` and confirmed step 1 passed (`[ok] binario tem o fix do mlockall`), and ran `cargo test -p ramshared-wsl2d` (all 87 tests passed).

## Rollback trigger
Revert commit if preflight binary verification fails.

---
*PR created automatically by Jules for task [7729627271875938220](https://jules.google.com/task/7729627271875938220) started by @emersonbusson*