### PR TITLE
🧹 refactor(winsvc): handle Mutex lock errors safely in driver_link test backend

### DIFF
--- a/crates/ramshared-winsvc/src/driver_link.rs
+++ b/crates/ramshared-winsvc/src/driver_link.rs
@@ -554,8 +554,8 @@ mod tests {
             Ok(())
         }
         fn write_at(&mut self, off: u64, data: &[u8]) -> Result<(), IoError> {
-            *self.writes.lock().unwrap() += 1;
-            *self.last_write.lock().unwrap() = data.to_vec();
+            *self.writes.lock().map_err(|e| IoError(e.to_string()))? += 1;
+            *self.last_write.lock().map_err(|e| IoError(e.to_string()))? = data.to_vec();
             let o = off as usize;
             self.data[o..o + data.len()].copy_from_slice(data);
             Ok(())


### PR DESCRIPTION
## Summary
* 🎯 **What:** Replaced unsafe `unwrap()` calls on `Mutex::lock()` in `RamBe::write_at` inside `crates/ramshared-winsvc/src/driver_link.rs` with safe error propagation using `.map_err(|e| IoError(e.to_string()))?`.
* 💡 **Why:** Replaces potentially panicking `unwrap()` calls on Mutex lock acquisition with `Result` error propagation, improving code reliability and maintainability.
* ✅ **Verification:** Ran `cargo test -p ramshared-winsvc` and verified all 128 tests pass.
* ✨ **Result:** Clean, safe error handling for Mutex locks in `RamBe`.

## Labels
type:refactor
area:winsvc

## Commits
| Commit | Description |
| --- | --- |
| d004eb6af3d80c6ff3fa6cef750c0da4efc245cd | refactor(winsvc): replace unsafe unwrap on Mutex lock in driver_link RamBe implementation |

---
*PR created automatically by Jules for task [15143630102596307930](https://jules.google.com/task/15143630102596307930) started by @emersonbusson*