### PR TITLE
feat: validate PSI memory pressure bounds

### DIFF
--- a/crates/ramshared-agent/src/psi.rs
+++ b/crates/ramshared-agent/src/psi.rs
@@ -38,10 +38,18 @@ pub fn parse_psi(content: &str) -> Option<PsiSample> {
             total = v.parse::<u64>().ok();
         }
     }
+    let a10 = avg10?;
+    let a60 = avg60?;
+    let t = total?;
+
+    if !(0.0..=100.0).contains(&a10) || !(0.0..=100.0).contains(&a60) {
+        return None;
+    }
+
     Some(PsiSample {
-        avg10: avg10?,
-        avg60: avg60?,
-        stall_us: total?,
+        avg10: a10,
+        avg60: a60,
+        stall_us: t,
     })
 }
 
@@ -181,6 +189,12 @@ mod tests {
     #[test]
     fn parse_psi_no_some_line_is_none() {
         assert!(parse_psi("full avg10=1.0 avg60=2.0 avg300=3.0 total=5\n").is_none());
+    }
+
+    #[test]
+    fn parse_psi_rejects_out_of_bounds_pressure() {
+        assert!(parse_psi("some avg10=100.01 avg60=0.00 avg300=0.00 total=0\n").is_none());
+        assert!(parse_psi("some avg10=0.00 avg60=-0.01 avg300=0.00 total=0\n").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Resumo
Validate PSI memory pressure averages against physical hardware constraints in `crates/ramshared-agent/src/psi.rs` using the 0.00-100.00% boundary. It enforces defensive programming by returning `None` early without nesting the entire struct allocation path.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 7b5316c | refactor parse_psi for physical boundaries | Ensure hardware metrics can't breach physical constraints downstream | Modifies parsing and adds defensive tests without touching nested logic |

## Issue
N/A

## Responsavel
Jules / CleanArch100 / 2026-09-06

## Labels
type:test, area:agent

## Validacao
```bash
umask 0022 && cargo test -p ramshared-agent && cargo clippy -- -D warnings
```

## Rollback trigger
If the test binary panics due to out-of-bounds pressure causing internal states to fail.

---
*PR created automatically by Jules for task [2752142929662406570](https://jules.google.com/task/2752142929662406570) started by @emersonbusson*