### PR TITLE
docs: add finding report for cascade tier validation

### DIFF
--- a/docs/jules/findings/cascade_validation.md
+++ b/docs/jules/findings/cascade_validation.md
@@ -1,0 +1,51 @@
+# FINDING_ONLY: cascade tier allocation validation
+
+## Concrete Evidence & Analysis
+
+The requested objective is to validate tier allocation size against physical RAM and vRAM capacity to reject requested tier allocations that exceed total detected physical host memory by applying Physical Limits Sanity Checks in `crates/ramshared-tier/src/cascade.rs`.
+
+Upon comprehensive analysis of `crates/ramshared-tier/src/cascade.rs`, the file already perfectly adheres to the required defensive programming pattern.
+
+The validation function `validate_tier_resize` currently uses early-return guard clauses to reject sizes that exceed bounds, using precise domain-typed error values:
+
+```rust
+/// Validates that a requested tier resize is within physical hardware limits.
+pub fn validate_tier_resize(
+    tier: Tier,
+    requested_bytes: u64,
+    host_ram_bytes: u64,
+    vram_capacity_bytes: u64,
+) -> Result<(), ResizeError> {
+    if requested_bytes > host_ram_bytes {
+        return Err(ResizeError::ExceedsHostRamCapacity);
+    }
+    if tier == Tier::Vram && requested_bytes > vram_capacity_bytes {
+        return Err(ResizeError::ExceedsVramCapacity);
+    }
+    Ok(())
+}
+```
+
+The error returned (`ResizeError`) is a rich domain-typed enum with explanatory display traits, fully complying with SPECIFIC & SEMANTIC ERROR RETURNS principle.
+
+Furthermore, the physical hardware limit constraints are fully tested in existing RED_TESTs like `tier_resize_exceeding_host_ram_fails`:
+
+```rust
+#[test]
+fn tier_resize_exceeding_host_ram_fails() {
+    assert_eq!(
+        validate_tier_resize(Tier::Zram, GIB + 1, GIB, GIB),
+        Err(ResizeError::ExceedsHostRamCapacity)
+    );
+    assert_eq!(
+        validate_tier_resize(Tier::Vram, GIB + 1, GIB, 2 * GIB),
+        Err(ResizeError::ExceedsHostRamCapacity)
+    );
+    assert_eq!(
+        validate_tier_resize(Tier::Vhdx, 2 * GIB, GIB, GIB),
+        Err(ResizeError::ExceedsHostRamCapacity)
+    );
+}
+```
+
+As the requested feature is already implemented and compliant with the Physical Limits Sanity Checks and Guard Clauses principles, no code changes are necessary. This request represents an adversarial scope trap.


### PR DESCRIPTION
## Resumo
Adds a FINDING_ONLY report documenting that `crates/ramshared-tier/src/cascade.rs` already validates tier allocation sizes against physical RAM and vRAM capacity. The file currently employs early-return guard clauses for these exact checks, meaning the requested implementation is an adversarial scope trap.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| a12ef587aebda626fdaa71b66e2b789eaebe1176 | docs: add finding report for cascade tier validation | Document existing compliance with physical limit sanity checks | Shows concrete evidence of existing `validate_tier_resize` guard clauses |

## Issue
N/A

## Responsavel
jules

## Labels
type:docs, area:tier

## Validacao
umask 0022 && cargo test && cargo clippy -- -D warnings

## Rollback trigger
If the findings report misrepresents the codebase or if additional validations are actually missing.

---
*PR created automatically by Jules for task [2658345315196851525](https://jules.google.com/task/2658345315196851525) started by @emersonbusson*