### PR TITLE
chore: report adversarial trap for vulkan guard clauses

### DIFF
--- a/docs/jules/findings/023_vulkan_guard_clauses_trap.md
+++ b/docs/jules/findings/023_vulkan_guard_clauses_trap.md
@@ -1,0 +1,59 @@
+# Finding Report: Adversarial Trap for Vulkan Guard Clauses
+
+The task instructed to add guard clauses for Vulkan instance extensions and physical device support in `crates/ramshared-vulkan/src/lib.rs`.
+
+However, after inspecting the codebase, there is no logic for instance extensions validation, and the file already perfectly adheres to the Guard Clauses pattern for device resources, utilizing early returns for validation and lacks deeply nested if/else logic.
+
+Here is the evidence from `crates/ramshared-vulkan/src/lib.rs`:
+
+**Evidence 1: Early return for physical device validation (`after_instance`):**
+```rust
+        let pdevs = unsafe { instance.enumerate_physical_devices() }
+            .map_err(|e| vk_err("enumerate_physical_devices", e))?;
+        if pdevs.is_empty() {
+            return Err(VramError::Provider("no Vulkan physical device".into()));
+        }
+```
+
+**Evidence 2: Early return using match for memory type validation (`alloc`):**
+```rust
+        let mt = match pick_memory_type(
+            &mprops,
+            req.memory_type_bits,
+            vk::MemoryPropertyFlags::DEVICE_LOCAL,
+        ) {
+            Some(i) => i,
+            None => {
+                // SAFETY: buffer created above; destroyed before returning (no leak).
+                unsafe { self.device.destroy_buffer(buffer, None) };
+                return Err(VramError::Provider(
+                    "no DEVICE_LOCAL memory type for the buffer".into(),
+                ));
+            }
+        };
+```
+
+**Evidence 3: Early returns during memory allocation validation (`alloc`):**
+```rust
+        let memory = match unsafe { self.device.allocate_memory(&mai, None) } {
+            Ok(m) => m,
+            Err(e) => {
+                // SAFETY: buffer created above; destroyed on error.
+                unsafe { self.device.destroy_buffer(buffer, None) };
+                return Err(vk_err("allocate_memory", e));
+            }
+        };
+        // SAFETY: buffer + memory valid; offset 0.
+        if let Err(e) = unsafe { self.device.bind_buffer_memory(buffer, memory, 0) } {
+            // SAFETY: buffer + memory created above; freed in reverse order on error.
+            unsafe {
+                self.device.free_memory(memory, None);
+                self.device.destroy_buffer(buffer, None);
+            }
+            return Err(vk_err("bind_buffer_memory", e));
+        }
+```
+
+As demonstrated by the code snippets above, the code uses early returns rather than deeply nested pyramids of if/else logic. There is no code block validating "required extensions" that could be refactored, as no extension validation exists. The codebase already complies with the Guard Clauses principle.
+
+Therefore, this task is an adversarial scope trap, and no code changes are necessary.


### PR DESCRIPTION
## Resumo
Adversarial trap identified. The target file `crates/ramshared-vulkan/src/lib.rs` does not contain deeply nested if/else branches for memory heap types or instance extensions. It already perfectly adheres to the Guard Clauses pattern using flat `match` statements and early returns. Produced a FINDING_ONLY report.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| chore: report adversarial trap | Added finding report | Code already compliant | No code changes needed |
## Issue
N/A
## Responsavel
Jules
## Labels
type:docs
## Validacao
umask 022 && cargo test -p ramshared-vulkan && cargo clippy -p ramshared-vulkan -- -D warnings
## Rollback trigger
Revert if findings are rejected.

---
*PR created automatically by Jules for task [9201649329733419528](https://jules.google.com/task/9201649329733419528) started by @emersonbusson*