### PR TITLE
refactor(core): return semantic errors in checksum verify

### DIFF
--- a/crates/ramshared-integrity/src/hash.rs
+++ b/crates/ramshared-integrity/src/hash.rs
@@ -85,19 +85,28 @@ impl ChecksumTable {
     }
 
     /// Verifies the read block against the recorded hash.
-    /// `None` = never written (ok); `Some(true)` = matches; `Some(false)` =
-    /// mismatch (corruption/torn read) -> the caller returns an I/O error.
-    pub fn verify(&self, idx: usize, data: &[u8]) -> Option<bool> {
+    /// `Ok(true)` = matches; `Ok(false)` = never written (ok);
+    /// `Err(...)` = mismatch (corruption/torn read) -> the caller returns an I/O error.
+    pub fn verify(&self, idx: usize, data: &[u8]) -> Result<bool, ChecksumMismatchError> {
         if data.is_empty() || data.len() < 512 || !data.len().is_power_of_two() {
-            return Some(false);
+            return Err(ChecksumMismatchError::InvalidBufferLength { len: data.len() });
         }
         let Some(slot) = self.sums.get(idx) else {
-            return Some(false); // out of bounds = invalid
+            return Err(ChecksumMismatchError::OutOfBounds { idx });
         };
         let Some(expected) = slot else {
-            return None;
+            return Ok(false);
         };
-        Some(*expected == block_hash(data))
+        let computed = block_hash(data);
+        if *expected == computed {
+            Ok(true)
+        } else {
+            Err(ChecksumMismatchError::Mismatch {
+                idx,
+                expected: *expected,
+                computed,
+            })
+        }
     }
 }
 
@@ -119,7 +128,7 @@ mod tests {
         let mut t = ChecksumTable::new(8);
         let data = vec![0xABu8; 4096];
         assert!(t.record(3, &data));
-        assert_eq!(t.verify(3, &data), Some(true));
+        assert_eq!(t.verify(3, &data), Ok(true));
     }
 
     #[test]
@@ -129,14 +138,24 @@ mod tests {
         t.record(3, &data);
         let mut corrupt = data.clone();
         corrupt[0] ^= 0xff;
-        assert_eq!(t.verify(3, &corrupt), Some(false));
+        assert_eq!(
+            t.verify(3, &corrupt),
+            Err(ChecksumMismatchError::Mismatch {
+                idx: 3,
+                expected: block_hash(&data),
+                computed: block_hash(&corrupt),
+            })
+        );
     }
 
     #[test]
     fn unwritten_block_is_none_oob_is_invalid() {
         let mut t = ChecksumTable::new(2);
-        assert_eq!(t.verify(0, &[0u8; 4096]), None); // never written
-        assert_eq!(t.verify(99, &[0u8; 4096]), Some(false)); // out of bounds
+        assert_eq!(t.verify(0, &[0u8; 4096]), Ok(false)); // never written
+        assert_eq!(
+            t.verify(99, &[0u8; 4096]),
+            Err(ChecksumMismatchError::OutOfBounds { idx: 99 })
+        ); // out of bounds
         assert!(!t.record(99, &[0u8; 4096]));
     }
 
@@ -146,8 +165,14 @@ mod tests {
         assert!(!t.record(3, &[])); // empty
         assert!(!t.record(3, &[0u8; 123])); // not power of two / < 512
 
-        assert_eq!(t.verify(3, &[]), Some(false));
-        assert_eq!(t.verify(3, &[0u8; 123]), Some(false));
+        assert_eq!(
+            t.verify(3, &[]),
+            Err(ChecksumMismatchError::InvalidBufferLength { len: 0 })
+        );
+        assert_eq!(
+            t.verify(3, &[0u8; 123]),
+            Err(ChecksumMismatchError::InvalidBufferLength { len: 123 })
+        );
     }
 
     #[test]
@@ -157,9 +182,9 @@ mod tests {
         let data_65536 = vec![0xEFu8; 65536];
 
         assert!(t.record(1, &data_512));
-        assert_eq!(t.verify(1, &data_512), Some(true));
+        assert_eq!(t.verify(1, &data_512), Ok(true));
 
         assert!(t.record(2, &data_65536));
-        assert_eq!(t.verify(2, &data_65536), Some(true));
+        assert_eq!(t.verify(2, &data_65536), Ok(true));
     }
 }


### PR DESCRIPTION
## Resumo
This changes `ChecksumTable::verify` to return a `Result<bool, ChecksumMismatchError>` instead of an `Option<bool>`, to correctly provide semantic details like `Mismatch`, `OutOfBounds`, and `InvalidBufferLength` per the Specific & Semantic Errors architectural principle.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| a6dac1c410305bb6ef1a1b81121b52d1a76bc330 | Return typed ChecksumMismatchError | To avoid generic errors or swallowing failure context | Changed Option<bool> to Result<bool, ChecksumMismatchError> |

## Labels
type:refactor, area:core

## Validacao
cargo test -p ramshared-integrity && cargo clippy -p ramshared-integrity -- -D warnings

## Rollback trigger
Rollback if signature change causes downstream build failures.

---
*PR created automatically by Jules for task [16394875506367169488](https://jules.google.com/task/16394875506367169488) started by @emersonbusson*