### PR TITLE
docs(audit): publish finding for adversarial guard clause task

### DIFF
--- a/docs/jules/findings/017-guard-clauses.md
+++ b/docs/jules/findings/017-guard-clauses.md
@@ -1,0 +1,31 @@
+# FINDING_ONLY: Guard Clauses for extent boundaries and sector alignment
+
+The file `crates/ramshared-block/src/request.rs` already correctly validates extent boundaries against physical limits and sector alignment. Specifically, the function `validate` performs these checks using guard clauses that return immediately on failure:
+
+```rust
+fn validate<B: BlockBackend + ?Sized>(req: &Request, backend: &B) -> Result<(), u32> {
+    let bs = backend.block_size() as u64;
+    if bs == 0 {
+        return Err(NBD_EINVAL);
+    }
+    // Sector alignment validation
+    if !req.offset.is_multiple_of(bs) {
+        return Err(NBD_EINVAL);
+    }
+    if !(req.len as u64).is_multiple_of(bs) {
+        return Err(NBD_EINVAL);
+    }
+
+    // Extent bounds validation against physical context (device capacity)
+    let Some(end) = req.offset.checked_add(req.len as u64) else {
+        return Err(NBD_ERANGE);
+    };
+    if end > backend.size_bytes() {
+        return Err(NBD_ERANGE);
+    }
+
+    // ...
+}
+```
+
+Since the target file already applies the principle with precision and contains the required specific & semantic error returns (e.g. `NBD_EINVAL` for unaligned inputs, and `NBD_ERANGE` for bounds exceedance), attempting to refactor this file further would introduce an architectural mismatch or redundant logic. This task has been identified as an adversarial trap. Therefore, this FINDING_ONLY report is produced as evidence.


### PR DESCRIPTION
## Resumo
Acknowledged an adversarial trap task requesting refactoring of `crates/ramshared-block/src/request.rs` for guard clauses. The file is already perfectly compliant. Produced a `FINDING_ONLY` report in `docs/jules/findings/017-guard-clauses.md`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| docs(audit): add FINDING_ONLY report for guard clauses | Added `017-guard-clauses.md` | Task requested refactoring already compliant code. | Produced report to satisfy adversarial task constraints. |

## Issue
N/A

## Responsavel
Jules

## Labels
type:docs

## Validacao
`cargo test -p ramshared-block` and `cargo clippy -- -D warnings`

## Rollback trigger
Revert if documentation breaks any CI checks.

---
*PR created automatically by Jules for task [17509066558546777555](https://jules.google.com/task/17509066558546777555) started by @emersonbusson*