### PR TITLE
fix(agent): strictly enforce watchdog deadline greater than 10ms

### DIFF
--- a/crates/ramshared-agent/src/watchdog.rs
+++ b/crates/ramshared-agent/src/watchdog.rs
@@ -44,7 +44,7 @@ pub struct Watchdog {
 
 impl Watchdog {
     pub fn new(deadline: Duration, now: Instant) -> Result<Self, WatchdogError> {
-        if deadline < Duration::from_millis(10) {
+        if deadline <= Duration::from_millis(10) {
             return Err(WatchdogError::TooShort);
         }
         if deadline > Duration::from_secs(86400) {
@@ -100,6 +100,10 @@ mod tests {
         let t0 = Instant::now();
         assert_eq!(
             Watchdog::new(Duration::from_millis(5), t0),
+            Err(WatchdogError::TooShort)
+        );
+        assert_eq!(
+            Watchdog::new(Duration::from_millis(10), t0),
             Err(WatchdogError::TooShort)
         );
         assert_eq!(


### PR DESCRIPTION
## Resumo
Modified the `watchdog.rs` file to enforce that the heartbeat frequency (deadline) is strictly greater than the timer resolution, changing the bounds check from `< 10ms` to `<= 10ms`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| the SHA retrieved in step 5 | Modified watchdog validation logic to strictly reject 10ms deadline | To ensure the heartbeat frequency strictly exceeds the timer resolution | Changed `<` to `<=` and updated tests. |

## Labels
type:refactor
area:agent

## Validacao
umask 0022 && cargo test -p ramshared-agent && cargo clippy -- -D warnings

## Rollback trigger
Revert if tests fail or if the strict requirement causes regressions.

---
*PR created automatically by Jules for task [11045738484952670014](https://jules.google.com/task/11045738484952670014) started by @emersonbusson*