### PR TITLE
🧪 test(winsvc): add unit tests for DriverLink::request_stop

### DIFF
--- a/crates/ramshared-winsvc/src/driver_link.rs
+++ b/crates/ramshared-winsvc/src/driver_link.rs
@@ -741,4 +741,33 @@ mod tests {
         assert_eq!(*writes.lock().unwrap(), 0);
         assert_eq!(link.backend_writes, 0);
     }
+
+    #[test]
+    fn request_stop_causes_commit_and_fetch_to_return_stopped_error() {
+        let mut link = DriverLink::new(4, 4096, 4096).unwrap();
+        let mut be = RamBe {
+            data: vec![0u8; 8192],
+            bs: 4096,
+            last_write: Arc::new(Mutex::new(Vec::new())),
+            writes: Arc::new(Mutex::new(0)),
+        };
+        link.request_stop();
+        assert_eq!(
+            link.commit_and_fetch(&mut be),
+            Err(DriverLinkError::Stopped)
+        );
+    }
+
+    #[test]
+    fn request_stop_stops_run_io_loop() {
+        let mut link = DriverLink::new(4, 4096, 4096).unwrap();
+        let mut be = RamBe {
+            data: vec![0u8; 8192],
+            bs: 4096,
+            last_write: Arc::new(Mutex::new(Vec::new())),
+            writes: Arc::new(Mutex::new(0)),
+        };
+        link.request_stop();
+        assert_eq!(link.run_io_loop(&mut be, 10).unwrap(), 0);
+    }
 }


### PR DESCRIPTION
## 🎯 What
Address testing gap for public method `request_stop` in `DriverLink`.

## 📊 Coverage
Added tests `request_stop_causes_commit_and_fetch_to_return_stopped_error` and `request_stop_stops_run_io_loop`.

## ✨ Result
Verifies `request_stop` sets `stop = true` and properly stops `commit_and_fetch` and `run_io_loop`.

## Labels
`type:testing`, `area:winsvc`

## Commits
| Commit | Description |
| --- | --- |
| e4f5c47de180aed0af86c5abf7a32fda01f4fb21 | test(winsvc): add unit tests for DriverLink::request_stop |

---
*PR created automatically by Jules for task [15011037159439397543](https://jules.google.com/task/15011037159439397543) started by @emersonbusson*