### PR TITLE
refactor(ramshared-dxg): flatten nested if/else in validate_query

### DIFF
--- a/crates/ramshared-dxg/src/lib.rs
+++ b/crates/ramshared-dxg/src/lib.rs
@@ -267,12 +267,12 @@ fn validate_enum(request: &uapi::EnumAdapters2, capacity: Option<usize>) -> Resu
 
 fn validate_query(query: &uapi::QueryVideoMemoryInfo) -> Result<(), DxgError> {
     if query.process != 0 {
-        Err(DxgError::Malformed("process"))
-    } else if query.adapter == 0 {
-        Err(DxgError::Malformed("adapter"))
-    } else {
-        Ok(())
+        return Err(DxgError::Malformed("process"));
     }
+    if query.adapter == 0 {
+        return Err(DxgError::Malformed("adapter"));
+    }
+    Ok(())
 }
 
 fn close_adapter(file: &File, handle: u32) {


### PR DESCRIPTION
## Resumo
Refactored `validate_query` to use early-return guard clauses instead of nested if/else logic, adhering to the Clean Architecture principles for guard clauses and root indentation for the happy path.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(ramshared-dxg): flatten nested if/else in validate_query | Flattened if/else in `validate_query` | Enforce Guard Clauses principle | Converted nested logic to early returns |
## Issue
None
## Responsavel
Jules
## Labels
type:refactor
## Validacao
cargo test -p ramshared-dxg && cargo clippy -- -D warnings
## Rollback trigger
Any regression in DXG parsing causing tests or runtime failure.

---
*PR created automatically by Jules for task [3223561567417473646](https://jules.google.com/task/3223561567417473646) started by @emersonbusson*