### PR TITLE
feat(cli): reject stress thread count exceeding physical limit

### DIFF
--- a/crates/ramshared-cli/src/stress.rs
+++ b/crates/ramshared-cli/src/stress.rs
@@ -214,7 +214,13 @@ pub fn parse_stress_args(args: &[String]) -> Result<StressOptions, String> {
         .map(|n| n.get() as u64)
         .unwrap_or(1);
 
-    opts.threads = opts.threads.clamp(1, max_threads);
+    if opts.threads > max_threads {
+        return Err(format!(
+            "thread count {} exceeds physical hardware limit ({})",
+            opts.threads, max_threads
+        ));
+    }
+    opts.threads = opts.threads.max(1);
     opts.start_pct = opts.start_pct.clamp(1, 200);
     opts.target_pct = opts.target_pct.clamp(opts.start_pct, 200);
     opts.step_pct = opts.step_pct.clamp(1, 25);
@@ -1102,13 +1108,12 @@ mod tests {
     }
 
     #[test]
-    fn clamps_thread_count_to_physical_limits() {
+    fn rejects_thread_count_exceeding_physical_limits() {
         let args = vec!["--threads".to_string(), "999999".to_string()];
-        let opts = parse_stress_args(&args).unwrap_or_default();
-        let max_threads = std::thread::available_parallelism()
-            .map(|n| n.get() as u64)
-            .unwrap_or(1);
-        assert_eq!(opts.threads, max_threads);
+        let res = parse_stress_args(&args);
+        assert!(res.is_err());
+        let err = res.unwrap_err();
+        assert!(err.contains("exceeds physical hardware limit"));
     }
 
     #[test]


### PR DESCRIPTION
## Resumo
This PR enforces physical limits sanity checks by explicitly validating and rejecting stress test thread counts that exceed the system's available logical processors, replacing the previous silent clamping mechanism.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 7c37c2d7f2d4f63695768274f5c23a4af9e04de2 | feat(cli): reject stress thread count exceeding physical limit | To enforce physical hardware limit validation defensively | Modified crates/ramshared-cli/src/stress.rs |

## Issue
N/A

## Responsavel
Jules

## Labels
type:refactor, area:cli

## Validacao
Executed `umask 0022 && cargo test -p ramshared-cli && cargo clippy -- -D warnings` and verified all tests pass.

## Rollback trigger
If the stress command fails on machines with virtual cores not correctly reported by `available_parallelism`, revert this commit to restore clamping.

---
*PR created automatically by Jules for task [6090130895229849002](https://jules.google.com/task/6090130895229849002) started by @emersonbusson*