### PR TITLE
🧪 test(winsvc): add unit tests for driver_read_slot

### DIFF
--- a/crates/ramshared-winsvc/src/driver_link.rs
+++ b/crates/ramshared-winsvc/src/driver_link.rs
@@ -715,6 +715,21 @@ mod tests {
     }
 
     #[test]
+    fn driver_read_slot_valid_and_invalid() {
+        let mut queue = InMemoryQueue::new(4, 4096, 4096).unwrap();
+        let payload = vec![0x42u8; 1024];
+        queue.driver_write_slot(1, &payload).unwrap();
+        let read_data = queue.driver_read_slot(1, 1024).unwrap();
+        assert_eq!(read_data, payload.as_slice());
+
+        let err_slot = queue.driver_read_slot(4, 1024).unwrap_err();
+        assert!(matches!(err_slot, DriverLinkError::Invalid(_)));
+
+        let err_len = queue.driver_read_slot(1, 4097).unwrap_err();
+        assert!(matches!(err_len, DriverLinkError::Invalid(_)));
+    }
+
+    #[test]
     fn invalid_slot_does_not_touch_backend() {
         let mut link = DriverLink::new(4, 4096, 4096).unwrap();
         let writes = Arc::new(Mutex::new(0));


### PR DESCRIPTION
## Summary
Adds unit testing for `driver_read_slot` in `crates/ramshared-winsvc/src/driver_link.rs`.

## Changes
- Added `driver_read_slot_valid_and_invalid` unit test in `driver_link.rs` covering happy path reading from a slot, out-of-bounds slot index error, and length exceeding `max_io_bytes` error.

## Commits
- d84f97b9eeb21eb28a033165af01796e4acf8d0b

## Labels
- type:test
- area:winsvc

---
*PR created automatically by Jules for task [8785327212779694787](https://jules.google.com/task/8785327212779694787) started by @emersonbusson*