### PR TITLE
refactor: flatten nested config validation branches into early guard exits

### DIFF
--- a/crates/ramshared-winsvc/src/config.rs
+++ b/crates/ramshared-winsvc/src/config.rs
@@ -188,21 +188,19 @@ impl WinDriveConfig {
                 detail: format!("must be D..=Z, got {:?}", self.volume_letter),
             });
         }
-        if let Some(path) = &self.volume_mount_path {
+        let is_valid_mount = self.volume_mount_path.as_ref().is_none_or(|path| {
             let value = path.to_string_lossy().replace('/', "\\");
             let prefix = r"C:\ProgramData\RamShared\mounts\";
-            if !value
-                .to_ascii_lowercase()
-                .starts_with(&prefix.to_ascii_lowercase())
-                || value[prefix.len()..].is_empty()
-                || value.contains("..")
-                || value.contains(['\'', ';', '\r', '\n'])
-            {
-                return Err(ConfigError::Invalid {
-                    field: "volume_mount_path",
-                    detail: format!("must be a child of {prefix}"),
-                });
-            }
+            value.to_ascii_lowercase().starts_with(&prefix.to_ascii_lowercase())
+                && value.len() > prefix.len()
+                && !value.contains("..")
+                && !value.contains(['\'', ';', '\r', '\n'])
+        });
+        if !is_valid_mount {
+            return Err(ConfigError::Invalid {
+                field: "volume_mount_path",
+                detail: format!("must be a child of {}", r"C:\ProgramData\RamShared\mounts\"),
+            });
         }
         if self.tenant.is_empty() {
             return Err(ConfigError::Invalid {

--- a/crates/ramshared-winsvc/src/config.rs
+++ b/crates/ramshared-winsvc/src/config.rs
@@ -191,7 +191,9 @@ impl WinDriveConfig {
         let is_valid_mount = self.volume_mount_path.as_ref().is_none_or(|path| {
             let value = path.to_string_lossy().replace('/', "\\");
             let prefix = r"C:\ProgramData\RamShared\mounts\";
-            value.to_ascii_lowercase().starts_with(&prefix.to_ascii_lowercase())
+            value
+                .to_ascii_lowercase()
+                .starts_with(&prefix.to_ascii_lowercase())
                 && value.len() > prefix.len()
                 && !value.contains("..")
                 && !value.contains(['\'', ';', '\r', '\n'])


### PR DESCRIPTION
## Resumo
Flatten nested config validation branches in `config.rs` into early guard exits to adhere to Clean Architecture Principle 1 (Guard Clauses over nested if/else). 

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor: flatten nested config validation branches into early guard exits | Replaced `if let Some` and nested `if` with `is_none_or` guard pattern | To improve readability and adhere to the architectural rules of guard clauses | Reduces branching and keeps happy path at root indentation level |

## Issue
None

## Responsavel
Jules

## Labels
type:refactor

## Validacao
cargo clippy -p ramshared-winsvc -- -D warnings && cargo test -p ramshared-winsvc

## Rollback trigger
Any failure during service deployment when parsing config.

---
*PR created automatically by Jules for task [5598946271603433406](https://jules.google.com/task/5598946271603433406) started by @emersonbusson*