### PR TITLE
🧪 test(winsvc): add unit tests for ProductManifestV1 version_directory and artifact

### DIFF
--- a/crates/ramshared-winsvc/src/package.rs
+++ b/crates/ramshared-winsvc/src/package.rs
@@ -485,4 +485,17 @@ mod tests {
         let injected_char = build_residue_script('\'');
         assert!(injected_char.is_err());
     }
+
+    #[test]
+    fn product_manifest_version_directory_and_artifact() {
+        let m = manifest();
+        assert_eq!(m.version_directory(), "1.2.3-abcdef123456");
+
+        let artifact = m.artifact(ArtifactRole::BrokerExe).unwrap();
+        assert_eq!(artifact.role, ArtifactRole::BrokerExe);
+
+        let mut m_missing = manifest();
+        m_missing.artifacts.retain(|a| a.role != ArtifactRole::BrokerExe);
+        assert!(m_missing.artifact(ArtifactRole::BrokerExe).is_err());
+    }
 }


### PR DESCRIPTION
## 🎯 What
Added unit test coverage for `ProductManifestV1`'s public methods (`version_directory` and `artifact`) in `crates/ramshared-winsvc/src/package.rs`.

## 📊 Coverage
- Verified `version_directory()` returns formatted version and 12-char commit prefix string (`1.2.3-abcdef123456`).
- Verified `artifact()` successfully retrieves an artifact by role and returns an error when the requested artifact role is missing.

## ✨ Result
Increases test coverage and guarantees `ProductManifestV1` version directory string formatting and artifact lookup behavior.

---
*PR created automatically by Jules for task [6764195187964680909](https://jules.google.com/task/6764195187964680909) started by @emersonbusson*