### PR TITLE
🧪 test(winsvc): add unit test coverage for connect_product_pipe

### DIFF
--- a/crates/ramshared-winsvc/src/ipc.rs
+++ b/crates/ramshared-winsvc/src/ipc.rs
@@ -234,4 +234,22 @@ mod tests {
         let result = retry_until(Instant::now(), || Err(2));
         assert_eq!(result, Err(BrokerConnectError::Deadline));
     }
+    #[cfg(windows)]
+    #[test]
+    fn connect_product_pipe_deadline_stops_retry() {
+        let result = NamedPipeBrokerStream::connect_product_pipe(Instant::now());
+        assert!(matches!(
+            result,
+            Err(BrokerConnectError::Deadline) | Err(BrokerConnectError::NonTransient(_))
+        ));
+    }
+    #[cfg(windows)]
+    #[test]
+    fn connect_status_pipe_deadline_stops_retry() {
+        let result = NamedPipeBrokerStream::connect_status_pipe(Instant::now());
+        assert!(matches!(
+            result,
+            Err(BrokerConnectError::Deadline) | Err(BrokerConnectError::NonTransient(_))
+        ));
+    }
 }


### PR DESCRIPTION
## Title
🧪 test(winsvc): add unit test coverage for connect_product_pipe

## Description
🎯 **What:**
Added unit test coverage for `NamedPipeBrokerStream::connect_product_pipe` and `NamedPipeBrokerStream::connect_status_pipe` in `crates/ramshared-winsvc/src/ipc.rs`.

📊 **Coverage:**
- Added `connect_product_pipe_deadline_stops_retry` under `#[cfg(windows)]` to test deadline expiration during product named pipe connection.
- Added `connect_status_pipe_deadline_stops_retry` under `#[cfg(windows)]` to test deadline expiration during status named pipe connection.

✨ **Result:**
The public functions `connect_product_pipe` and `connect_status_pipe` now have explicit unit test coverage in `ipc.rs`.

## Labels
type:testing
area:winsvc

## Commits
656b4eaae83d14f25f76064a1f1ca3d516ff14ad

---
*PR created automatically by Jules for task [1708203885364369494](https://jules.google.com/task/1708203885364369494) started by @emersonbusson*