### PR TITLE
🧪 test(winsvc): add unit tests for public entry function in main.rs

### DIFF
--- a/crates/ramshared-winsvc/src/main.rs
+++ b/crates/ramshared-winsvc/src/main.rs
@@ -127,6 +127,26 @@ mod windows_svc {
         }
     }
 
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_entry_invalid_args_returns_code_2() {
+            let args = vec!["ramshared-winsvc.exe".to_string(), "invalid_command".to_string()];
+            let code = entry(args);
+            assert_eq!(code, 2);
+        }
+
+        #[test]
+        fn test_entry_empty_args_handled() {
+            let args = vec!["ramshared-winsvc.exe".to_string()];
+            let code = entry(args);
+            // SCM default without service dispatcher running returns 1
+            assert_eq!(code, 1);
+        }
+    }
+
     fn service_main(_args: Vec<OsString>) {
         if let Err(e) = run_service() {
             eprintln!("service error: {e}");

--- a/crates/ramshared-winsvc/src/main.rs
+++ b/crates/ramshared-winsvc/src/main.rs
@@ -133,7 +133,10 @@ mod windows_svc {
 
         #[test]
         fn test_entry_invalid_args_returns_code_2() {
-            let args = vec!["ramshared-winsvc.exe".to_string(), "invalid_command".to_string()];
+            let args = vec![
+                "ramshared-winsvc.exe".to_string(),
+                "invalid_command".to_string(),
+            ];
             let code = entry(args);
             assert_eq!(code, 2);
         }


### PR DESCRIPTION
## Summary
Add unit test coverage for the public function `entry` in `crates/ramshared-winsvc/src/main.rs`.

## Coverage
- Added `test_entry_invalid_args_returns_code_2` to test CLI argument parsing returning exit code 2 for invalid arguments.
- Added `test_entry_empty_args_handled` to test default SCM fallback returning exit code 1 when no service dispatcher is present.

## Labels
type:testing
area:winsvc

## Commits
| Hash | Message |
| --- | --- |
| d5308765c91b162b507c94c5e948be96e29c527a | test(winsvc): add unit tests for public entry function in main.rs |


---
*PR created automatically by Jules for task [2186675681595389877](https://jules.google.com/task/2186675681595389877) started by @emersonbusson*