### PR TITLE
docs: add finding only report for winbroker error mapping

### DIFF
--- a/docs/jules/findings/winbroker_error.md
+++ b/docs/jules/findings/winbroker_error.md
@@ -1,0 +1,19 @@
+FINDING_ONLY
+The objective to map Windows named pipe errors to semantic WinBrokerError variants is already fully and perfectly implemented in crates/ramshared-winbroker/src/lib.rs.
+Evidence:
+pub enum WinBrokerError {
+    PipeBusy,
+    NoData,
+    BrokenPipe,
+    Other(std::io::Error),
+}
+impl From<std::io::Error> for WinBrokerError {
+    fn from(error: std::io::Error) -> Self {
+        match error.raw_os_error() {
+            Some(231) => Self::PipeBusy,   // ERROR_PIPE_BUSY
+            Some(232) => Self::NoData,     // ERROR_NO_DATA
+            Some(109) => Self::BrokenPipe, // ERROR_BROKEN_PIPE
+            _ => Self::Other(error),
+        }
+    }
+}


### PR DESCRIPTION
## Issue
Map Windows named pipe errors to semantic WinBrokerError

## Responsavel
CleanArch100/2026-09-06/semantic_error/winbroker/087

## Resumo
Created a FINDING_ONLY report because the requested semantic error mappings for Windows named pipe errors (`ERROR_PIPE_BUSY`, `ERROR_NO_DATA`, `ERROR_BROKEN_PIPE`) are already fully and perfectly implemented in `WinBrokerError`.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 7ca5c3bbaeb574ba3dc1ee7a202c1c7028b1aa80 | docs: add finding only report for winbroker error mapping | To document that the requested mappings are already present | The target variants and From<io::Error> trait are fully implemented in crates/ramshared-winbroker/src/lib.rs |

## Labels
type:refactor, area:core

## Validacao
cargo test -p ramshared-winbroker

## Rollback trigger
Trigger rollback if the finding report is factually incorrect or if the code mappings are somehow deemed insufficient.

---
*PR created automatically by Jules for task [5131785869342040341](https://jules.google.com/task/5131785869342040341) started by @emersonbusson*