### PR TITLE
docs(jules): add finding report for teardown bug explanation task

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -472,6 +472,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-05T14:24:00Z"
+    },
+    {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "reliability",
+      "canonicalSource": "docs/postmortems/TEMPLATE.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-06T00:00:00Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/finding-teardown-bug-explanation.md
+++ b/docs/jules/findings/finding-teardown-bug-explanation.md
@@ -1,0 +1,7 @@
+# Finding Report: Teardown Bug Explanation in QEMU
+
+## Overview
+The reference at `crates/ramshared-wsl2d/src/main.rs:72` (`the teardown bug that hung WSL2 is independent of the backend`) is historical context describing past behavior in QEMU/WSL2 and does not constitute a pending bug or actionable feature request.
+
+## Status
+FINDING_ONLY report created.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 252,
-    "classified": 249,
+    "total": 253,
+    "classified": 250,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -556,6 +556,18 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/finding-teardown-bug-explanation.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "reliability",
+      "canonicalSource": "docs/postmortems/TEMPLATE.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Summary
Created FINDING_ONLY report for teardown bug explanation task.

## Test Plan
Ran `cargo test -p ramshared-wsl2d` to verify all tests pass.

## Labels
type:refactor
area:core

## Commits
| Commit | Description |
| --- | --- |
| 5687f2c508bb4b507dc4463f073066f9051909ef | docs(jules): add finding report for teardown bug explanation task |


---
*PR created automatically by Jules for task [4432849433697188012](https://jules.google.com/task/4432849433697188012) started by @emersonbusson*