### PR TITLE
🧪 test(winsvc): add unit tests for lock_product_volume

### DIFF
--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1187,4 +1187,25 @@ mod tests {
             .unwrap_err();
         assert!(error.to_string().contains("malformed Get-Disk output"));
     }
+
+    #[test]
+    fn lock_product_volume_rejects_invalid_drive_letter() {
+        let err = WindowsHostState::lock_product_volume('A', None).unwrap_err();
+        assert!(err.to_string().contains("letter must be D..=Z"));
+
+        let err = WindowsHostState::lock_product_volume('C', None).unwrap_err();
+        assert!(err.to_string().contains("letter must be D..=Z"));
+
+        let err = WindowsHostState::lock_product_volume('a', None).unwrap_err();
+        assert!(err.to_string().contains("letter must be D..=Z"));
+    }
+
+    #[test]
+    fn lock_product_volume_valid_letter_attempts_path_lock() {
+        let err = WindowsHostState::lock_product_volume('z', Some(1)).unwrap_err();
+        assert!(err.to_string().contains("volume"));
+
+        let err = WindowsHostState::lock_product_volume('D', None).unwrap_err();
+        assert!(err.to_string().contains("volume"));
+    }
 }


### PR DESCRIPTION
# 🧪 test(winsvc): add unit tests for lock_product_volume

## 🎯 What
Add unit test coverage for the public `lock_product_volume` method on `WindowsHostState` in `crates/ramshared-winsvc/src/windows_host.rs`.

## 📊 Coverage
- `lock_product_volume_rejects_invalid_drive_letter`: Verifies that drive letters outside `'D'..='Z'` (e.g. `'A'`, `'C'`, and lowercase `'a'`) are rejected with `letter must be D..=Z`.
- `lock_product_volume_valid_letter_attempts_path_lock`: Verifies that valid drive letters (e.g. `'z'`, `'D'`) are converted to uppercase and proceed to path locking attempt (`HostError::Volume`).

## ✨ Result
Increases unit test coverage for `lock_product_volume` validation logic and path lock delegation in `ramshared-winsvc`.

## Labels
- type:testing
- area:winsvc

## Commits
| Hash | Message |
| --- | --- |
| c56b2100a751f14cb5a8ba6f8b1b8a84a538a2e3 | 🧪 test(winsvc): add unit tests for lock_product_volume |

---
*PR created automatically by Jules for task [5089558438870748617](https://jules.google.com/task/5089558438870748617) started by @emersonbusson*