### PR TITLE
feat(cuda): validate device memory pitch and alignment constraints

### DIFF
--- a/crates/ramshared-cuda/src/vram_impl.rs
+++ b/crates/ramshared-cuda/src/vram_impl.rs
@@ -29,10 +29,18 @@ impl VramMemory for DeviceMem<'_, '_> {
     fn zero(&mut self) -> Result<(), VramError> {
         DeviceMem::zero(self).map_err(Into::into)
     }
+    #[allow(clippy::manual_is_multiple_of)]
     fn read_at(&self, off: u64, dst: &mut [u8]) -> Result<(), VramError> {
+        if off % 256 != 0 || dst.len() as u64 % 256 != 0 {
+            return Err(VramError::InvalidAlignment);
+        }
         DeviceMem::read_at(self, off as usize, dst).map_err(Into::into)
     }
+    #[allow(clippy::manual_is_multiple_of)]
     fn write_at(&mut self, off: u64, src: &[u8]) -> Result<(), VramError> {
+        if off % 256 != 0 || src.len() as u64 % 256 != 0 {
+            return Err(VramError::InvalidAlignment);
+        }
         DeviceMem::write_at(self, off as usize, src).map_err(Into::into)
     }
 }


### PR DESCRIPTION
## Resumo
Enforce hardware-specific CUDA memory alignment (256-byte pitch) before memory copy operations, validating physical hardware bounds over basic numeric limits.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
| 3c98f3eb54c0c69e8b1e625659deb8b9568061b0 | Apply 256-byte alignment bounds on vRAM | Prevent unaligned CUDA accesses | `vram_impl.rs` |
## Issue
054
## Responsavel
Jules
## Labels
type:security, area:cuda
## Validacao
`umask 0022 && cargo test -p ramshared-cuda && cargo clippy -- -D warnings`
## Rollback trigger
Valid 256-aligned allocations unexpectedly rejected by driver.

---
*PR created automatically by Jules for task [1998160009112718459](https://jules.google.com/task/1998160009112718459) started by @emersonbusson*