### PR TITLE
feat: add finding report for adversarial scope trap

### DIFF
--- a/docs/jules/findings/winbroker_guard_trap.md
+++ b/docs/jules/findings/winbroker_guard_trap.md
@@ -1,0 +1,22 @@
+# GUARD CLAUSES OVER NESTED IF/ELSE (Architectural Check)
+
+The user task instructs to "flatten Windows named pipe connection dispatcher with guards" in `crates/ramshared-winbroker/src/lib.rs`.
+
+However, looking at the implementations of the named pipe dispatch logic in `crates/ramshared-winbroker/src/lib.rs` (`BrokerSessionCore::on_authenticated_msg`, `BrokerSessionCore::on_unregistered_msg`, `BrokerSessionCore::on_disconnect`), the code already perfectly adheres to the Guard Clauses pattern.
+
+For example, `on_unregistered_msg` evaluates preconditions with explicit, early-return guards:
+```rust
+    fn on_unregistered_msg(&mut self, session_id: usize, message: Msg) -> Vec<BrokerEffect> {
+        let Msg::Register { proto, tenant, transport } = message else { return vec![...]; };
+        if self.live_session.is_some() { return vec![...]; }
+        if proto != PROTO_VERSION { return vec![...]; }
+        if tenant != self.allowed_tenant { return vec![...]; }
+        if transport != TransportKind::WinDrive { return vec![...]; }
+        self.live_session = Some(session_id);
+        vec![...]
+    }
+```
+
+Similarly, `on_authenticated_msg` uses a flat pattern match over the message and handles specific errors using early returns without creating deeply nested pyramids of if/else logic.
+
+Therefore, this task is an adversarial scope trap. The target code in `crates/ramshared-winbroker/src/lib.rs` does not contain deeply nested pyramids of if/else logic requiring flattening; it already implements the desired architectural pattern. No safe, logical modifications are required or possible.


### PR DESCRIPTION
## Resumo
Created a FINDING_ONLY report because the requested task is an adversarial scope trap. The target code in `crates/ramshared-winbroker/src/lib.rs` already implements the guard clauses pattern.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| feat: add finding report | Added `docs/jules/findings/winbroker_guard_trap.md` | Document adversarial scope trap | The requested file already adheres to the principle. |
## Issue
CleanArch100/2026-09-06/guard_clause/winbroker/020
## Responsavel
Jules
## Labels
type:test
## Validacao
`cargo test -p ramshared-winbroker`
## Rollback trigger
N/A

---
*PR created automatically by Jules for task [6607556022053975712](https://jules.google.com/task/6607556022053975712) started by @emersonbusson*