### PR TITLE
⚡ report finding for workload fixture vector allocation trap

### DIFF
--- a/docs/jules/findings/27-workload-fixture-vec-allocation-trap.md
+++ b/docs/jules/findings/27-workload-fixture-vec-allocation-trap.md
@@ -1,0 +1,14 @@
+# FINDING_ONLY: Vector Allocation in Test Fixture Loop (workload.rs:2151)
+
+## Intent
+The task requested hoisting a `Vec::new()` initialization and calling `.clear()` on it within a loop in `crates/ramshared-cli/src/workload.rs` to prevent repeated vector allocations.
+
+## Analysis
+1. `Vec::new()` in Rust is a `const fn` (`RawVec::NEW`) that creates an empty vector with 0 capacity. It performs **0 heap allocations**.
+2. The `ReservationLedger` struct owns its `reservations: Vec<Reservation>` field. In Rust's ownership model, hoisting a vector outside the loop and calling `.clear()` on it in each iteration is impossible because `ReservationLedger` takes ownership of the vector (moving it).
+3. The instantiation of `ReservationLedger` (and its `Vec::new()`) is located inside the `Ok(())` arm of `fs::create_dir(&path)`. When `fs::create_dir` succeeds, `serde_json::to_vec` runs once and `return path;` immediately exits the function and loop.
+4. On loop iterations where `fs::create_dir(&path)` returns `Err(ErrorKind::AlreadyExists)`, execution hits `continue`, skipping line 2151 entirely. No vector is constructed on retry iterations.
+5. The function `fixture()` is a test helper function inside `#[cfg(test)] mod tests` in `crates/ramshared-cli/src/workload.rs`, not a hot production runtime path.
+
+## Conclusion
+The claim that line 2151 performs repeated vector allocations in a loop is an architectural and language misconception. Hoisting the initialization and using `.clear()` is both impossible due to Rust move semantics and unnecessary because `Vec::new()` is non-allocating and executes at most once before function return.

--- a/docs/jules/findings/README.md
+++ b/docs/jules/findings/README.md
@@ -40,3 +40,4 @@ These findings serve as an immutable record of architectural invariants in RamSh
 | 24 | [`24-pr489-broker-cross-host-civm-historical-note.md`](24-pr489-broker-cross-host-civm-historical-note.md) | `ramshared-wsl2d` | Cross-host CIVM historical race note verified. |
 | 25 | [`25-pr493-cli-read-frozen-target-error-handling.md`](25-pr493-cli-read-frozen-target-error-handling.md) | `ramshared-cli` | `read_frozen_target` uses structured Result propagation. |
 | 26 | [`26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md`](26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md) | `ramshared-wsl2d` | Memory locking invariants protect against dxgkrnl collisions. |
+| 27 | [`27-workload-fixture-vec-allocation-trap.md`](27-workload-fixture-vec-allocation-trap.md) | `ramshared-cli` | `Vec::new()` is zero-allocating and only executed once before return in test fixture loop. |


### PR DESCRIPTION
## Resumo
Report architectural finding for workload fixture vector allocation trap in crates/ramshared-cli/src/workload.rs:2151. Vec::new() is zero-allocating and the block is guarded inside an Ok arm that immediately returns.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| `bb34e3a` | Add finding report for workload fixture vector trap | Document that Vec::new() is non-allocating and executed once before return | <details><summary>Context</summary>Analysis proved Vec::new() performs zero heap allocations and runs at most once before returning path.</details> |

## Issue
Fixes #000

## Responsavel
@google-labs-jules[bot]

## Labels
`type:docs`, `area:cli`

## Validacao
- `umask 0022 && cargo test -p ramshared-cli workload::tests::workload_fixture_roots_are_unique_and_avoid_shared_disk_sync`
- `cat docs/jules/findings/27-workload-fixture-vec-allocation-trap.md`

## Rollback trigger
N/A (Documentation finding only)

---
*PR created automatically by Jules for task [7198032978431078880](https://jules.google.com/task/7198032978431078880) started by @emersonbusson*