### PR TITLE
🧹 [code health improvement description]

### DIFF
--- a/docs/jules/findings/RAW_DISK_SERVICE_PANIC_AUDIT.md
+++ b/docs/jules/findings/RAW_DISK_SERVICE_PANIC_AUDIT.md
@@ -1,0 +1,10 @@
+# Finding: RawDisk Service Panic Audit
+
+## Summary
+An audit of `crates/ramshared-winsvc/src/service.rs` was conducted regarding the reported `panic!()` calls in `RawGates`.
+
+## Verification
+Inspection of `crates/ramshared-winsvc/src/service.rs` (lines 505-530) confirms that `RawGates` methods (`lock_volume`, `unlock_volume`, `flush_and_dismount`) do not contain `panic!()` calls. Instead, they properly return `Err("an exact RAW disk has no volume to lock".into())`, `Err("an exact RAW disk has no volume to unlock".into())`, and `Err("an exact RAW disk has no filesystem to dismount".into())`.
+
+## Conclusion
+The reported issue has already been resolved in the current baseline repository. No further code modifications to `crates/ramshared-winsvc/src/service.rs` are required.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,10 +2,10 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 252,
+    "total": 253,
     "classified": 249,
     "excluded": 3,
-    "unclassified": 0,
+    "unclassified": 1,
     "ambiguous": 0
   },
   "entries": [
@@ -556,6 +556,14 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/RAW_DISK_SERVICE_PANIC_AUDIT.md",
+      "disposition": "unclassified",
+      "ruleId": null,
+      "verification": {
+        "state": "unverified"
+      }
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Summary
Document audit finding verifying that panic!() calls in RawGates within crates/ramshared-winsvc/src/service.rs were previously replaced with semantic Err returns.

## Changes
- Add `docs/jules/findings/RAW_DISK_SERVICE_PANIC_AUDIT.md` finding report
- Update `docs/reference/DOCUMENTATION-INVENTORY.json`

## Verification
Ran `cargo test -p ramshared-winsvc service::tests::exact_raw_disk_runs_both_gates_without_volume_operations` and confirmed 100% pass rate.

## Labels
type:documentation
area:windows-driver

## Commits
42d129588d536cbf1fe4446a6d9f03f8929ff95f

---
*PR created automatically by Jules for task [17979162899706740226](https://jules.google.com/task/17979162899706740226) started by @emersonbusson*