### PR TITLE
refactor(integrity): semantic error returns for block checksum verification inputs

### DIFF
--- a/crates/ramshared-integrity/src/hash.rs
+++ b/crates/ramshared-integrity/src/hash.rs
@@ -72,32 +72,40 @@ impl ChecksumTable {
         }
     }
 
-    /// Records the hash of a written block. Returns `false` if `idx` is out of bounds or data is invalid.
-    pub fn record(&mut self, idx: usize, data: &[u8]) -> bool {
+    /// Records the hash of a written block.
+    pub fn record(&mut self, idx: usize, data: &[u8]) -> Result<(), ChecksumMismatchError> {
         if data.is_empty() || data.len() < 512 || !data.len().is_power_of_two() {
-            return false;
+            return Err(ChecksumMismatchError::InvalidBufferLength { len: data.len() });
         }
         let Some(slot) = self.sums.get_mut(idx) else {
-            return false;
+            return Err(ChecksumMismatchError::OutOfBounds { idx });
         };
         *slot = Some(block_hash(data));
-        true
+        Ok(())
     }
 
     /// Verifies the read block against the recorded hash.
-    /// `None` = never written (ok); `Some(true)` = matches; `Some(false)` =
-    /// mismatch (corruption/torn read) -> the caller returns an I/O error.
-    pub fn verify(&self, idx: usize, data: &[u8]) -> Option<bool> {
+    /// `Ok(false)` = never written (ok); `Ok(true)` = matches;
+    /// `Err` = mismatch (corruption/torn read) or invalid parameters.
+    pub fn verify(&self, idx: usize, data: &[u8]) -> Result<bool, ChecksumMismatchError> {
         if data.is_empty() || data.len() < 512 || !data.len().is_power_of_two() {
-            return Some(false);
+            return Err(ChecksumMismatchError::InvalidBufferLength { len: data.len() });
         }
         let Some(slot) = self.sums.get(idx) else {
-            return Some(false); // out of bounds = invalid
+            return Err(ChecksumMismatchError::OutOfBounds { idx });
         };
         let Some(expected) = slot else {
-            return None;
+            return Ok(false);
         };
-        Some(*expected == block_hash(data))
+        let computed = block_hash(data);
+        if *expected != computed {
+            return Err(ChecksumMismatchError::Mismatch {
+                idx,
+                expected: *expected,
+                computed,
+            });
+        }
+        Ok(true)
     }
 }
 
@@ -118,36 +126,36 @@ mod tests {
     fn table_records_and_verifies() {
         let mut t = ChecksumTable::new(8);
         let data = vec![0xABu8; 4096];
-        assert!(t.record(3, &data));
-        assert_eq!(t.verify(3, &data), Some(true));
+        assert!(t.record(3, &data).is_ok());
+        assert_eq!(t.verify(3, &data), Ok(true));
     }
 
     #[test]
     fn table_detects_corruption() {
         let mut t = ChecksumTable::new(8);
         let data = vec![0xABu8; 4096];
-        t.record(3, &data);
+        t.record(3, &data).unwrap();
         let mut corrupt = data.clone();
         corrupt[0] ^= 0xff;
-        assert_eq!(t.verify(3, &corrupt), Some(false));
+        assert_eq!(t.verify(3, &corrupt), Err(ChecksumMismatchError::Mismatch { idx: 3, expected: block_hash(&data), computed: block_hash(&corrupt) }));
     }
 
     #[test]
     fn unwritten_block_is_none_oob_is_invalid() {
         let mut t = ChecksumTable::new(2);
-        assert_eq!(t.verify(0, &[0u8; 4096]), None); // never written
-        assert_eq!(t.verify(99, &[0u8; 4096]), Some(false)); // out of bounds
-        assert!(!t.record(99, &[0u8; 4096]));
+        assert_eq!(t.verify(0, &[0u8; 4096]), Ok(false)); // never written
+        assert_eq!(t.verify(99, &[0u8; 4096]), Err(ChecksumMismatchError::OutOfBounds { idx: 99 })); // out of bounds
+        assert_eq!(t.record(99, &[0u8; 4096]), Err(ChecksumMismatchError::OutOfBounds { idx: 99 }));
     }
 
     #[test]
     fn table_rejects_empty_and_wrong_length_data() {
         let mut t = ChecksumTable::new(8);
-        assert!(!t.record(3, &[])); // empty
-        assert!(!t.record(3, &[0u8; 123])); // not power of two / < 512
+        assert_eq!(t.record(3, &[]), Err(ChecksumMismatchError::InvalidBufferLength { len: 0 })); // empty
+        assert_eq!(t.record(3, &[0u8; 123]), Err(ChecksumMismatchError::InvalidBufferLength { len: 123 })); // not power of two / < 512
 
-        assert_eq!(t.verify(3, &[]), Some(false));
-        assert_eq!(t.verify(3, &[0u8; 123]), Some(false));
+        assert_eq!(t.verify(3, &[]), Err(ChecksumMismatchError::InvalidBufferLength { len: 0 }));
+        assert_eq!(t.verify(3, &[0u8; 123]), Err(ChecksumMismatchError::InvalidBufferLength { len: 123 }));
     }
 
     #[test]
@@ -156,10 +164,10 @@ mod tests {
         let data_512 = vec![0xCDu8; 512];
         let data_65536 = vec![0xEFu8; 65536];
 
-        assert!(t.record(1, &data_512));
-        assert_eq!(t.verify(1, &data_512), Some(true));
+        assert!(t.record(1, &data_512).is_ok());
+        assert_eq!(t.verify(1, &data_512), Ok(true));
 
-        assert!(t.record(2, &data_65536));
-        assert_eq!(t.verify(2, &data_65536), Some(true));
+        assert!(t.record(2, &data_65536).is_ok());
+        assert_eq!(t.verify(2, &data_65536), Ok(true));
     }
 }


### PR DESCRIPTION
## Resumo
Refactored `ChecksumTable::record` and `verify` in `crates/ramshared-integrity/src/hash.rs` to return `Result<_, ChecksumMismatchError>` instead of generic `bool`/`Option<bool>`. This ensures specific and semantic error returns are propagated (e.g., `InvalidBufferLength`, `OutOfBounds`, `Mismatch`) instead of swallowing failure codes into `false`, adhering strictly to the defensive programming and semantic error architectural directives while perfectly preserving the existing Guard Clauses pattern on the happy path.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| refactor(integrity): semantic error returns for block checksum verification inputs | Refactored ChecksumTable record and verify to return Result<_, ChecksumMismatchError> | Eliminate generic boolean errors and swallow failures, returning precise domain types for out-of-bounds and mismatched checksums. | Replaces bool with Result<(), ChecksumMismatchError> in record() and Option<bool> with Result<bool, ChecksumMismatchError> in verify(). |

## Issue
N/A

## Responsavel
Jules

## Labels
type:refactor, type:integrity

## Validacao
```bash
cargo test --manifest-path crates/ramshared-integrity/Cargo.toml && cargo clippy --manifest-path crates/ramshared-integrity/Cargo.toml -- -D warnings
```

## Rollback trigger
Revert if dependent crates integrating `ramshared-integrity` unexpectedly break due to the stricter return signatures.

---
*PR created automatically by Jules for task [11249244045997632709](https://jules.google.com/task/11249244045997632709) started by @emersonbusson*