### PR TITLE
fix(wsl2d): enforce max message size limit to prevent memory exhaustion

### DIFF
--- a/crates/ramshared-wsl2d/src/conn.rs
+++ b/crates/ramshared-wsl2d/src/conn.rs
@@ -159,6 +159,12 @@ pub fn spawn_reader<S: Read + Send + 'static, W2: Write + Send + 'static>(
                     break;
                 }
             };
+            // Anti-DoS: physical upper bound for IPC buffers (16 MiB) to prevent memory exhaustion.
+            if req.len > 16 * 1024 * 1024 {
+                eprintln!("[ramsharedd] conn: request len {} exceeds physical IPC buffer bound (16 MiB); disconnecting", req.len);
+                break;
+            }
+
             // Anti-DoS: a WRITE can never exceed the negotiated export (prevents allocating gigabytes).
             if req.cmd == Command::Write && req.len as u64 > export_size {
                 eprintln!(


### PR DESCRIPTION
## Resumo
Enforce a physical hardware/runtime boundary check on the IPC buffer size limit (16 MiB) in the NBD connection reader loop to prevent memory exhaustion from oversized messages.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 9c0a62666618f04190e5f98b99a89c17a4232cea | Added physical upper bound check (16 MiB) on incoming payload size. | To apply the Physical Limits Sanity Checks principle, rejecting excessive buffers to prevent Out-of-Memory exhaustion. | Guard clause added to `spawn_reader` in `conn.rs` right after parse validation and before the logical export_size check. |

## Issue
sanity_check/wsl2d/041

## Responsavel
Jules

## Labels
type:security, area:wsl2d

## Validacao
umask 0022 && cargo test -p ramshared-wsl2d && cargo clippy -p ramshared-wsl2d -- -D warnings

## Rollback trigger
If valid NBD interactions start failing due to requiring a payload size greater than 16 MiB.

---
*PR created automatically by Jules for task [15755937293613853409](https://jules.google.com/task/15755937293613853409) started by @emersonbusson*