### PR TITLE
refactor(config): rich ConfigError with file location and expected type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,7 @@ name = "ramshared-config"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_path_to_error",
  "toml",
 ]
 
@@ -865,6 +866,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/crates/ramshared-config/Cargo.toml
+++ b/crates/ramshared-config/Cargo.toml
@@ -10,6 +10,7 @@ publish.workspace = true
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 toml = "1.1"
+serde_path_to_error = "0.1"
 
 [lints.clippy]
 unwrap_used = "deny"

--- a/crates/ramshared-config/src/error.rs
+++ b/crates/ramshared-config/src/error.rs
@@ -6,6 +6,7 @@ pub enum ConfigError {
         message: String,
         line: Option<usize>,
         column: Option<usize>,
+        key_path: String,
     },
     Invalid {
         key_path: String,
@@ -23,11 +24,20 @@ impl fmt::Display for ConfigError {
                 message,
                 line: Some(l),
                 column: Some(c),
+                key_path,
             } => {
-                write!(f, "parse error at line {}, col {}: {}", l, c, message)
+                if key_path.is_empty() {
+                    write!(f, "parse error at line {}, col {}: {}", l, c, message)
+                } else {
+                    write!(f, "parse error at line {}, col {} for key '{}': {}", l, c, key_path, message)
+                }
             }
-            Self::Parse { message, .. } => {
-                write!(f, "parse error: {}", message)
+            Self::Parse { message, key_path, .. } => {
+                if key_path.is_empty() {
+                    write!(f, "parse error: {}", message)
+                } else {
+                    write!(f, "parse error for key '{}': {}", key_path, message)
+                }
             }
             Self::Invalid { key_path, reason } => {
                 write!(f, "invalid configuration at '{}': {}", key_path, reason)
@@ -51,13 +61,15 @@ mod tests {
             message: "bad token".into(),
             line: Some(10),
             column: Some(5),
+            key_path: "broker.listen".into(),
         };
-        assert_eq!(e1.to_string(), "parse error at line 10, col 5: bad token");
+        assert_eq!(e1.to_string(), "parse error at line 10, col 5 for key 'broker.listen': bad token");
 
         let e2 = ConfigError::Parse {
             message: "unexpected eof".into(),
             line: None,
             column: None,
+            key_path: "".into(),
         };
         assert_eq!(e2.to_string(), "parse error: unexpected eof");
 

--- a/crates/ramshared-config/src/error.rs
+++ b/crates/ramshared-config/src/error.rs
@@ -29,10 +29,16 @@ impl fmt::Display for ConfigError {
                 if key_path.is_empty() {
                     write!(f, "parse error at line {}, col {}: {}", l, c, message)
                 } else {
-                    write!(f, "parse error at line {}, col {} for key '{}': {}", l, c, key_path, message)
+                    write!(
+                        f,
+                        "parse error at line {}, col {} for key '{}': {}",
+                        l, c, key_path, message
+                    )
                 }
             }
-            Self::Parse { message, key_path, .. } => {
+            Self::Parse {
+                message, key_path, ..
+            } => {
                 if key_path.is_empty() {
                     write!(f, "parse error: {}", message)
                 } else {
@@ -63,7 +69,10 @@ mod tests {
             column: Some(5),
             key_path: "broker.listen".into(),
         };
-        assert_eq!(e1.to_string(), "parse error at line 10, col 5 for key 'broker.listen': bad token");
+        assert_eq!(
+            e1.to_string(),
+            "parse error at line 10, col 5 for key 'broker.listen': bad token"
+        );
 
         let e2 = ConfigError::Parse {
             message: "unexpected eof".into(),

--- a/crates/ramshared-config/src/lib.rs
+++ b/crates/ramshared-config/src/lib.rs
@@ -269,7 +269,10 @@ mod tests {
             column: Some(2),
             key_path: "broker".into(),
         };
-        assert_eq!(p1.to_string(), "parse error at line 1, col 2 for key 'broker': msg");
+        assert_eq!(
+            p1.to_string(),
+            "parse error at line 1, col 2 for key 'broker': msg"
+        );
 
         let p2 = ConfigError::Parse {
             message: "msg".into(),

--- a/crates/ramshared-config/src/lib.rs
+++ b/crates/ramshared-config/src/lib.rs
@@ -95,11 +95,44 @@ fn parse_meminfo(text: &str) -> Option<u64> {
 
 impl Config {
     pub fn parse(text: &str) -> Result<Self, ConfigError> {
-        toml::from_str(text).map_err(|err| {
-            let message = err.message().to_string();
+        let deserializer = match toml::Deserializer::parse(text) {
+            Ok(d) => d,
+            Err(err) => {
+                let message = err.message().to_string();
+                let mut line = None;
+                let mut column = None;
+                if let Some(span) = err.span() {
+                    let mut l = 1;
+                    let mut c = 1;
+                    for (i, ch) in text.chars().enumerate() {
+                        if i == span.start {
+                            line = Some(l);
+                            column = Some(c);
+                            break;
+                        }
+                        if ch == '\n' {
+                            l += 1;
+                            c = 1;
+                        } else {
+                            c += 1;
+                        }
+                    }
+                }
+                return Err(ConfigError::Parse {
+                    message,
+                    line,
+                    column,
+                    key_path: String::new(),
+                });
+            }
+        };
+
+        serde_path_to_error::deserialize(deserializer).map_err(|err| {
+            let inner_err = err.inner();
+            let message = inner_err.message().to_string();
             let mut line = None;
             let mut column = None;
-            if let Some(span) = err.span() {
+            if let Some(span) = inner_err.span() {
                 let mut l = 1;
                 let mut c = 1;
                 for (i, ch) in text.chars().enumerate() {
@@ -116,10 +149,13 @@ impl Config {
                     }
                 }
             }
+
+            let key_path = err.path().to_string();
             ConfigError::Parse {
                 message,
                 line,
                 column,
+                key_path,
             }
         })
     }
@@ -219,8 +255,9 @@ mod tests {
             ConfigError::Parse {
                 line: Some(2),
                 column: Some(13),
+                ref key_path,
                 ..
-            }
+            } if key_path == "broker.slice_mib"
         ));
     }
 
@@ -230,13 +267,15 @@ mod tests {
             message: "msg".into(),
             line: Some(1),
             column: Some(2),
+            key_path: "broker".into(),
         };
-        assert_eq!(p1.to_string(), "parse error at line 1, col 2: msg");
+        assert_eq!(p1.to_string(), "parse error at line 1, col 2 for key 'broker': msg");
 
         let p2 = ConfigError::Parse {
             message: "msg".into(),
             line: None,
             column: None,
+            key_path: "".into(),
         };
         assert_eq!(p2.to_string(), "parse error: msg");
 


### PR DESCRIPTION
## Issue
rich ConfigError with file location and expected type

## Responsavel
jules

## Resumo
Replaced generic error string matching in `ramshared-config` with proper typed extraction via `serde_path_to_error`. The new implementation enriches the `ConfigError::Parse` variant with both a structured `key_path` and the specific expected type error natively from serde/toml.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 38e903a90303e8184f02c1bddc37b74d012be7ba | refactor(config): rich ConfigError with file location and expected type | Provide specific semantic errors and exact configuration locations on parse failure. | Integrated `serde_path_to_error` and replaced `toml::from_str` string-hacking. |

## Labels
type:refactor, area:core

## Validacao
cargo test -p ramshared-config && cargo clippy -p ramshared-config -- -D warnings

## Rollback trigger
Test failure or pipeline failure

---
*PR created automatically by Jules for task [8351840840730837462](https://jules.google.com/task/8351840840730837462) started by @emersonbusson*