### PR TITLE
⚡ refactor(wsl2d): analyze synchronous IO in ProductionUblkRuntime

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -4,6 +4,16 @@
   "registeredAt": "2026-08-11T15:15:12Z",
   "routes": [
     {
+      "id": "jules-findings-documents",
+      "pattern": "docs/jules/findings/*",
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/synchronous-io-wsl2d-main.md",
+      "lifecycle": "reviewable",
+      "freshnessDays": 90,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-08-11T15:15:12Z"
+    },
+    {
       "id": "root-product-documents",
       "pattern": "README.md",
       "owner": "product-documentation",

--- a/docs/jules/findings/synchronous-io-wsl2d-main.md
+++ b/docs/jules/findings/synchronous-io-wsl2d-main.md
@@ -1,0 +1,12 @@
+# Analysis of Synchronous IO / Loop in `crates/ramshared-wsl2d/src/main.rs:4560`
+
+## Overview
+The issue report highlights `crates/ramshared-wsl2d/src/main.rs:4560` (`wait_for_shutdown`, `swap_state`, `swapoff` in `ProductionUblkRuntime`).
+
+## Analysis
+1. `wait_for_shutdown()` polls an `AtomicBool` (`SHUTDOWN`) with `std::thread::sleep(Duration::from_millis(200))` inside a blocking loop while waiting for SIGINT/SIGTERM daemon shutdown.
+2. `ProductionUblkRuntime` is a synchronous trait implementation for `UblkRuntime`, which manages synchronous device lifecycle commands (`ublk_control`, `swapoff`, reading `/proc/swaps`).
+3. `wait_for_shutdown()` is invoked only during daemon shutdown wait sequence in `run_ublk_device_loop` on a dedicated CLI runner thread. It does not block any async event loop or high-frequency worker queue.
+
+## Finding
+The code at line 4560 represents synchronous daemon lifecycle waiting and synchronous kernel `/proc/swaps` / `swapoff` runtime execution. Modifying `UblkRuntime` to async or altering the polling interval is unsafe for block device teardown ordering and is intended synchronous management code.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 252,
-    "classified": 249,
+    "total": 253,
+    "classified": 250,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -554,6 +554,18 @@
       },
       "owner": "documentation-governance",
       "canonicalSource": "docs/governance/README.md",
+      "lifecycle": "reviewable",
+      "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/synchronous-io-wsl2d-main.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings-documents",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/synchronous-io-wsl2d-main.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
     },


### PR DESCRIPTION
## Summary
Analyze the issue highlighting synchronous IO / loop in `ProductionUblkRuntime` (`crates/ramshared-wsl2d/src/main.rs:4560`). Investigation confirms that `ProductionUblkRuntime::wait_for_shutdown()` runs on a dedicated CLI runner thread during block device teardown rather than an async worker loop or event loop thread. Modifying `UblkRuntime` to async or altering polling behavior is unsafe for block device teardown ordering and is intended synchronous management code. An analysis finding report has been recorded in `docs/jules/findings/synchronous-io-wsl2d-main.md`.

## Labels
type:refactor
area:core

## Commits
| Commit Hash | Message |
| --- | --- |
| `8a79175fd21205d8319cbcfa60d605d94e7c1e68` | `refactor(wsl2d): analyze synchronous IO in ProductionUblkRuntime` |


---
*PR created automatically by Jules for task [8722831060628343539](https://jules.google.com/task/8722831060628343539) started by @emersonbusson*