### PR TITLE
🧪 test(winsvc): add unit tests for DriverLink run_io_loop

### DIFF
--- a/crates/ramshared-winsvc/src/driver_link.rs
+++ b/crates/ramshared-winsvc/src/driver_link.rs
@@ -741,4 +741,26 @@ mod tests {
         assert_eq!(*writes.lock().unwrap(), 0);
         assert_eq!(link.backend_writes, 0);
     }
+
+    #[test]
+    fn run_io_loop_executes_cycles_and_respects_stop() {
+        let mut link = DriverLink::new(4, 4096, 4096).unwrap();
+        let mut be = RamBe {
+            data: vec![0u8; 1 << 16],
+            bs: 4096,
+            last_write: Arc::new(Mutex::new(Vec::new())),
+            writes: Arc::new(Mutex::new(0)),
+        };
+        {
+            let mut fake = FakeDriver::new(&mut link);
+            fake.submit_read(1, 0, 4096, 0).unwrap();
+        }
+        let processed = link.run_io_loop(&mut be, 3).unwrap();
+        assert_eq!(processed, 1);
+
+        // Verify stop flag terminates the loop early
+        link.request_stop();
+        let processed_after_stop = link.run_io_loop(&mut be, 5).unwrap();
+        assert_eq!(processed_after_stop, 0);
+    }
 }


### PR DESCRIPTION
## Summary
Adds unit test coverage for `DriverLink::run_io_loop` in `crates/ramshared-winsvc/src/driver_link.rs`.

## Labels
- type:testing
- area:winsvc

## Commits
| Hash | Message |
| --- | --- |
| 2a28d8fbb64c1555f70ea777d0648dddfe32f2a4 | test(winsvc): add unit tests for DriverLink run_io_loop |

## Description
🎯 **What:** Adds unit test coverage for `DriverLink::run_io_loop` in `crates/ramshared-winsvc/src/driver_link.rs`.
📊 **Coverage:** Tests cycle execution with pending I/O submissions and verifies stop flag handling.
✨ **Result:** Ensures `run_io_loop` operates deterministically and handles stopping conditions properly.

---
*PR created automatically by Jules for task [16565654981393052564](https://jules.google.com/task/16565654981393052564) started by @emersonbusson*