### PR TITLE
feat(vulkan): sanity check buffer size against physical heap bound

### DIFF
--- a/crates/ramshared-vulkan/src/lib.rs
+++ b/crates/ramshared-vulkan/src/lib.rs
@@ -388,6 +388,15 @@ impl VramProvider for VulkanProvider {
         Self: 'p;
 
     fn alloc(&self, bytes: usize) -> Result<Self::Mem<'_>, VramError> {
+        let total = self.device_local_total();
+        if bytes as u64 > total {
+            return Err(VramError::OutOfRange {
+                off: 0,
+                len: bytes as u64,
+                size: total,
+            });
+        }
+
         // Rounds buffer size to a multiple of 4 (requirement for vkCmdFillBuffer with WHOLE_SIZE
         // in zero); the logical len remains `bytes`.
         let buf_size = ((bytes as u64).max(1) + 3) & !3;
@@ -647,6 +656,27 @@ mod tests {
             total >> 20,
             free0 >> 20,
             free1 >> 20
+        );
+    }
+
+    #[test]
+    #[ignore = "requires Vulkan loader + ICD (lavapipe is enough; run with --ignored)"]
+    fn alloc_exceeds_heap_returns_out_of_range() {
+        let p = VulkanProvider::open(0).expect("opens Vulkan");
+        let total = p.device_local_total();
+        assert!(total > 0, "total > 0");
+
+        let size = total as usize + 4096;
+        let res = p.alloc(size);
+        assert!(res.is_err(), "alloc should fail");
+        let err = match res {
+            Err(e) => e,
+            Ok(_) => panic!("alloc succeeded unexpectedly"),
+        };
+        assert!(
+            matches!(err, VramError::OutOfRange { .. }),
+            "expected OutOfRange for excessive size, got: {:?}",
+            err
         );
     }
 }


### PR DESCRIPTION
## Resumo
Added physical bounds sanity checking to `VulkanProvider::alloc` to reject allocation requests that exceed the size of the underlying physical memory heap using an early return guard clause (`VramError::OutOfRange`), preventing out-of-bounds operations at the driver level. Added a test `alloc_exceeds_heap_returns_out_of_range` to verify this behavior.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 769f10942f3f089d7cb52e593efd5a0298d10dd2 | Added size bound check in `alloc` and test | To avoid requesting invalid sizes from the hardware layer and enforce physical memory bounds | Uses guard clause pattern in `crates/ramshared-vulkan/src/lib.rs` |

## Issue
jules/sanity_check/vulkan/056

## Responsavel
Jules

## Labels
type:security,area:vulkan

## Validacao
VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json umask 0022 && cargo test -p ramshared-vulkan -- --ignored && cargo clippy -- -D warnings

## Rollback trigger
Driver crash, memory leaks or other unstable Vulkan behavior resulting from test regression.

---
*PR created automatically by Jules for task [3203886726275099113](https://jules.google.com/task/3203886726275099113) started by @emersonbusson*