### PR TITLE
chore: add physical limits check for stride vs page size

### DIFF
--- a/crates/ramshared-integrity/src/pattern.rs
+++ b/crates/ramshared-integrity/src/pattern.rs
@@ -64,7 +64,14 @@ pub fn fill_block(buf: &mut [u8], idx: u64, kind: Pattern) {
 
 /// Returns `Ok(())` if `buf` matches the expected pattern for block index `idx`, or an `IntegrityError` otherwise.
 pub fn verify_block(buf: &[u8], idx: u64, kind: Pattern) -> Result<(), IntegrityError> {
-    let mut expected = vec![0u8; buf.len()];
+    let page_size = 4096;
+    let stride = buf.len();
+    #[allow(clippy::manual_is_multiple_of)]
+    if stride == 0 || page_size % stride != 0 {
+        return Err(IntegrityError::InvalidStride { stride, page_size });
+    }
+
+    let mut expected = vec![0u8; stride];
     fill_block(&mut expected, idx, kind);
     for (offset, (&actual, &exp)) in buf.iter().zip(expected.iter()).enumerate() {
         if actual != exp {
@@ -80,6 +87,24 @@ pub fn verify_block(buf: &[u8], idx: u64, kind: Pattern) -> Result<(), Integrity
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn invalid_stride_is_rejected() {
+        assert_eq!(
+            verify_block(&[0u8; 3], 0, Pattern::Zero),
+            Err(IntegrityError::InvalidStride {
+                stride: 3,
+                page_size: 4096
+            })
+        );
+        assert_eq!(
+            verify_block(&[], 0, Pattern::Zero),
+            Err(IntegrityError::InvalidStride {
+                stride: 0,
+                page_size: 4096
+            })
+        );
+    }
 
     #[test]
     fn fill_then_verify_round_trips() {


### PR DESCRIPTION
## Resumo
Adiciona checagem de limites físicos (sanity check) na função `verify_block` para garantir que o tamanho do buffer (stride) divide exata e precisamente o tamanho de uma página de memória (4096 bytes). Caso contrário, a função irá retornar um `IntegrityError::InvalidStride` e abortar (guard pattern).

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 668cd63ea736001021ab9bd0d24e98fd7eab2221 | Implementou `InvalidStride` guard clause e `RED_TEST`. | Para assegurar sanity check físico contra divisionamentos incompletos ou desalinhados que poderiam invalidar testes de corrupção. | N/A |

## Labels
type:refactor, area:integrity

## Validacao
`umask 0022 && cargo test -p ramshared-integrity && cargo clippy -p ramshared-integrity -- -D warnings`

## Rollback trigger
Se houver falsos positivos ou panics inesperados de bounds check na execução das suítes de teste de outros crates dependendo the `ramshared-integrity`.

RULES MAIN_DIFF FILES INVARIANTS COUNTERFACTUAL RED_TEST COVERAGE REAL_PROOF ROLLBACK PR_BOUNDARY do not merge

---
*PR created automatically by Jules for task [2419849195336190688](https://jules.google.com/task/2419849195336190688) started by @emersonbusson*