### PR TITLE
🧹 refactor(block): replace unwrap with expect in test backend helper

### DIFF
--- a/crates/ramshared-block/src/origin_cache.rs
+++ b/crates/ramshared-block/src/origin_cache.rs
@@ -900,7 +900,8 @@ mod tests {
         provider: &'a FakeProvider,
         origin: ScriptedOrigin,
     ) -> WriteThroughCacheBackend<'a, FakeProvider, ScriptedOrigin> {
-        WriteThroughCacheBackend::with_chunk_bytes(provider, origin, 32, 4, 8).unwrap()
+        WriteThroughCacheBackend::with_chunk_bytes(provider, origin, 32, 4, 8)
+            .expect("valid test backend geometry")
     }
 
     fn grow_one<O: OriginStorage>(backend: &mut WriteThroughCacheBackend<'_, FakeProvider, O>) {


### PR DESCRIPTION
## Context
The test helper function `backend()` in `crates/ramshared-block/src/origin_cache.rs` previously called `.unwrap()` when constructing `WriteThroughCacheBackend`. Replacing `.unwrap()` with `.expect(...)` improves error clarity and maintainability in test execution.

## Changes
- Updated `backend()` in `crates/ramshared-block/src/origin_cache.rs` to call `.expect("valid test backend geometry")`.

## Verification
- Ran unit tests using `cargo test -p ramshared-block`, all 82 tests passed successfully.

## Labels
- type:refactor
- area:core

## Commits
| Hash | Message |
| --- | --- |
| 49e32ade9e758bc20ab2632edd4a0595570a0b11 | refactor(block): replace unsafe unwrap in origin_cache test helper |


---
*PR created automatically by Jules for task [3347731051226697124](https://jules.google.com/task/3347731051226697124) started by @emersonbusson*