### PR TITLE
🧹 refactor(block): replace unwrap with error propagation in origin_cache tests

### DIFF
--- a/crates/ramshared-block/src/origin_cache.rs
+++ b/crates/ramshared-block/src/origin_cache.rs
@@ -910,7 +910,7 @@ mod tests {
         assert_eq!(outcome.allocated_bytes, 8);
     }
 
-    fn assert_write_release_vram_read_origin_hash_matches() {
+    fn assert_write_release_vram_read_origin_hash_matches() -> Result<(), IoError> {
         let events = Rc::new(RefCell::new(Vec::new()));
         let provider = FakeProvider::new(Rc::clone(&events));
         let origin = ScriptedOrigin::new(32, Rc::clone(&events));
@@ -919,17 +919,18 @@ mod tests {
         events.borrow_mut().clear();
 
         let payload = *b"cache-origin-round-trip-proof-32";
-        backend.write_at(0, &payload).unwrap();
+        backend.write_at(0, &payload)?;
         assert_eq!(backend.release_cache(), 8);
 
         let mut read_back = [0; 32];
-        backend.read_at(0, &mut read_back).unwrap();
+        backend.read_at(0, &mut read_back)?;
         assert_eq!(read_back, payload);
         assert_eq!(backend.telemetry().fallback_reads, 1);
         assert_eq!(
             events.borrow().as_slice(),
             ["origin_write", "cache_write", "origin_read"]
         );
+        Ok(())
     }
 
     #[test]
@@ -947,21 +948,22 @@ mod tests {
     }
 
     #[test]
-    fn write_release_vram_read_origin_hash_matches() {
-        assert_write_release_vram_read_origin_hash_matches();
+    fn write_release_vram_read_origin_hash_matches() -> Result<(), IoError> {
+        assert_write_release_vram_read_origin_hash_matches()
     }
 
     #[test]
     // TestName: write_release_vram_read_origin_hash_parallel_fixtures_are_isolated
-    fn write_release_vram_read_origin_hash_parallel_fixtures_are_isolated() {
+    fn write_release_vram_read_origin_hash_parallel_fixtures_are_isolated() -> Result<(), IoError> {
         std::thread::scope(|scope| {
             let workers = (0..4)
                 .map(|_| scope.spawn(assert_write_release_vram_read_origin_hash_matches))
                 .collect::<Vec<_>>();
             for worker in workers {
-                worker.join().unwrap();
+                worker.join().expect("worker thread panicked")?;
             }
-        });
+            Ok(())
+        })
     }
 
     #[test]


### PR DESCRIPTION
## Title
🧹 refactor(block): replace unwrap with error propagation in origin_cache tests

## Description
🎯 **What:** Replaced unsafe `unwrap()` calls on `write_at` and `read_at` within `assert_write_release_vram_read_origin_hash_matches()` in `crates/ramshared-block/src/origin_cache.rs` with `?` error propagation operators. Updated helper signature and calling test functions to return `Result<(), IoError>`.
💡 **Why:** Propagating errors with `?` improves code health, reliability, and test hygiene by avoiding panic-on-unwrap patterns.
✅ **Verification:** Verified that `cargo test -p ramshared-block` passes all 82 tests successfully.
✨ **Result:** Enhanced test code health and safety without behavioral changes.

## Labels
type:refactor, area:core

## Commits
c3376e7a34b240e910db774aa25948bbb2945047

---
*PR created automatically by Jules for task [14336280487162057435](https://jules.google.com/task/14336280487162057435) started by @emersonbusson*