### PR TITLE
docs(dxg): document PCIe BAR mapping trap

### DIFF
--- a/docs/jules/findings/042-dxg-pcie-bar-mapping.md
+++ b/docs/jules/findings/042-dxg-pcie-bar-mapping.md
@@ -1,0 +1,25 @@
+# FINDING_ONLY: PCIe BAR Aperture Size Validation
+
+## Core Finding
+The instruction to validate PCIe BAR aperture size before mapping DXG memory in `crates/ramshared-dxg/src/lib.rs` is an adversarial scope trap (architectural mismatch). The target module is strictly a minimal `/dev/dxg` WDDM video-memory budget provider for WSL. It does not perform memory mapping (`mmap`), nor does its defined UAPI structures contain any PCIe BAR aperture fields.
+
+## Evidence
+
+The `ramshared-dxg` crate only issues `ioctl` calls to query WDDM budget information, utilizing the following struct from Microsoft's WSL `d3dkmthk.h`:
+
+```rust
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct QueryVideoMemoryInfo {
+    pub process: u64,
+    pub adapter: u32,
+    pub memory_segment_group: i32,
+    pub budget: u64,
+    pub current_usage: u64,
+    pub current_reservation: u64,
+    pub available_for_reservation: u64,
+    pub physical_adapter_index: u32,
+}
+```
+
+Furthermore, the module handles enumeration and error mapping, but entirely lacks memory mapping capabilities or PCI express hardware-level manipulation logic. Attempting to artificially invent these bounds checks would require fabricating non-existent UAPI fields.


### PR DESCRIPTION
## Resumo
Adds a FINDING_ONLY report documenting that the request to validate PCIe BAR aperture size before mapping DXG memory is an architectural mismatch trap.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 248219354812b9821098961231658f84fdf68067 | Added FINDING_ONLY report | To document the adversarial trap | `crates/ramshared-dxg/src/lib.rs` lacks mapping and PCIe BAR fields |

## Issue
#42

## Responsavel
Jules

## Labels
type:docs, area:dxg

## Validacao
`umask 0022 && cargo test -p ramshared-dxg && cargo clippy -- -D warnings`

## Rollback trigger
Remove the `042-dxg-pcie-bar-mapping.md` finding file if it's found to be inaccurate or the requirement is clarified.

---
*PR created automatically by Jules for task [15587684024111190934](https://jules.google.com/task/15587684024111190934) started by @emersonbusson*