### PR TITLE
feat(cuda): validate context handle and device ordinal with early return guards

### DIFF
--- a/crates/ramshared-cuda/src/driver.rs
+++ b/crates/ramshared-cuda/src/driver.rs
@@ -29,6 +29,8 @@ pub enum CudaError {
     },
     /// VRAM memory region access out of bounds (offset + len > size).
     OutOfRange { off: usize, len: usize, size: usize },
+    /// Invalid input or context state.
+    InvalidInput(&'static str),
 }
 
 impl fmt::Display for CudaError {
@@ -41,6 +43,9 @@ impl fmt::Display for CudaError {
             }
             CudaError::OutOfRange { off, len, size } => {
                 write!(f, "out of bounds access: off={off} len={len} > size={size}")
+            }
+            CudaError::InvalidInput(msg) => {
+                write!(f, "invalid input: {msg}")
             }
         }
     }
@@ -134,6 +139,13 @@ impl Cuda {
 
     /// Gets the device handle for the specified `ordinal` index, resolving its name.
     pub fn device(&self, ordinal: i32) -> Result<Device, CudaError> {
+        if ordinal < 0 {
+            return Err(CudaError::InvalidInput("device ordinal cannot be negative"));
+        }
+        if ordinal >= self.device_count()? {
+            return Err(CudaError::InvalidInput("device ordinal out of bounds"));
+        }
+
         let mut raw: CuDevice = 0;
         // SAFETY: raw points to a valid local memory location.
         let r = unsafe { (self.syms.device_get)(&mut raw, ordinal) };
@@ -160,6 +172,9 @@ impl Cuda {
         // SAFETY: raw points to a valid local; device.raw is a valid CUdevice handle.
         let r = unsafe { (self.syms.ctx_create)(&mut raw, 0, device.raw) };
         check(&self.syms, r, "cuCtxCreate")?;
+        if raw.is_null() {
+            return Err(CudaError::InvalidInput("CUDA context handle is null"));
+        }
         Ok(Context { cuda: self, raw })
     }
 }

--- a/crates/ramshared-cuda/src/lib.rs
+++ b/crates/ramshared-cuda/src/lib.rs
@@ -58,6 +58,14 @@ mod tests {
     }
 
     #[test]
+    fn reject_invalid_device_ordinal() {
+        let e = CudaError::InvalidInput("device ordinal cannot be negative");
+        let s = e.to_string();
+        assert!(s.contains("invalid input"));
+        assert!(s.contains("negative"));
+    }
+
+    #[test]
     fn driver_error_carries_op_and_code() {
         let e = CudaError::Driver {
             op: "cuMemAlloc",


### PR DESCRIPTION
## Resumo
Refactor `crates/ramshared-cuda/src/driver.rs` to validate device ordinal and context pointer with early return guard clauses.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 7ad0f63e1aa2436159a265a941abd649bd3f9b63 | Add guard clauses in device and create_context | Adhere to CleanArchitecture rule of flattening logic | Checks added for negative and out-of-bound ordinal and null pointers |

## Issue
N/A

## Responsavel
Jules

## Labels
type:refactor, area:cuda

## Validacao
cargo test -p ramshared-cuda && cargo clippy -p ramshared-cuda -- -D warnings

## Rollback trigger
Driver initialization failure due to overly aggressive pointer or bounds checks.

---
*PR created automatically by Jules for task [15736397309695735642](https://jules.google.com/task/15736397309695735642) started by @emersonbusson*