### PR TITLE
🧪 [testing improvement] Add unit test for WindowsHostState::is_elevated

### DIFF
--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1187,4 +1187,10 @@ mod tests {
             .unwrap_err();
         assert!(error.to_string().contains("malformed Get-Disk output"));
     }
+
+    #[test]
+    fn is_elevated_queries_process_token_without_panic() {
+        let elevated = WindowsHostState::is_elevated();
+        let _ = elevated;
+    }
 }


### PR DESCRIPTION
# 🧪 [testing improvement] Add unit test for WindowsHostState::is_elevated

## 🎯 What
Adds a unit test for `WindowsHostState::is_elevated()` in `crates/ramshared-winsvc/src/windows_host.rs`.

## 📊 Coverage
Covered `WindowsHostState::is_elevated()` to verify process token querying executes without panic.

## ✨ Result
Increased test coverage for `WindowsHostState`.

## Labels
`type:testing`, `area:winsvc`

## Commits
| Commit | Description |
| --- | --- |
| `fce2e7c9d1515eb46601fc9e654367b069cf2b03` | test(winsvc): add unit test for WindowsHostState::is_elevated |

---
*PR created automatically by Jules for task [4582414060204071506](https://jules.google.com/task/4582414060204071506) started by @emersonbusson*