### PR TITLE
🧹 refactor(agent): replace explicit panic in parse_config test helper

### DIFF
--- a/crates/ramshared-agent/src/main.rs
+++ b/crates/ramshared-agent/src/main.rs
@@ -565,10 +565,12 @@ mod tests {
     }
 
     fn parse_config(v: &[&str]) -> Config {
-        match parse_args(&args(v)).expect("arguments must parse as a configuration") {
-            ParsedArgs::Config(config) => config,
-            ParsedArgs::Help => panic!("test expected configuration, not help"),
+        match parse_args(&args(v)) {
+            Ok(ParsedArgs::Config(config)) => Ok(config),
+            Ok(ParsedArgs::Help) => Err("test expected configuration, not help".to_string()),
+            Err(err) => Err(err),
         }
+        .expect("arguments must parse as a configuration")
     }
 
     fn test_config(broker: String, watchdog: Duration) -> Config {


### PR DESCRIPTION
🎯 **What:** Replaced the explicit `panic!()` call in the `parse_config` test helper function in `crates/ramshared-agent/src/main.rs` with `Result` mapping and `.expect()`.
💡 **Why:** Eliminates explicit `panic!()` invocation in test utilities, improving code health, maintainability, and clean error handling.
✅ **Verification:** Confirmed via `cargo test -p ramshared-agent` and `git diff`.
✨ **Result:** Refactored test helper code without behavior changes or regressions.

Commit SHA: a9fd23b4a6e92308ee16e483643e8b33fe76edaa

---
*PR created automatically by Jules for task [13482959448400027384](https://jules.google.com/task/13482959448400027384) started by @emersonbusson*