### PR TITLE
🧪 [testing improvement] Add test for WindowsHostState::flush_and_dismount

### DIFF
--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1187,4 +1187,16 @@ mod tests {
             .unwrap_err();
         assert!(error.to_string().contains("malformed Get-Disk output"));
     }
+
+    #[test]
+    fn flush_and_dismount_invalid_handle_returns_volume_error() {
+        let vol = LockedVolume {
+            letter: 'Z',
+            disk_number: 1,
+            handle: INVALID_HANDLE_VALUE,
+        };
+        let err = WindowsHostState::flush_and_dismount(&vol).unwrap_err();
+        assert!(matches!(err, HostError::Volume(_)));
+        assert!(err.to_string().contains("FlushFileBuffers"));
+    }
 }


### PR DESCRIPTION
## Summary

Add unit test coverage for `WindowsHostState::flush_and_dismount` in `crates/ramshared-winsvc/src/windows_host.rs`.

## Details

- Adds `flush_and_dismount_invalid_handle_returns_volume_error` test in `windows_host.rs`.
- Tests error handling when `flush_and_dismount` is called with an invalid handle.
- Confirms proper error propagation (`HostError::Volume`).

## Labels
type:test,area:winsvc

## Commits
| Hash | Message |
| --- | --- |
| ac1d10b5606e5dce2c761115798adb778284b15e | test(winsvc): add unit test for flush_and_dismount in windows_host |


---
*PR created automatically by Jules for task [3074990503146908733](https://jules.google.com/task/3074990503146908733) started by @emersonbusson*