### PR TITLE
🧹 docs(findings): report finding for monitor malformed reservation ledger

### DIFF
--- a/docs/jules/findings/27-monitor-telemetry-refuses-malformed-reservation-ledger-trap.md
+++ b/docs/jules/findings/27-monitor-telemetry-refuses-malformed-reservation-ledger-trap.md
@@ -1,0 +1,30 @@
+# Finding 27: Monitor Telemetry Malformed Reservation Ledger Test Length Verification
+
+- **Source:** Code Health Improvement Task
+- **Crate:** `ramshared-cli`
+- **Module:** `monitor.rs`
+- **Classification:** `FINDING_ONLY`
+
+## Observation
+
+The code health issue reported function `monitor_telemetry_refuses_malformed_reservation_ledger` at `crates/ramshared-cli/src/monitor.rs:1829` as being overly long (500 lines).
+
+Inspection of `crates/ramshared-cli/src/monitor.rs` confirms that `monitor_telemetry_refuses_malformed_reservation_ledger` is actually only 8 lines long:
+
+```rust
+    #[test]
+    // TestName: monitor_telemetry_refuses_malformed_reservation_ledger
+    fn monitor_telemetry_refuses_malformed_reservation_ledger() {
+        let contents = "{not-json";
+        let (root, path) = monitor_ledger_path("malformed", Some(contents));
+        assert_eq!(read_reservation_totals(&path), (0, 0));
+        assert_eq!(fs::read_to_string(&path).unwrap(), contents);
+        fs::remove_dir_all(root).unwrap();
+    }
+```
+
+The function is concise, clean, fully covered, and passes all tests without issue.
+
+## Verdict
+
+Accepted as documented architectural verification (`FINDING_ONLY`). No code modification is necessary or warranted.

--- a/docs/jules/findings/README.md
+++ b/docs/jules/findings/README.md
@@ -40,3 +40,4 @@ These findings serve as an immutable record of architectural invariants in RamSh
 | 24 | [`24-pr489-broker-cross-host-civm-historical-note.md`](24-pr489-broker-cross-host-civm-historical-note.md) | `ramshared-wsl2d` | Cross-host CIVM historical race note verified. |
 | 25 | [`25-pr493-cli-read-frozen-target-error-handling.md`](25-pr493-cli-read-frozen-target-error-handling.md) | `ramshared-cli` | `read_frozen_target` uses structured Result propagation. |
 | 26 | [`26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md`](26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md) | `ramshared-wsl2d` | Memory locking invariants protect against dxgkrnl collisions. |
+| 27 | [`27-monitor-telemetry-refuses-malformed-reservation-ledger-trap.md`](27-monitor-telemetry-refuses-malformed-reservation-ledger-trap.md) | `ramshared-cli` | `monitor_telemetry_refuses_malformed_reservation_ledger` is 8 lines long and concise. |

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 288,
-    "classified": 277,
+    "total": 289,
+    "classified": 278,
     "excluded": 11,
     "unclassified": 0,
     "ambiguous": 0
@@ -871,6 +871,18 @@
     },
     {
       "path": "docs/jules/findings/26-pr497-wsl2d-dxgkrnl-mlockall-invariants.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "historical",
+      "freshnessDays": null
+    },
+    {
+      "path": "docs/jules/findings/27-monitor-telemetry-refuses-malformed-reservation-ledger-trap.md",
       "disposition": "classified",
       "ruleId": "jules-findings",
       "verification": {


### PR DESCRIPTION
🎯 **What:**
Analyzed reported code health issue on `monitor_telemetry_refuses_malformed_reservation_ledger` in `crates/ramshared-cli/src/monitor.rs`.

💡 **Why:**
Inspection confirmed that `monitor_telemetry_refuses_malformed_reservation_ledger` is actually an 8-line, well-factored, passing test function. Refactoring it would introduce unnecessary code churn and hallucinated changes. A `FINDING_ONLY` report was generated in `docs/jules/findings/27-monitor-telemetry-refuses-malformed-reservation-ledger-trap.md` following project standards.

✅ **Verification:**
1. Ran `umask 0022 && cargo test -p ramshared-cli -- monitor::tests` (19/19 tests passed).
2. Ran `./scripts/docs-check.sh` (docs-check OK).

✨ **Result:**
Recorded architectural verification without code modifications, preserving codebase clarity and stability.

---
*PR created automatically by Jules for task [14246332426548212087](https://jules.google.com/task/14246332426548212087) started by @emersonbusson*