### PR TITLE
feat: Produce FINDING_ONLY report for IPC protocol architectural trap

### DIFF
--- a/docs/jules/findings/guard_clauses.md
+++ b/docs/jules/findings/guard_clauses.md
@@ -1,0 +1,2 @@
+FINDING_ONLY
+The task instructs to validate IPC message magic bytes, protocol version, and length header with guard clauses before buffer allocation in crates/ramshared-broker/src/protocol.rs. However, the protocol is explicitly documented as a JSON-lines wire format (ADR-0005), which is debuggable with nc/jq. There are no binary magic bytes or length headers before the JSON payload. Adding such headers would break the JSON-lines format and the tool compatibility. Therefore, this is an architectural trap and safe code is not possible.


### PR DESCRIPTION
## Resumo
Produce FINDING_ONLY report due to architectural trap.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: add finding | Created finding report | Architectural trap in JSON-lines protocol | Documented why we cannot add binary headers |

## Issue
CleanArch100/2026-09-06/guard_clause/broker/013

## Responsavel
Jules

## Labels
type:refactor

## Validacao
cargo test && cargo clippy -- -D warnings

## Rollback trigger
None

---
*PR created automatically by Jules for task [16612313029351520509](https://jules.google.com/task/16612313029351520509) started by @emersonbusson*