### PR TITLE
🧪 test(winsvc): add unit test for WindowsHostState::lock_volume

### DIFF
--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1134,10 +1134,16 @@ mod tests {
 
     #[test]
     fn lock_volume_invalid_letter_is_rejected() {
-        let err = WindowsHostState::lock_volume('C').unwrap_err();
+        let err = match WindowsHostState::lock_volume('C') {
+            Err(e) => e,
+            Ok(_) => panic!("expected lock_volume to fail for letter C"),
+        };
         assert!(matches!(err, HostError::Volume(msg) if msg.contains("letter must be D..=Z")));
 
-        let err = WindowsHostState::lock_volume('A').unwrap_err();
+        let err = match WindowsHostState::lock_volume('A') {
+            Err(e) => e,
+            Ok(_) => panic!("expected lock_volume to fail for letter A"),
+        };
         assert!(matches!(err, HostError::Volume(msg) if msg.contains("letter must be D..=Z")));
     }
 

--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1133,6 +1133,15 @@ mod tests {
     }
 
     #[test]
+    fn lock_volume_invalid_letter_is_rejected() {
+        let err = WindowsHostState::lock_volume('C').unwrap_err();
+        assert!(matches!(err, HostError::Volume(msg) if msg.contains("letter must be D..=Z")));
+
+        let err = WindowsHostState::lock_volume('A').unwrap_err();
+        assert!(matches!(err, HostError::Volume(msg) if msg.contains("letter must be D..=Z")));
+    }
+
+    #[test]
     fn lun_identity_requires_vendor_product_serial_and_size() {
         let lun = LunIdentity {
             vendor: "RAMSHARE".into(),


### PR DESCRIPTION
## Summary
Added unit test `lock_volume_invalid_letter_is_rejected` in `crates/ramshared-winsvc/src/windows_host.rs` to verify that `lock_volume` validates drive letters and returns `HostError::Volume` when invalid drive letters like 'C' or 'A' are provided.

## Labels
type:test
area:winsvc

## Commits
| Commit | Description |
| --- | --- |
| f703fa9b988a5a819672b21a9c3b235ab4cd7022 | test(winsvc): add unit test coverage for lock_volume validation |

## PR Details
🎯 **What:** Added unit test for `WindowsHostState::lock_volume` drive letter validation.
📊 **Coverage:** Covered edge case where drive letter is outside 'D'..='Z' range.
✨ **Result:** Verified that `lock_volume` rejects invalid drive letters without attempting OS calls.

---
*PR created automatically by Jules for task [1800208225073811653](https://jules.google.com/task/1800208225073811653) started by @emersonbusson*