### PR TITLE
refactor(cli): map diagnostic failures to semantic exit codes

### DIFF
--- a/crates/ramshared-cli/src/diagnose.rs
+++ b/crates/ramshared-cli/src/diagnose.rs
@@ -41,7 +41,7 @@ struct Event {
 #[derive(Debug)]
 pub enum DiagnoseError {
     InvalidArgs(String),
-    Io(String),
+    Io(std::io::Error, std::path::PathBuf),
     ParseJson(String),
 }
 
@@ -49,7 +49,7 @@ impl std::fmt::Display for DiagnoseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::InvalidArgs(msg) => write!(f, "{msg}"),
-            Self::Io(msg) => write!(f, "{msg}"),
+            Self::Io(err, path) => write!(f, "read {}: {err}", path.display()),
             Self::ParseJson(msg) => write!(f, "{msg}"),
         }
     }
@@ -59,7 +59,7 @@ impl DiagnoseError {
     pub fn exit_code(&self) -> u8 {
         match self {
             Self::InvalidArgs(_) => 22, // EINVAL
-            Self::Io(_) => 2,           // ENOENT
+            Self::Io(err, _) => err.raw_os_error().unwrap_or(5) as u8,
             Self::ParseJson(_) => 22,   // EINVAL for malformed json
         }
     }
@@ -82,7 +82,7 @@ struct Diagnosis {
 pub fn run(args: &[String]) -> Result<(), DiagnoseError> {
     let (path, json) = parse_args(args)?;
     let text = fs::read_to_string(&path)
-        .map_err(|e| DiagnoseError::Io(format!("read {}: {e}", path.display())))?;
+        .map_err(|e| DiagnoseError::Io(e, path.clone()))?;
     let diagnosis = diagnose_jsonl(&text)?;
     if json {
         println!("{}", render_json(&diagnosis));

--- a/crates/ramshared-cli/tests/cli_dispatch.rs
+++ b/crates/ramshared-cli/tests/cli_dispatch.rs
@@ -269,4 +269,14 @@ fn cli_diagnose_errors_semantic_codes() {
 
     let invalid_flag = run_cli(&["diagnose", "--invalid-flag"]);
     assert_eq!(invalid_flag.status.code(), Some(22)); // EINVAL
+
+    use std::os::unix::fs::PermissionsExt;
+    let path = std::env::temp_dir().join(format!("ramshared-test-no-perm-{}.jsonl", std::process::id()));
+    std::fs::write(&path, "{}").unwrap();
+    let mut perms = std::fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o000);
+    std::fs::set_permissions(&path, perms).unwrap();
+    let permission_denied = run_cli(&["diagnose", "--events", path.to_str().unwrap()]);
+    assert_eq!(permission_denied.status.code(), Some(13)); // EACCES
+    let _ = std::fs::remove_file(path);
 }


### PR DESCRIPTION
## Resumo
Returns precise OS semantic errors in diagnose CLI command instead of generic code.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
| f6311e9431d24b3cbec7295b12c322f3b083e1ae | map diagnostic failures to semantic exit codes | Return precise typed OS error codes | Refactored DiagnoseError::Io to wrap io::Error |

## Labels
type:refactor

## Validacao
umask 0022 && cargo test -p ramshared-cli && cargo clippy -- -D warnings

## Rollback trigger
Tests failing or panics in CLI.

## Issue
Semantic CLI error exit mapping with descriptive diagnostic codes

## Responsavel
CleanArch100/2026-09-06

---
*PR created automatically by Jules for task [17368349058612196204](https://jules.google.com/task/17368349058612196204) started by @emersonbusson*