### PR TITLE
docs: report existing compliance for protocol guard clauses

### DIFF
--- a/docs/jules/findings/016-guard-clause-block.md
+++ b/docs/jules/findings/016-guard-clause-block.md
@@ -1,0 +1,39 @@
+FINDING_ONLY: The requested refactoring to flatten block protocol packet parsing into guard clauses in `crates/ramshared-block/src/protocol.rs` is an architectural trap.
+
+**Evidence:**
+An analysis of `crates/ramshared-block/src/protocol.rs` reveals that there is no deeply nested if/else logic present in the packet parsing functionality.
+
+1. **`parse_request` Function:** This is the only packet parsing function in the file. It already implements linear guard clauses correctly:
+   ```rust
+   pub fn parse_request(buf: &[u8]) -> Result<Request, ProtocolError> {
+       if buf.len() < REQUEST_LEN {
+           return Err(ProtocolError::TruncatedPayload {
+               got: buf.len(),
+               need: REQUEST_LEN,
+           });
+       }
+       let magic = be32(&buf[0..4]);
+       if magic != NBD_REQUEST_MAGIC {
+           return Err(ProtocolError::InvalidHeader(magic));
+       }
+       Ok(Request { ... })
+   }
+   ```
+2. **`Command::from_u16` Function:** This function uses a flat `match` statement, not nested if/else logic:
+   ```rust
+   impl Command {
+       pub fn from_u16(v: u16) -> Self {
+           match v {
+               0 => Command::Read,
+               1 => Command::Write,
+               2 => Command::Disc,
+               3 => Command::Flush,
+               4 => Command::Trim,
+               other => Command::Unknown(other),
+           }
+       }
+   }
+   ```
+
+**Conclusion:**
+The target file `crates/ramshared-block/src/protocol.rs` already fully complies with the "Guard Clauses" architectural principle. The code correctly validates pre-requisites and aborts immediately on invalid inputs with early returns, keeping the happy path at the root indentation level. No further refactoring can be applied to this file without introducing arbitrary or detrimental changes.


### PR DESCRIPTION
## Resumo
Documented that crates/ramshared-block/src/protocol.rs already uses linear guard clauses for packet parsing and does not contain deeply nested if-else logic.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| docs: report existing compliance for protocol guard clauses | Created FINDING_ONLY report | Code already compliant | Documented in docs/jules/findings/016-guard-clause-block.md |
## Issue
016
## Responsavel
Jules
## Labels
type:docs
## Validacao
cargo test -p ramshared-block && cargo clippy -p ramshared-block -- -D warnings
## Rollback trigger
Revert if this finding is incorrect and refactoring was actually needed.

---
*PR created automatically by Jules for task [7838271495011638785](https://jules.google.com/task/7838271495011638785) started by @emersonbusson*