### PR TITLE
refactor: flatten connection handshake loop with early error guard returns

### DIFF
--- a/crates/ramshared-wsl2d/src/conn.rs
+++ b/crates/ramshared-wsl2d/src/conn.rs
@@ -135,13 +135,11 @@ pub fn spawn_reader<S: Read + Send + 'static, W2: Write + Send + 'static>(
 ) -> JoinHandle<()> {
     std::thread::spawn(move || {
         let mut reader = BufReader::new(stream);
-        let idx = match server_handshake(&mut reader, &mut hs_writer, &exports, tx_flags) {
-            Ok(i) => i,
-            Err(e) => {
-                eprintln!("[ramsharedd] conn: handshake failed: {e}");
-                let _ = jobs.send(WMsg::Closed);
-                return;
-            }
+        let Ok(idx) = server_handshake(&mut reader, &mut hs_writer, &exports, tx_flags).inspect_err(|e| {
+            eprintln!("[ramsharedd] conn: handshake failed: {e}");
+            let _ = jobs.send(WMsg::Closed);
+        }) else {
+            return;
         };
 
         drop(hs_writer); // handshake completed; from here on only the writer thread writes replies.
@@ -152,12 +150,10 @@ pub fn spawn_reader<S: Read + Send + 'static, W2: Write + Send + 'static>(
             if reader.read_exact(&mut hdr).is_err() {
                 break; // EOF or socket error
             }
-            let req = match parse_request(&hdr) {
-                Ok(r) => r,
-                Err(e) => {
-                    eprintln!("[ramsharedd] conn: malformed request: {e}; disconnecting");
-                    break;
-                }
+            let Ok(req) = parse_request(&hdr).inspect_err(|e| {
+                eprintln!("[ramsharedd] conn: malformed request: {e}; disconnecting");
+            }) else {
+                break;
             };
             // Anti-DoS: a WRITE can never exceed the negotiated export (prevents allocating gigabytes).
             if req.cmd == Command::Write && req.len as u64 > export_size {


### PR DESCRIPTION
## Resumo
Flatten connection handshake loop in conn.rs to use guard clauses instead of nested if/else.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor: flatten connection handshake loop with early error guard returns | Flattened connection handshake loop | Guard Clauses | Used early return pattern to avoid deep nesting. |

## Issue
N/A

## Responsavel
Jules

## Labels
type:refactor

## Validacao
umask 0022 && cargo test -p ramshared-wsl2d
cargo clippy -p ramshared-wsl2d -- -D warnings

## Rollback trigger
Tests failing or CI breaking.

---
*PR created automatically by Jules for task [6715439127108153174](https://jules.google.com/task/6715439127108153174) started by @emersonbusson*