### PR TITLE
docs: add finding only report for vram allocation trap

### DIFF
--- a/docs/jules/findings/077-vram-allocation.md
+++ b/docs/jules/findings/077-vram-allocation.md
@@ -1,0 +1,2 @@
+FINDING ONLY: Architectural Mismatch Trap
+The task requested to return semantic errors on vRAM allocation in crates/ramshared-vram/src/lib.rs. However, this file only contains abstract traits and error types, not concrete allocation logic.


### PR DESCRIPTION
## Issue
Semantic error returns on vRAM allocation

## Responsavel
Jules

## Resumo
Created a finding only report because crates/ramshared-vram/src/lib.rs only contains abstract traits and no concrete allocation logic.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| d2bb7fdd036deccac16ec9cb4183c9590675fd75 | add finding only report | architectural mismatch trap | documented in docs/jules/findings |

## Labels
type:security

## Validacao
umask 0022 && cargo test && cargo clippy -- -D warnings

## Rollback trigger
revert if required

---
*PR created automatically by Jules for task [6362129483054237984](https://jules.google.com/task/6362129483054237984) started by @emersonbusson*