### PR TITLE
refactor: flatten subprocess spawn arguments validation with guards

### DIFF
--- a/crates/ramshared-cli/src/bounded_process.rs
+++ b/crates/ramshared-cli/src/bounded_process.rs
@@ -590,13 +590,20 @@ where
         ));
     }
     let program_path = std::path::Path::new(program);
-    if program_path.is_absolute() && !program_path.exists() {
+    let is_absolute_missing = program_path.is_absolute() && !program_path.exists();
+    if is_absolute_missing {
         return Err(ProcessSpawnError::spawn(
             label,
             io::Error::new(io::ErrorKind::NotFound, "binary path does not exist"),
         ));
     }
     for arg in command.get_args() {
+        if arg.is_empty() {
+            return Err(ProcessSpawnError::spawn(
+                label,
+                io::Error::new(io::ErrorKind::InvalidInput, "empty argument"),
+            ));
+        }
         if arg.as_bytes().contains(&0) {
             return Err(ProcessSpawnError::spawn(
                 label,


### PR DESCRIPTION
## Resumo
Refactor subprocess spawn validation to use early-return guard clauses for empty arguments. This guarantees empty args are detected and rejected cleanly without nested logic, adhering to the CleanArch physical limits and specific semantic error returns guidelines.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 6f300398c511f379306f037b06c81cfe546718d3 | Added empty arg check | To prevent empty argument execution via shell or parsers and satisfy defensive limits | Early return guard clause `arg.is_empty()` |

## Issue
#029

## Responsavel
Jules

## Labels
type:refactor, area:cli

## Validacao
`umask 0022 && cargo test -p ramshared-cli && cargo clippy -p ramshared-cli -- -D warnings`

## Rollback trigger
Argument execution exceptions on valid empty strings required by other tasks.

---
*PR created automatically by Jules for task [11370050245279902599](https://jules.google.com/task/11370050245279902599) started by @emersonbusson*