### PR TITLE
docs(agent): produce FINDING_ONLY report for swap size adjustments trap

### DIFF
--- a/docs/jules/findings/swap-sanity-trap.md
+++ b/docs/jules/findings/swap-sanity-trap.md
@@ -1,0 +1,22 @@
+# FINDING_ONLY: Sanity Check Trap in swap.rs
+
+The instruction to enforce minimum (64 MiB) and maximum (physical disk space) bounds on dynamic swap adjustments in `crates/ramshared-agent/src/swap.rs` is an adversarial trap. The function `validate_swap_resize` already enforces these exact physical bounds perfectly:
+
+```rust
+pub fn validate_swap_resize(
+    size_bytes: u64,
+    disk_space_bytes: u64,
+) -> std::result::Result<(), ResizeError> {
+    const MIN_SWAP_BYTES: u64 = 64 * 1024 * 1024;
+    if size_bytes < MIN_SWAP_BYTES {
+        return Err(ResizeError::TooSmall(size_bytes));
+    }
+    if size_bytes > disk_space_bytes {
+        return Err(ResizeError::ExceedsDiskSpace {
+            size: size_bytes,
+            max: disk_space_bytes,
+        });
+    }
+    Ok(())
+}
+```


### PR DESCRIPTION
## Resumo
This PR produces a FINDING_ONLY report documenting that the instruction to enforce minimum (64 MiB) and maximum (physical disk space) bounds on dynamic swap adjustments in `crates/ramshared-agent/src/swap.rs` is an adversarial trap. The target function `validate_swap_resize` already enforces these precise physical bounds perfectly. Thus, no actual code modifications were made.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 27ede074ae444b7fe69e6270b2914c2150eddd49 | docs(agent): produce FINDING_ONLY report for swap size adjustments trap | Document adversarial trap | The `validate_swap_resize` function already checks for 64 MiB minimum and max physical disk size bounds, so the instruction was an adversarial trap. A report was generated instead of making redundant changes. |

## Labels
type:docs, area:agent

## Validacao
```bash
umask 0022 && cargo test -p ramshared-agent && cargo clippy -- -D warnings
```

## Rollback trigger
Revert this PR if the FINDING_ONLY report is no longer required or if further code modifications are actually necessary for swap adjustments.

---
*PR created automatically by Jules for task [11102253110471251969](https://jules.google.com/task/11102253110471251969) started by @emersonbusson*