### PR TITLE
docs: add finding report for vram_impl.rs guard clause trap

### DIFF
--- a/docs/jules/findings/cuda_guard_clause_trap.md
+++ b/docs/jules/findings/cuda_guard_clause_trap.md
@@ -1,0 +1,12 @@
+# Finding: Target code does not have nested structures needing flattening
+## Context
+The instruction requested to "flatten device pointer allocation and mapping with guard clauses" inside `crates/ramshared-cuda/src/vram_impl.rs` and associated test files, specifically aiming to "Validate device memory pointers and stream status with early return guards".
+
+## Evidence
+- `crates/ramshared-cuda/src/vram_impl.rs` is merely a trait implementation delegating to the `driver.rs` module and handling basic error conversion. There is no device allocation logic or memory mapping inside `vram_impl.rs` (it calls `Context::alloc(self, bytes)`).
+- `crates/ramshared-cuda/src/driver.rs` handles the actual allocation and mapping, and error handling already uses the `?` operator (which is an idiomatic Rust early-return pattern) or small, single-level match/if statements without deep nested "pyramids".
+- The task requests flattening nested if/else for pointers/streams, but `vram_impl.rs` simply doesn't contain this logic.
+- Even in `crates/ramshared-cuda/src/driver.rs`, the `check` function and `mem_alloc`/`memcpy_htod` calls are linear with no nesting. There are no "stream status" checks as streams aren't explicitly manipulated (it uses synchronous API like `memset_d8` and `memcpy_htod`).
+
+## Conclusion
+This appears to be an adversarial scope trap matching the memory rule regarding refactoring targets that do not actually contain the logic to be refactored (e.g., traits vs concrete implementations). I have generated this `FINDING_ONLY` report as mandated by the IMMUTABLE CONTRACT rule #4.


### PR DESCRIPTION
## Resumo
The instruction requested flattening device pointer allocation and mapping with guard clauses in `crates/ramshared-cuda/src/vram_impl.rs`. However, this file only implements abstract traits (`VramMemory`, `VramProvider`) and does not contain allocation or mapping logic, which resides in `driver.rs` and already uses early returns (the `?` operator). A FINDING_ONLY report was generated to document this architectural mismatch.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| docs: add finding report for vram_impl.rs guard clause trap | Added FINDING_ONLY report. | To document the adversarial trap requesting refactoring of non-existent logic in `vram_impl.rs`. | Created `docs/jules/findings/cuda_guard_clause_trap.md`. |

## Issue
N/A

## Responsavel
Jules

## Labels
type:docs

## Validacao
`cargo test -p ramshared-cuda` and `cargo clippy -p ramshared-cuda -- -D warnings`

## Rollback trigger
Any CI/CD pipeline failure or review rejection.

---
*PR created automatically by Jules for task [15125207776854996725](https://jules.google.com/task/15125207776854996725) started by @emersonbusson*