### PR TITLE
fix(broker): use explicit bounds check returning IndexOutOfRange in slice lookups

### DIFF
--- a/crates/ramshared-broker/src/slices.rs
+++ b/crates/ramshared-broker/src/slices.rs
@@ -91,7 +91,11 @@ impl SliceMap {
     }
 
     pub fn get(&self, id: SliceId) -> Option<&Slice> {
-        self.slices.iter().find(|s| s.id == id)
+        let idx = id as usize;
+        if idx >= self.slices.len() {
+            return None;
+        }
+        Some(&self.slices[idx])
     }
 
     pub fn slices(&self) -> &[Slice] {
@@ -99,10 +103,11 @@ impl SliceMap {
     }
 
     fn get_mut(&mut self, id: SliceId) -> Result<&mut Slice, SliceError> {
-        self.slices
-            .iter_mut()
-            .find(|s| s.id == id)
-            .ok_or(SliceError::UnknownSlice)
+        let idx = id as usize;
+        if idx >= self.slices.len() {
+            return Err(SliceError::IndexOutOfRange);
+        }
+        Ok(&mut self.slices[idx])
     }
 
     /// `Free → Active(tenant)`. Err if non-`Free` (atomicity invariant; `Leased` rejects).
@@ -267,10 +272,10 @@ mod tests {
     }
 
     #[test]
-    fn unknown_slice_is_error() {
+    fn out_of_range_slice_is_error() {
         let mut m = SliceMap::new(1, 64, 64).unwrap();
-        assert_eq!(m.assign(9, 1), Err(SliceError::UnknownSlice));
-        assert_eq!(m.drain(9), Err(SliceError::UnknownSlice));
+        assert_eq!(m.assign(9, 1), Err(SliceError::IndexOutOfRange));
+        assert_eq!(m.drain(9), Err(SliceError::IndexOutOfRange));
         assert!(m.get(9).is_none());
     }
 }


### PR DESCRIPTION
## Resumo
Modified `get` and `get_mut` methods in `crates/ramshared-broker/src/slices.rs` to implement explicit physical bounds checking using array indexing, replacing the previous `find` closure. If the index exceeds bounds, it now returns the precise semantic error `SliceError::IndexOutOfRange`. The implementation for `SliceError::AlreadyAllocated` was already perfectly implemented natively.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 6e8fa8e8760a80f12b7b4995ae87c953668edc52 | Use explicit bounds check returning IndexOutOfRange in slice lookups | Enforce physical limits and defensive programming, returning precise semantic errors. | Modified `get` and `get_mut` and updated the `out_of_range_slice_is_error` test. |

## Labels
type:refactor

## Validacao
umask 0022 && cargo test && cargo clippy -- -D warnings

## Rollback trigger
Any regression in slice lookup bounds checking or failing tests in `ramshared-broker` -> revert.

## Issue
Semantic SliceError for out-of-bounds access and allocation collisions

## Responsavel
CleanArch100/2026-09-06/semantic_error/broker/082

---
*PR created automatically by Jules for task [1801520859074121255](https://jules.google.com/task/1801520859074121255) started by @emersonbusson*