### PR TITLE
docs(reliability): document WSL2 residency canary load spike calibration

### DIFF
--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 252,
-    "classified": 249,
+    "total": 253,
+    "classified": 250,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -941,6 +941,18 @@
     },
     {
       "path": "docs/reliability/wsl2-fase0-final.md",
+      "disposition": "classified",
+      "ruleId": "reliability-documents",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "reliability",
+      "canonicalSource": "docs/reliability/GAP-REGISTER.md",
+      "lifecycle": "reviewable",
+      "freshnessDays": 90
+    },
+    {
+      "path": "docs/reliability/wsl2d-residency-load-spike-calibration.md",
       "disposition": "classified",
       "ruleId": "reliability-documents",
       "verification": {

--- a/docs/reliability/wsl2d-residency-load-spike-calibration.md
+++ b/docs/reliability/wsl2d-residency-load-spike-calibration.md
@@ -1,0 +1,12 @@
+# WSL2 Residency Canary Load Spike Calibration (DT-31)
+
+## Context
+In `crates/ramshared-wsl2d/src/residency.rs`, line 171 records a historical bug where setting the latency threshold multiplier to `8x` baseline triggered false positive demotion verdicts under load (e2e cross-host civm reaching ~17x serve latency), thereby dropping swap unexpectedly under heavy workloads.
+
+## Current Implementation Analysis
+The codebase already incorporates the calibration fix (DT-31):
+- `ResidencyConfig::default()` sets `latency_mult` to `64`.
+- The test `load_spike_below_threshold_stays_ok()` in `crates/ramshared-wsl2d/src/residency.rs` verifies that a 17x serve latency spike across 10 iterations remains `Verdict::Ok` and does not trigger demotion.
+
+## Verification
+The unit test suite for `ramshared-wsl2d` passes cleanly via `cargo test -p ramshared-wsl2d`.


### PR DESCRIPTION
## Description
Document the WSL2 residency canary latency multiplier calibration (DT-31) addressing past load spike false positives.

## Labels
type:documentation
area:reliability

## Commits
| Hash | Message |
| --- | --- |
| 8f161ec904d8843babd8d6db791ce3cf64af169f | docs(reliability): document WSL2 residency canary load spike calibration |

---
*PR created automatically by Jules for task [16554657512154590932](https://jules.google.com/task/16554657512154590932) started by @emersonbusson*