### PR TITLE
🧪 [testing] add unit tests for observe_product_volume

### DIFF
--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1197,20 +1197,20 @@ mod tests {
                 "0123456789ABCDEF",
                 64 * 1024 * 1024,
             );
-            assert!(matches!(res, Err(HostError::Volume(msg)) if msg.contains("letter must be D..=Z")));
+            assert!(
+                matches!(res, Err(HostError::Volume(msg)) if msg.contains("letter must be D..=Z"))
+            );
         }
     }
 
     #[test]
     fn observe_product_volume_invalid_serial() {
         for bad_serial in ["12345", "12345678901234567", "123456789012345Z"] {
-            let res = WindowsHostState::observe_product_volume(
-                'D',
-                None,
-                bad_serial,
-                64 * 1024 * 1024,
+            let res =
+                WindowsHostState::observe_product_volume('D', None, bad_serial, 64 * 1024 * 1024);
+            assert!(
+                matches!(res, Err(HostError::Identity(msg)) if msg.contains("serial must be 16 hex chars"))
             );
-            assert!(matches!(res, Err(HostError::Identity(msg)) if msg.contains("serial must be 16 hex chars")));
         }
     }
 }

--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1187,4 +1187,30 @@ mod tests {
             .unwrap_err();
         assert!(error.to_string().contains("malformed Get-Disk output"));
     }
+
+    #[test]
+    fn observe_product_volume_invalid_letter() {
+        for bad_letter in ['A', 'C', '['] {
+            let res = WindowsHostState::observe_product_volume(
+                bad_letter,
+                None,
+                "0123456789ABCDEF",
+                64 * 1024 * 1024,
+            );
+            assert!(matches!(res, Err(HostError::Volume(msg)) if msg.contains("letter must be D..=Z")));
+        }
+    }
+
+    #[test]
+    fn observe_product_volume_invalid_serial() {
+        for bad_serial in ["12345", "12345678901234567", "123456789012345Z"] {
+            let res = WindowsHostState::observe_product_volume(
+                'D',
+                None,
+                bad_serial,
+                64 * 1024 * 1024,
+            );
+            assert!(matches!(res, Err(HostError::Identity(msg)) if msg.contains("serial must be 16 hex chars")));
+        }
+    }
 }


### PR DESCRIPTION
🧪 [testing] add unit tests for observe_product_volume

## What
Add unit tests for `WindowsHostState::observe_product_volume` covering argument validation logic.

## Coverage
- `observe_product_volume_invalid_letter`: Validates rejection of letters outside `'D'..='Z'`.
- `observe_product_volume_invalid_serial`: Validates rejection of serials that are not 16 hex characters.

## Result
Improved test coverage for public function `WindowsHostState::observe_product_volume` in `crates/ramshared-winsvc/src/windows_host.rs`.

## Labels
- `type:testing`
- `area:winsvc`

## Commits
| Commit | Message |
| --- | --- |
| 992881ac23d32b25361cae6c64e3f9cf4af3931c | 🧪 [testing] add unit tests for observe_product_volume |


---
*PR created automatically by Jules for task [12759304578289482521](https://jules.google.com/task/12759304578289482521) started by @emersonbusson*