### PR TITLE
refactor: apply guard clauses to block request handler

### DIFF
--- a/crates/ramshared-wsl2d/src/ublk_server.rs
+++ b/crates/ramshared-wsl2d/src/ublk_server.rs
@@ -83,20 +83,19 @@ pub fn serve_request<B: BlockBackend + ?Sized>(
         return EINVAL;
     }
 
-    // Physical bounds guard
-    if req
-        .offset
-        .checked_add(req.len as u64)
-        .is_none_or(|end| end > backend.size_bytes())
-    {
-        return EINVAL;
-    }
-
     // Command guard
     if !matches!(
         req.cmd,
         Command::Read | Command::Write | Command::Flush | Command::Trim
     ) {
+        return EINVAL;
+    }
+
+    // Physical bounds guard
+    let Some(end) = req.offset.checked_add(req.len as u64) else {
+        return EINVAL;
+    };
+    if end > backend.size_bytes() {
         return EINVAL;
     }
 
@@ -111,10 +110,10 @@ pub fn serve_request<B: BlockBackend + ?Sized>(
         _ => unreachable!(),
     };
 
-    match served {
-        Ok(bytes) => i32::try_from(bytes).unwrap_or(EIO),
-        Err(_) => EIO,
-    }
+    let Ok(bytes) = served else {
+        return EIO;
+    };
+    i32::try_from(bytes).unwrap_or(EIO)
 }
 
 /// Handle of the ublk server thread; `join` waits for the loop to terminate (upon receiving the
@@ -394,12 +393,9 @@ fn dispatch_request<S: QueueServer>(
     let snapshot = server.io_desc_snapshot(tag)?;
     let iod = ublk::IoDesc::from_ne_bytes(&snapshot)
         .ok_or_else(|| io::Error::other("invalid io-desc snapshot"))?;
-    let req = match iod.to_block_request(tag) {
-        Ok(req) => req,
-        Err(_) => {
-            server.commit_and_fetch(tag, -22)?; // EINVAL (no buffer taken from the pool)
-            return Ok(false);
-        }
+    let Ok(req) = iod.to_block_request(tag) else {
+        server.commit_and_fetch(tag, -22)?; // EINVAL (no buffer taken from the pool)
+        return Ok(false);
     };
 
     // Takes a recycled buffer and sizes it to `len`. `unwrap_or_default` only allocates during


### PR DESCRIPTION
## Resumo
Refactored `ublk_server.rs` to enforce the architectural principle of using early guard clauses instead of nested logic. Implemented physical limit sanity checks on block bounds using `let else` blocks, validated opcodes via explicit `matches!` guard, and flattened the main matching block with early returns. Note that buffer non-nullness is inherently enforced by safe Rust's `&mut [u8]` reference bounds without explicit runtime checks needed beyond slice bounds checking.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor: apply guard clauses | Replaced nested `match` statements with `let else` and `if let` blocks. Updated physical bounds `is_none_or` check to a guard pattern. | To enforce the guard clause architectural principle and eliminate deeply nested `if/else` pyramids in critical block serving paths. | `crates/ramshared-wsl2d/src/ublk_server.rs` |

## Issue
N/A

## Responsavel
Jules

## Labels
type:refactor

## Validacao
`cargo test -p ramshared-wsl2d` and `cargo clippy -p ramshared-wsl2d -- -D warnings` executed successfully. Verified that all unit tests covering bounds checking and opcode refusals pass.

## Rollback trigger
Any unexpected block rejection or runtime panic when evaluating IO request parameters or opcodes in the data path.

---
*PR created automatically by Jules for task [14711223880885275535](https://jules.google.com/task/14711223880885275535) started by @emersonbusson*