### PR TITLE
docs: add FINDING_ONLY report for config parsing trap

### DIFF
--- a/docs/jules/findings/guard_clauses_config.md
+++ b/docs/jules/findings/guard_clauses_config.md
@@ -1,0 +1,42 @@
+# FINDING_ONLY: Config Section Parsing
+
+## Context
+The task requires decomposing nested parser logic for missing required keys into sequential guard clauses in `crates/ramshared-config/src/lib.rs`.
+
+## Finding
+The configuration parsing in `crates/ramshared-config/src/lib.rs` is implemented using declarative Serde derivation (`#[derive(Deserialize)]`) and default attributes (`#[serde(default = "...")]`). The actual TOML parsing is delegated to `toml::from_str`. There is no custom procedural parsing logic or nested if/else statements for missing required keys to flatten. Thus, the requested refactoring is an architectural mismatch/trap.
+
+## Evidence
+```rust
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct Config {
+    #[serde(default)]
+    pub broker: BrokerConfig,
+    #[serde(default)]
+    pub agent: AgentConfig,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct BrokerConfig {
+    #[serde(default = "default_listen")]
+    pub listen: String,
+    #[serde(default = "default_slices")]
+    pub slices: u16,
+    #[serde(default = "default_slice_mib")]
+    pub slice_mib: u64,
+    #[serde(default = "default_backend")]
+    pub backend: String,
+}
+
+// ...
+
+impl Config {
+    pub fn parse(text: &str) -> Result<Self, ConfigError> {
+        toml::from_str(text).map_err(|err| {
+            // ... error handling
+        })
+    }
+}
+```


### PR DESCRIPTION
## Resumo
Added a FINDING_ONLY report for the configuration parsing logic. The task requested to decompose nested parser logic for missing required keys into guard clauses. However, `crates/ramshared-config/src/lib.rs` uses declarative `serde::Deserialize` and `#[serde(default)]` attributes. There is no custom procedural parsing logic to flatten, rendering the requested refactoring an architectural mismatch/trap.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 4cde80595b40cfe3e8463967167ae29478a4cb8c | docs: add FINDING_ONLY report for config parsing trap | Document the architectural trap | The file uses Serde derive rather than nested parsing logic |

## Issue
N/A

## Responsavel
Jules

## Labels
type:docs, area:finding

## Validacao
`cargo test -p ramshared-config`
`cargo clippy -p ramshared-config -- -D warnings`

## Rollback trigger
If the documentation is found to be incorrect or if the findings are rejected.

---
*PR created automatically by Jules for task [7699637590455186000](https://jules.google.com/task/7699637590455186000) started by @emersonbusson*