### PR TITLE
refactor: map storage backend failures to semantic POSIX error codes

### DIFF
--- a/crates/ramshared-wsl2d/src/ublk_server.rs
+++ b/crates/ramshared-wsl2d/src/ublk_server.rs
@@ -29,6 +29,7 @@ use crate::{
 
 const EIO: i32 = -5;
 const EINVAL: i32 = -22;
+const ERANGE: i32 = -34;
 
 trait QueueServer {
     fn submit_initial_fetch(&mut self) -> io::Result<()>;
@@ -89,7 +90,7 @@ pub fn serve_request<B: BlockBackend + ?Sized>(
         .checked_add(req.len as u64)
         .is_none_or(|end| end > backend.size_bytes())
     {
-        return EINVAL;
+        return ERANGE;
     }
 
     // Command guard
@@ -963,7 +964,7 @@ mod join_tests {
 
         request.len = 4096;
         request.offset = 4096; // Out of bounds (backend is 4096, offset 4096 + len 4096 = 8192 > 4096)
-        assert_eq!(serve_request(&request, &mut backend, &mut buffer), EINVAL);
+        assert_eq!(serve_request(&request, &mut backend, &mut buffer), ERANGE);
     }
 
     #[test]

--- a/crates/ramshared-wsl2d/tests/ublk_server.rs
+++ b/crates/ramshared-wsl2d/tests/ublk_server.rs
@@ -48,10 +48,10 @@ fn serve_request_handles_flush_and_rejects_oversized_or_oob() {
         -22
     );
 
-    // READ outside the backend => -EINVAL.
+    // READ outside the backend => -ERANGE.
     assert_eq!(
         ublk_server::serve_request(&req(Command::Read, 51200, 512), &mut backend, &mut buf),
-        -22
+        -34
     );
 }
 
@@ -72,18 +72,18 @@ fn serve_request_guards_against_out_of_bounds_upfront() {
 
     // Overflow offset + len
     assert_eq!(
-        ublk_server::serve_request(&req(Command::Read, u64::MAX, 1024), &mut backend, &mut buf),
-        -22 // EINVAL
+        ublk_server::serve_request(&req(Command::Read, u64::MAX - 511, 1024), &mut backend, &mut buf),
+        -34 // ERANGE
     );
 
     // Exceeds backend size bytes
     assert_eq!(
         ublk_server::serve_request(&req(Command::Read, 4096, 512), &mut backend, &mut buf),
-        -22 // EINVAL
+        -34 // ERANGE
     );
     assert_eq!(
         ublk_server::serve_request(&req(Command::Write, 2048, 4096), &mut backend, &mut buf),
-        -22 // EINVAL
+        -34 // ERANGE
     );
 }
 


### PR DESCRIPTION
## Issue
Map storage backend failures to semantic POSIX error codes.

## Responsavel
CleanArch100/2026-09-06/semantic_error/wsl2d/073

## Resumo
Replaces the generic `-EINVAL` error with the specific semantic POSIX error `-ERANGE` for physical bounds and offset limit violations in the ublk backend. This correctly maps out-of-bounds occurrences to their precise meaning.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| e6149f7f8b4568cab80911fa573a0c2e8c73cdbb | Changed out of bounds return to ERANGE | Enforce specific semantic POSIX errors | Added constant ERANGE and modified tests to expect it |

## Labels
type:refactor

## Validacao
`umask 0022 && cargo test -p ramshared-wsl2d && cargo clippy -p ramshared-wsl2d -- -D warnings`
`umask 0022 && cargo test -p ramshared-wsl2d --test ublk_server`

## Rollback trigger
Test failures due to unhandled exceptions or incorrectly mapped semantic errors on out of bounds offsets.

---
*PR created automatically by Jules for task [16441764994307463032](https://jules.google.com/task/16441764994307463032) started by @emersonbusson*