### PR TITLE
🧪 test(winsvc): add unit test for driver_complete in driver_link

### DIFF
--- a/crates/ramshared-winsvc/src/driver_link.rs
+++ b/crates/ramshared-winsvc/src/driver_link.rs
@@ -741,4 +741,33 @@ mod tests {
         assert_eq!(*writes.lock().unwrap(), 0);
         assert_eq!(link.backend_writes, 0);
     }
+
+    #[test]
+    fn test_driver_complete_direct() {
+        let mut q = InMemoryQueue::new(4, 4096, 4096).unwrap();
+        assert_eq!(q.driver_complete().unwrap(), None);
+
+        let cqe1 = Cqe {
+            tag: 101,
+            status: ST_OK,
+            reserved: 0,
+        };
+        let cqe2 = Cqe {
+            tag: 102,
+            status: ST_EINVAL,
+            reserved: 0,
+        };
+        q.push_cqe(cqe1).unwrap();
+        q.push_cqe(cqe2).unwrap();
+
+        let popped1 = q.driver_complete().unwrap().unwrap();
+        assert_eq!(popped1.tag, 101);
+        assert_eq!(popped1.status, ST_OK);
+
+        let popped2 = q.driver_complete().unwrap().unwrap();
+        assert_eq!(popped2.tag, 102);
+        assert_eq!(popped2.status, ST_EINVAL);
+
+        assert_eq!(q.driver_complete().unwrap(), None);
+    }
 }


### PR DESCRIPTION
# 🧪 test(winsvc): add unit test for driver_complete in driver_link

## Summary
Adds `test_driver_complete_direct` unit test covering `InMemoryQueue::driver_complete` directly in `crates/ramshared-winsvc/src/driver_link.rs`.

## Details
- 🎯 **What:** Adds unit test coverage for public function `driver_complete`.
- 📊 **Coverage:** Tests empty completion queue returning `Ok(None)`, popping pushed CQEs in FIFO order returning `Ok(Some(cqe))`, and returning `Ok(None)` when empty again.
- ✨ **Result:** Improved test coverage for `driver_complete`.

## Labels
type:testing
area:winsvc

## Commits
| Commit | Description |
| --- | --- |
| c3fac77f01dee54cdd8042d3e095a21fcb6432d2 | test(winsvc): add unit test for driver_complete in driver_link |

---
*PR created automatically by Jules for task [17060799916146258480](https://jules.google.com/task/17060799916146258480) started by @emersonbusson*