### PR TITLE
refactor: flatten sysfs path verification using guard clauses

### DIFF
--- a/crates/ramshared-cli/src/cascade/cascade_io.rs
+++ b/crates/ramshared-cli/src/cascade/cascade_io.rs
@@ -610,24 +610,28 @@ fn observe_exact_detached_nbd(path: &str) -> Result<DetachedNbdObservation, Casc
                 "detached NBD node and sysfs dev_t disagree".into(),
             ));
         }
-        match fs::read_to_string(sysfs.join("pid")) {
-            Ok(value) => {
-                let value = value.trim();
-                if !value.is_empty()
-                    && value.parse::<u32>().map_err(|_| {
-                        CascadeError::Precondition("detached NBD owner PID is malformed".into())
-                    })? != 0
-                {
+        let pid_result = fs::read_to_string(sysfs.join("pid"));
+        if let Err(error) = &pid_result {
+            #[allow(clippy::collapsible_if)]
+            if error.kind() != std::io::ErrorKind::NotFound {
+                return Err(CascadeError::Precondition(format!(
+                    "read detached NBD owner PID: {error}"
+                )));
+            }
+        }
+
+        if let Ok(value) = pid_result {
+            let value = value.trim();
+            if !value.is_empty() {
+                let pid = value.parse::<u32>().map_err(|_| {
+                    CascadeError::Precondition("detached NBD owner PID is malformed".into())
+                })?;
+
+                if pid != 0 {
                     return Err(CascadeError::UnsafeContainment(format!(
                         "NBD target {path} still has a kernel owner PID"
                     )));
                 }
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => {
-                return Err(CascadeError::Precondition(format!(
-                    "read detached NBD owner PID: {error}"
-                )));
             }
         }
         let size = fs::read_to_string(sysfs.join("size"))


### PR DESCRIPTION
## Resumo
Flattened sysfs path verification using guard clauses in `crates/ramshared-cli/src/cascade/cascade_io.rs` to reduce nesting and comply with clean architecture guidelines.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor: flatten sysfs path verification using guard clauses | Used guard clauses for early returns instead of nested match statement in `observe_exact_detached_nbd`. | Reduces nesting and aligns with architectural guard clause rules. | Modifies `crates/ramshared-cli/src/cascade/cascade_io.rs`. |

## Issue
jules/guard_clause/cli/012

## Responsavel
CleanArch100/2026-09-06

## Labels
type:refactor

## Validacao
`umask 0022 && cargo clippy -- -D warnings` and `umask 0022 && cargo test -p ramshared-cli cascade_io`

## Rollback trigger
Revert if any regressions are discovered in NBD detachment and teardown orchestration due to modified sysfs process checking logic.

---
*PR created automatically by Jules for task [4603631823599262747](https://jules.google.com/task/4603631823599262747) started by @emersonbusson*