### PR TITLE
🧹 refactor(winsvc): replace unwrap in with_reply test helper with ? error propagation

### DIFF
--- a/crates/ramshared-winsvc/src/broker_tenant.rs
+++ b/crates/ramshared-winsvc/src/broker_tenant.rs
@@ -261,13 +261,16 @@ mod tests {
 
     use ramshared_broker::protocol::{Msg, write_msg};
 
-    fn with_reply(request: Msg, reply: Msg) -> (Cursor<Vec<u8>>, Vec<u8>) {
+    fn with_reply(
+        request: Msg,
+        reply: Msg,
+    ) -> Result<(Cursor<Vec<u8>>, Vec<u8>), ramshared_broker::protocol::ProtocolError> {
         let mut out = Vec::new();
-        write_msg(&mut out, &reply).unwrap();
+        write_msg(&mut out, &reply)?;
         let mut in_buf = Vec::new();
-        write_msg(&mut in_buf, &request).unwrap(); // not used; stream is reply-only for read
+        write_msg(&mut in_buf, &request)?; // not used; stream is reply-only for read
         let _ = in_buf;
-        (Cursor::new(out), Vec::new())
+        Ok((Cursor::new(out), Vec::new()))
     }
 
     #[test]
@@ -396,7 +399,7 @@ mod tests {
     // silence unused helper
     #[test]
     fn dual_with_reply_helper_compiles() {
-        let _ = with_reply(Msg::Ack, Msg::Registered { tenant_id: 1 });
+        let _ = with_reply(Msg::Ack, Msg::Registered { tenant_id: 1 }).expect("with_reply failed");
     }
 
     #[test]


### PR DESCRIPTION
# 🧹 refactor(winsvc): replace unwrap in with_reply test helper with ? error propagation

## What
Refactored `with_reply` in `crates/ramshared-winsvc/src/broker_tenant.rs` to return `Result<(Cursor<Vec<u8>>, Vec<u8>), ProtocolError>` and propagated errors using `?` instead of `.unwrap()`.

## Why
Improves code health and reliability by replacing unsafe `.unwrap()` calls with explicit Result error propagation in test helper functions.

## Verification
Executed `cargo test -p ramshared-winsvc` to verify all 128 tests pass.

## Result
Clean error propagation without `.unwrap()` panics in `with_reply`.

## Labels
type:refactor
area:core

## Commits
| Commit SHA | Description |
| --- | --- |
| edd9de850dd41c0ff01307350331f24a470dff7a | refactor(winsvc): replace unwrap in with_reply test helper with ? error propagation |
| 5a7975d370190f633fb8f73a098808766b0ca3a3 | refactor(winsvc): update with_reply call site in dual_with_reply_helper_compiles |


---
*PR created automatically by Jules for task [4324217856320114545](https://jules.google.com/task/4324217856320114545) started by @emersonbusson*