### PR TITLE
docs: generate FINDING_ONLY report for worker thread validation

### DIFF
--- a/docs/jules/findings/038_winsvc_worker_threads.md
+++ b/docs/jules/findings/038_winsvc_worker_threads.md
@@ -1,0 +1,18 @@
+# FINDING_ONLY: Architectural Mismatch Trap
+
+## Analysis
+The directive to "validate worker thread count against physical CPU core count" in `crates/ramshared-winsvc/src/config.rs` is an architectural mismatch trap. The RamShared Windows service is explicitly designed with a single I/O thread loop and does not utilize configurable worker threads for its core operation.
+
+## Evidence
+1. `crates/ramshared-winsvc/src/product_online.rs` (Lines 1-2):
+    //! Windows product Online composition (SPEC DT-3/DT-4/DT-7):
+    //! broker lease -> CUDA DeviceMem -> CREATE/REGISTER -> I/O loop on one thread.
+
+2. `crates/ramshared-winsvc/src/driver_link.rs` (Lines 300-301):
+    /// Service handle: owns a [`QueueAccess`] and runs the single I/O thread loop (DT-3/DT-4).
+    pub struct DriverLink<Q: QueueAccess = InMemoryQueue> {
+
+3. `crates/ramshared-winsvc/src/config.rs`: The `WinDriveConfig` struct contains no `worker_threads` field, nor does it manage any worker thread pools. Adding a validation for a non-existent field or concept contradicts the strict single-threaded architecture of the service.
+
+## Conclusion
+No modifications were made to `crates/ramshared-winsvc/src/config.rs` to enforce a physical CPU core limit on worker threads, as doing so would violate the single-threaded design of the `WinDriveConfig` product suite.


### PR DESCRIPTION
## Resumo
Identify architectural mismatch trap regarding worker thread count validation.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 27c4ba95ca1e11f73d964b5cbb6ea2ebfded8753 | Create FINDING_ONLY report | Document architectural trap | The service utilizes a single I/O thread, making worker thread validation invalid. |

## Issue
#038

## Responsavel
Jules

## Labels
type:docs, area:architecture

## Validacao
umask 0022 && cargo test -p ramshared-winsvc && cargo clippy -- -D warnings

## Rollback trigger
Any NBD identity, comparison, custody, cleanup, or repository-copy validation mismatch.

---
*PR created automatically by Jules for task [6388295735340234390](https://jules.google.com/task/6388295735340234390) started by @emersonbusson*