### PR TITLE
🧪 test(winsvc): add unit test for DriverLink::from_queue

### DIFF
--- a/crates/ramshared-winsvc/src/driver_link.rs
+++ b/crates/ramshared-winsvc/src/driver_link.rs
@@ -741,4 +741,15 @@ mod tests {
         assert_eq!(*writes.lock().unwrap(), 0);
         assert_eq!(link.backend_writes, 0);
     }
+
+    #[test]
+    fn from_queue_initializes_driver_link() {
+        let queue = InMemoryQueue::new(4, 4096, 4096).unwrap();
+        let link = DriverLink::from_queue(queue);
+        assert_eq!(link.q.queue_depth(), 4);
+        assert_eq!(link.q.max_io_bytes(), 4096);
+        assert_eq!(link.q.block_size(), 4096);
+        assert_eq!(link.backend_writes, 0);
+        assert_eq!(link.stats().reads, 0);
+    }
 }


### PR DESCRIPTION
## Summary
Adds a unit test for DriverLink::from_queue in crates/ramshared-winsvc/src/driver_link.rs.

## Commits
| Commit | Description |
| --- | --- |
| 12af0a81340108571c16fa73ddb4266c7adaa691 | test(winsvc): add unit test for DriverLink::from_queue |

## Labels
type:test
area:winsvc

🎯 **What:** The testing gap addressed for DriverLink::from_queue.
📊 **Coverage:** DriverLink construction from an existing QueueAccess instance.
✨ **Result:** Increased test coverage for winsvc module.

---
*PR created automatically by Jules for task [10498697884112635775](https://jules.google.com/task/10498697884112635775) started by @emersonbusson*