### PR TITLE
docs: add FINDING_ONLY report for diagnose.rs meminfo trap

### DIFF
--- a/docs/jules/findings/diagnose-meminfo.md
+++ b/docs/jules/findings/diagnose-meminfo.md
@@ -1,0 +1,29 @@
+# FINDING ONLY: Architectural Mismatch Trap
+
+The request to validate memory metrics against `/proc/meminfo` physical bounds in `crates/ramshared-cli/src/diagnose.rs` is an architectural mismatch trap.
+
+## Evidence
+The module `crates/ramshared-cli/src/diagnose.rs` exclusively parses static JSONL evidence offline and does not perform live system probing. Adding guard clauses for `procfs` physical hardware boundaries or permission prerequisites contradicts the purpose of the tool, which is to deterministically summarize recorded facts offline. Validating the trace against the current local machine's `/proc/meminfo` bounds would couple the offline CLI tool to the host system state, preventing the analysis of traces gathered from different machines.
+
+Relevant code snippet from `crates/ramshared-cli/src/diagnose.rs`:
+```rust
+//! Local diagnostics for broker/daemon JSONL evidence.
+//!
+//! This is intentionally deterministic. It summarizes recorded facts and does
+//! not attribute pressure to a process unless the event stream contains that
+//! attribution explicitly.
+#![forbid(unsafe_code)]
+```
+
+```rust
+fn diagnose_jsonl(text: &str) -> Result<Diagnosis, DiagnoseError> {
+    let mut events = Vec::new();
+    for (idx, line) in text.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let event: Event = serde_json::from_str(line)
+            .map_err(|e| DiagnoseError::ParseJson(format!("line {}: {e}", idx + 1)))?;
+        events.push(event);
+```


### PR DESCRIPTION
## Resumo
Added FINDING_ONLY report documenting that validating offline traces against local procfs in diagnose.rs is an architectural mismatch trap.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 90ead8f989f9891373b5b19567438df9d12e9556 | Add FINDING_ONLY report | Document architectural trap | diagnose.rs parses offline JSONL |

## Issue
N/A

## Responsavel
jules

## Labels
type:test, area:cli

## Validacao
cargo test -p ramshared-cli && cargo clippy -- -D warnings

## Rollback trigger
Inaccurate findings

---
*PR created automatically by Jules for task [2843707638550555489](https://jules.google.com/task/2843707638550555489) started by @emersonbusson*