### PR TITLE
test(tier): document NBD readiness probe trap

### DIFF
--- a/docs/jules/findings/nbd_readiness_probe_trap.md
+++ b/docs/jules/findings/nbd_readiness_probe_trap.md
@@ -1,0 +1,55 @@
+# Finding Report: NBD Socket Readiness and Probe Timeout Guard Clauses
+
+## Target
+`crates/ramshared-tier/src/nbd_readiness.rs`
+
+## Objective
+Validate socket descriptor and connection state with guard clauses.
+
+## Findings
+The requested objective represents an architectural mismatch trap. The `crates/ramshared-tier/src/nbd_readiness.rs` module explicitly operates as a pure policy evaluator that "does not inspect the host or perform lifecycle actions."
+
+1. **Absence of Socket Operations:**
+   The file contains no socket operations, descriptors, or network connections. It only defines policy evaluation functions that process a static `ProductInput` observation struct.
+
+   ```rust
+   // From crates/ramshared-tier/src/nbd_readiness.rs:
+   //! Pure WSL2 NBD product readiness policy.
+   //!
+   //! This module does not inspect the host or perform lifecycle actions. Callers
+   //! provide a fresh observation and receive one stable state and reason.
+   ```
+
+2. **No Probe Implementations:**
+   The only reference to a "probe" or "timeout" is the `NbdReadinessError` enum, which is just an error type definition and not an active network probe function with nested logic.
+
+   ```rust
+   /// Semantic error for NBD probe connection failures.
+   #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+   pub enum NbdReadinessError {
+       /// Connection was refused (ECONNREFUSED).
+       ConnectionRefused,
+       /// Connection timed out (ETIMEDOUT).
+       Timeout,
+       /// Any other IO error kind.
+       Other(std::io::ErrorKind),
+   }
+   ```
+
+3. **Existing Guard Clauses Compliance:**
+   The existing evaluation functions in the file, such as `evaluate_product` and `validate_lower_tier_capacity`, already strictly adhere to the Guard Clauses pattern, utilizing linear early returns rather than deeply nested `if/else` logic.
+
+   ```rust
+   pub fn evaluate_product(input: &ProductInput) -> ProductDecision {
+       if input.reboot_requested {
+           return ProductDecision::blocked(RefusalCode::RebootRequested);
+       }
+       if input.operation.is_mutating() && input.approval != Approval::Present {
+           return ProductDecision::blocked(RefusalCode::ApprovalMissing);
+       }
+       // ... additional flat early returns ...
+   }
+   ```
+
+## Conclusion
+Since the target file performs no live socket probing and lacks nested logic to flatten, it is impossible to implement the requested code change. A `FINDING_ONLY` report is provided instead, leaving the source code untouched.


### PR DESCRIPTION
## Resumo
Produces a FINDING_ONLY report as `crates/ramshared-tier/src/nbd_readiness.rs` is a pure policy evaluator that does not inspect the host or perform lifecycle actions. It has no socket operations or probe functions with nested logic to refactor. Existing logic already perfectly complies with Guard Clauses.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| (current) | Added FINDING_ONLY report | To document the adversarial scope trap | Documented absence of socket operations in nbd_readiness.rs |

## Issue
CleanArch100/2026-09-06/guard_clause/tier/031

## Responsavel
jules

## Labels
type:test
area:tier

## Validacao
cargo test -p ramshared-tier && cargo clippy -- -D warnings

## Rollback trigger
If the report is found to be incorrect.

---
*PR created automatically by Jules for task [13531209425530159360](https://jules.google.com/task/13531209425530159360) started by @emersonbusson*