### PR TITLE
refactor: implement semantic PsiError for missing /proc/pressure metrics and parse errors

### DIFF
--- a/crates/ramshared-agent/src/psi.rs
+++ b/crates/ramshared-agent/src/psi.rs
@@ -11,14 +11,37 @@ use std::io::{Error, ErrorKind, Result};
 use ramshared_broker::model::PsiSample;
 use ramshared_broker::protocol::SwapEntry;
 
+#[derive(Debug)]
+pub enum PsiError {
+    Unavailable(std::io::Error),
+    CorruptedFormat,
+}
+
+impl std::fmt::Display for PsiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PsiError::Unavailable(e) => write!(f, "PSI unavailable: {}", e),
+            PsiError::CorruptedFormat => write!(f, "PSI corrupted format"),
+        }
+    }
+}
+
+impl std::error::Error for PsiError {}
+
+impl From<std::io::Error> for PsiError {
+    fn from(err: std::io::Error) -> Self {
+        PsiError::Unavailable(err)
+    }
+}
+
 /// Core logic for `read_psi` with dependency injection for the file path.
-fn read_psi_impl(path: &str) -> Result<PsiSample> {
+fn read_psi_impl(path: &str) -> std::result::Result<PsiSample, PsiError> {
     let raw = std::fs::read_to_string(path)?;
-    parse_psi(&raw).ok_or_else(|| Error::new(ErrorKind::InvalidData, "PSI ilegível"))
+    parse_psi(&raw).ok_or(PsiError::CorruptedFormat)
 }
 
 /// Reads and parses `/proc/pressure/memory`.
-pub fn read_psi() -> Result<PsiSample> {
+pub fn read_psi() -> std::result::Result<PsiSample, PsiError> {
     read_psi_impl("/proc/pressure/memory")
 }
 
@@ -293,14 +316,15 @@ mod tests {
 
     #[test]
     fn read_psi_impl_not_found() {
-        assert!(read_psi_impl("/proc/nonexistent_psi_file_12345").is_err());
+        let err = read_psi_impl("/proc/nonexistent_psi_file_12345").unwrap_err();
+        assert!(matches!(err, PsiError::Unavailable(_)));
     }
 
     #[test]
     fn read_psi_impl_invalid_data() {
         let path = write_temp_file("invalid content\n");
         let err = read_psi_impl(&path).unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::InvalidData);
+        assert!(matches!(err, PsiError::CorruptedFormat));
         std::fs::remove_file(path).unwrap();
     }
 


### PR DESCRIPTION
## Issue
Semantic PsiError for missing /proc/pressure metrics and parse errors

## Responsavel
Jules

## Resumo
Implemented semantic `PsiError` for `read_psi` function to return explicit variants `Unavailable` and `CorruptedFormat` instead of standard `std::io::Error`, adhering to the Specificity Rule for errors. Unit tests updated accordingly.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 9674c868ab2372cc28a3430a1a5137419968b51e | Implemented semantic `PsiError` enum. | To provide explicit error types for PSI metric reading failures. | `crates/ramshared-agent/src/psi.rs` modified to define `PsiError` and refactor `read_psi` functions. |

## Labels
type:refactor, area:agent

## Validacao
Executed `cargo test -p ramshared-agent psi` and `cargo clippy -p ramshared-agent -- -D warnings`.

## Rollback trigger
Revert if agent fails to start or parse metrics correctly.

---
*PR created automatically by Jules for task [15599085022657055499](https://jules.google.com/task/15599085022657055499) started by @emersonbusson*