### PR TITLE
refactor(winsvc): map IoctlError to semantic std::io::ErrorKind

### DIFF
--- a/crates/ramshared-winsvc/src/windows_driver.rs
+++ b/crates/ramshared-winsvc/src/windows_driver.rs
@@ -78,6 +78,20 @@ impl std::fmt::Display for IoctlError {
 
 impl std::error::Error for IoctlError {}
 
+impl From<IoctlError> for std::io::Error {
+    fn from(err: IoctlError) -> Self {
+        let kind = match err {
+            IoctlError::Open(_) => std::io::ErrorKind::NotFound,
+            IoctlError::Ioctl(_) => std::io::ErrorKind::Other,
+            IoctlError::Map(_) => std::io::ErrorKind::PermissionDenied,
+            IoctlError::Timeout => std::io::ErrorKind::TimedOut,
+            IoctlError::Cancelled => std::io::ErrorKind::Interrupted,
+            IoctlError::Invalid(_) => std::io::ErrorKind::InvalidInput,
+        };
+        std::io::Error::new(kind, err)
+    }
+}
+
 fn last_error_string(op: &str) -> String {
     let e = unsafe { windows_sys::Win32::Foundation::GetLastError() };
     format!("{op} win32={e}")
@@ -560,4 +574,37 @@ fn struct_bytes<T>(v: &T) -> Vec<u8> {
         ptr::copy_nonoverlapping((v as *const T) as *const u8, out.as_mut_ptr(), n);
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::ErrorKind;
+
+    #[test]
+    fn test_ioctl_error_conversion() {
+        let err = IoctlError::Timeout;
+        let io_err: std::io::Error = err.into();
+        assert_eq!(io_err.kind(), ErrorKind::TimedOut);
+
+        let err = IoctlError::Invalid("test".into());
+        let io_err: std::io::Error = err.into();
+        assert_eq!(io_err.kind(), ErrorKind::InvalidInput);
+
+        let err = IoctlError::Cancelled;
+        let io_err: std::io::Error = err.into();
+        assert_eq!(io_err.kind(), ErrorKind::Interrupted);
+
+        let err = IoctlError::Open("test".into());
+        let io_err: std::io::Error = err.into();
+        assert_eq!(io_err.kind(), ErrorKind::NotFound);
+
+        let err = IoctlError::Map("test".into());
+        let io_err: std::io::Error = err.into();
+        assert_eq!(io_err.kind(), ErrorKind::PermissionDenied);
+
+        let err = IoctlError::Ioctl("test".into());
+        let io_err: std::io::Error = err.into();
+        assert_eq!(io_err.kind(), ErrorKind::Other);
+    }
 }


### PR DESCRIPTION
## Resumo
Map Win32 driver errors (`IoctlError`) to specific, semantic `std::io::ErrorKind` variants (`PermissionDenied`, `NotFound`, `InvalidInput`, `TimedOut`) to adhere to the principle of returning semantic errors rather than generic ones.

## Issue
Map DeviceIoControl error codes to semantic std::io::ErrorKind.

## Responsavel
Jules (RamShared Architect)

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 664e6df5e07f046d73dd03180e9e56034180f6c4 | Added `From<IoctlError> for std::io::Error` conversion. | To provide typed, semantic errors instead of propagating generic errors or custom enums without standard traits. | Mapped `Open` to `NotFound`, `Ioctl` to `Other`, `Map` to `PermissionDenied`, `Timeout` to `TimedOut`, `Cancelled` to `Interrupted`, and `Invalid` to `InvalidInput`. Added test `test_ioctl_error_conversion` in `windows_driver.rs`. |

## Labels
type:refactor

## Validacao
umask 0022 && cargo test -p ramshared-winsvc && cargo clippy -p ramshared-winsvc -- -D warnings

## Rollback trigger
Any regression in driver link error propagation, failure to compile for Windows target, or incorrect handling of `std::io::Error` downstream.

---
*PR created automatically by Jules for task [14538903866627782059](https://jules.google.com/task/14538903866627782059) started by @emersonbusson*