### PR TITLE
docs: report architectural mismatch for origin cache host RAM check

### DIFF
--- a/docs/jules/findings/sanity_check_origin_cache.md
+++ b/docs/jules/findings/sanity_check_origin_cache.md
@@ -1,0 +1,32 @@
+# FINDING_ONLY: Architectural Mismatch Trap
+
+## Rationale
+The instruction to "enforce max cache size limit derived from available physical host RAM" in `crates/ramshared-block/src/origin_cache.rs` is an architectural mismatch trap.
+
+## Evidence
+1. **Domain Mismatch**: The `WriteThroughCacheBackend` uses a `VramProvider` to cache blocks in VRAM, not host RAM.
+```rust
+struct CacheChunk<M> {
+    mem: Option<M>,
+    generation: u64,
+    validity_generation: u64,
+    valid: Vec<bool>,
+    last_access: u64,
+}
+
+pub struct WriteThroughCacheBackend<'p, P: VramProvider + 'p, O> {
+    provider: &'p P,
+    origin: O,
+    size: u64,
+    block: u32,
+    chunk_bytes: u64,
+    chunks: Vec<CacheChunk<P::Mem<'p>>>,
+```
+
+2. **Dynamic Allocation via Telemetry**: The cache dynamically allocates VRAM based on a `GpuSample` budget provided at runtime, rather than statically enforcing a physical host RAM limit at construction.
+```rust
+pub fn observe_gpu(&mut self, sample: Option<GpuSample>, now: Duration) -> CachePolicyOutcome {
+    let target = physical_target_bytes(self.physical_cap_bytes, sample);
+```
+
+3. **Library Isolation**: The `ramshared-block` crate is an isolated domain library without system-level dependencies. System RAM boundary validation is the architectural responsibility of higher-level orchestrators (e.g., `crates/ramshared-tier/src/cascade.rs`), making a `/proc/meminfo` style host RAM check here inherently invalid.


### PR DESCRIPTION
## Resumo
Creates a FINDING_ONLY report because the requested physical host RAM check in `origin_cache.rs` is an architectural mismatch trap. The module dynamically allocates VRAM based on telemetry, and validating host RAM violates the isolated boundaries of the `ramshared-block` domain library.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1cdd45cda080f325a627fe3df2405a8ebeff8912 | docs: report architectural mismatch for origin cache host RAM check | Enforcing host RAM in a VRAM cache violates the architecture | Created `docs/jules/findings/sanity_check_origin_cache.md` |

## Issue
None

## Responsavel
Jules

## Labels
type:doc, area:block

## Validacao
```bash
umask 0022 && cargo test -p ramshared-block && cargo clippy -- -D warnings
```

## Rollback trigger
Revert the commit if the finding report format is deemed incorrect or if the architectural mismatch is disputed.

---
*PR created automatically by Jules for task [17365970170561171005](https://jules.google.com/task/17365970170561171005) started by @emersonbusson*