### PR TITLE
🔒 Fix PowerShell command injection vulnerability in residue script generation

### DIFF
--- a/crates/ramshared-winsvc/src/main.rs
+++ b/crates/ramshared-winsvc/src/main.rs
@@ -902,8 +902,14 @@ mod windows_svc {
             root.join(&manifest.artifact(ArtifactRole::WinsvcConfig)?.relative_path),
         )?)?;
         let script = ramshared_winsvc::package::build_residue_script(config.volume_letter)?;
+        let encoded_script = ramshared_winsvc::windows_host::encode_powershell_command(&script);
         let mut child = std::process::Command::new("powershell.exe")
-            .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-EncodedCommand",
+                &encoded_script,
+            ])
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .spawn()?;

--- a/crates/ramshared-winsvc/src/package.rs
+++ b/crates/ramshared-winsvc/src/package.rs
@@ -484,5 +484,9 @@ mod tests {
 
         let injected_char = build_residue_script('\'');
         assert!(injected_char.is_err());
+
+        for injection in [';', '$', '"', '\n', '\r', '`', '&', '|'] {
+            assert!(build_residue_script(injection).is_err(), "expected injection char {injection:?} to be rejected");
+        }
     }
 }

--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -869,7 +869,7 @@ fn validate_powershell_environment(
     Ok(validated)
 }
 
-fn encode_powershell_command(script: &str) -> String {
+pub fn encode_powershell_command(script: &str) -> String {
     use base64::Engine as _;
 
     let utf16le = script


### PR DESCRIPTION
## Resumo
Fixes a PowerShell command injection vulnerability in `crates/ramshared-winsvc/src/main.rs` by encoding the residue query PowerShell script as UTF-16LE Base64 (`-EncodedCommand`) rather than passing raw strings with `-Command`. Additionally adds comprehensive security unit test coverage in `crates/ramshared-winsvc/src/package.rs` to verify that volume letter inputs with command injection characters are strictly rejected.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 🔒 Fix PowerShell command injection vulnerability in residue script generation | Replaced raw `-Command` execution with `-EncodedCommand` in `observe_host_residue` and added injection unit tests | To eliminate risk of PowerShell command injection via volume letter configuration formatting | <details><summary>Detalhes</summary>Exported `encode_powershell_command` from `windows_host.rs`, updated `main.rs` to pass `-EncodedCommand`, and added tests for injection characters in `package.rs`</details> |

## Issue
Security vulnerability fix for PowerShell Command Injection via Format String in `crates/ramshared-winsvc`.

## Responsavel
Jules Security Agent

## Labels
security, bug, windows

## Validacao
- Ran `cargo test -p ramshared-winsvc` verifying all 128 unit tests pass.
- Verified `observe_host_residue_script_escaping` unit test rejects characters `;`, `$`, `"`, `\n`, `\r`, `` ` ``, `&`, `|`, and `'`.

## Rollback trigger
Revert commit if Windows service status residue query fails to execute PowerShell `-EncodedCommand`.

---
*PR created automatically by Jules for task [3289521244295306045](https://jules.google.com/task/3289521244295306045) started by @emersonbusson*