### PR TITLE
🧹 refactor(cli): decompose overly long stress run function into helper modules

### DIFF
--- a/crates/ramshared-cli/src/stress.rs
+++ b/crates/ramshared-cli/src/stress.rs
@@ -100,6 +100,19 @@ pub struct StressReport {
     pub status: String,
 }
 
+#[derive(Debug, Default)]
+struct StressExecutionState {
+    total_allocated_mb: u64,
+    max_safe_pct: u64,
+    peak_zram: u64,
+    peak_vram: u64,
+    peak_ssd: u64,
+    peak_total_swap: u64,
+    peak_pressure: f64,
+    readings_count: usize,
+    active_cycles_done: usize,
+}
+
 pub fn parse_stress_args(args: &[String]) -> Result<StressOptions, String> {
     let mut opts = StressOptions::default();
     let mut i = 0;
@@ -424,31 +437,21 @@ pub fn append_telemetry_log(path: &str, reading: &TelemetryReading) {
     }
 }
 
-pub fn run(opts: &StressOptions) -> Result<(), String> {
-    let term_signal = Arc::new(AtomicBool::new(false));
-    let last_heartbeat = Arc::new(AtomicU64::new(
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs(),
-    ));
-
-    let chunks = Arc::new(Mutex::new(Vec::<Vec<u8>>::new()));
-
-    // Autonomous Watchdog Thread: If main thread stalls > 3s, clears memory automatically
-    let chunks_watchdog = chunks.clone();
-    let heartbeat_watchdog = last_heartbeat.clone();
-    let term_watchdog = term_signal.clone();
-    let watchdog_handle = thread::spawn(move || {
-        while !term_watchdog.load(Ordering::Relaxed) {
+fn spawn_watchdog(
+    chunks: Arc<Mutex<Vec<Vec<u8>>>>,
+    last_heartbeat: Arc<AtomicU64>,
+    term_signal: Arc<AtomicBool>,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        while !term_signal.load(Ordering::Relaxed) {
             thread::sleep(Duration::from_millis(500));
             let now = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
-            let last = heartbeat_watchdog.load(Ordering::Relaxed);
+            let last = last_heartbeat.load(Ordering::Relaxed);
             if now.saturating_sub(last) > 4 {
-                if let Ok(mut guard) = chunks_watchdog.lock()
+                if let Ok(mut guard) = chunks.lock()
                     && !guard.is_empty()
                 {
                     guard.clear();
@@ -456,54 +459,57 @@ pub fn run(opts: &StressOptions) -> Result<(), String> {
                 break;
             }
         }
-    });
+    })
+}
 
-    let (ram_total_mb, ram_avail_init) = read_mem_info();
-    let (swap_init_total, _, _, _) = read_swap_tiers();
-
-    if !opts.json {
-        println!("{}", "═".repeat(105));
-        println!(" 🚀 RamShared Native Stress Governor & Multi-Tier Qualification Battery");
-        println!(
-            " Mode: {} │ Range: {}% ➔ {}% (+{}%) │ Safety Floor: >= {} MB │ Log: {}",
-            if opts.battery {
-                "FULL BATTERY (4 Phases)"
-            } else {
-                "Progressive 1%-by-1% Governor"
-            },
-            opts.start_pct,
-            opts.target_pct,
-            opts.step_pct,
-            opts.min_ram_mb,
-            opts.telemetry_log
-        );
-        println!(
-            "[i] Physical Host RAM: {} MB (Available: {} MB) │ Active Swap: {} MB",
-            ram_total_mb, ram_avail_init, swap_init_total
-        );
-        println!("{}", "═".repeat(105));
-        println!(
-            "┌───────┬────────────┬──────────────┬──────────────┬──────────────┬──────────────┬────────┬──────────┬─────────────┬───────────────────────────┐"
-        );
-        println!(
-            "│ Level │ Alloc RAM  │ ZRAM (Tier1) │ VRAM (Tier2) │ SSD (Tier3)  │ Total Swap   │ PSI-F  │ Latency  │ Stress Bar  │ Tier Operating Status     │"
-        );
-        println!(
-            "├───────┼────────────┼──────────────┼──────────────┼──────────────┼──────────────┼────────┼──────────┼─────────────┼───────────────────────────┤"
-        );
+fn print_stress_header(
+    opts: &StressOptions,
+    ram_total_mb: u64,
+    ram_avail_init: u64,
+    swap_init_total: u64,
+) {
+    if opts.json {
+        return;
     }
+    println!("{}", "═".repeat(105));
+    println!(" 🚀 RamShared Native Stress Governor & Multi-Tier Qualification Battery");
+    println!(
+        " Mode: {} │ Range: {}% ➔ {}% (+{}%) │ Safety Floor: >= {} MB │ Log: {}",
+        if opts.battery {
+            "FULL BATTERY (4 Phases)"
+        } else {
+            "Progressive 1%-by-1% Governor"
+        },
+        opts.start_pct,
+        opts.target_pct,
+        opts.step_pct,
+        opts.min_ram_mb,
+        opts.telemetry_log
+    );
+    println!(
+        "[i] Physical Host RAM: {} MB (Available: {} MB) │ Active Swap: {} MB",
+        ram_total_mb, ram_avail_init, swap_init_total
+    );
+    println!("{}", "═".repeat(105));
+    println!(
+        "┌───────┬────────────┬──────────────┬──────────────┬──────────────┬──────────────┬────────┬──────────┬─────────────┬───────────────────────────┐"
+    );
+    println!(
+        "│ Level │ Alloc RAM  │ ZRAM (Tier1) │ VRAM (Tier2) │ SSD (Tier3)  │ Total Swap   │ PSI-F  │ Latency  │ Stress Bar  │ Tier Operating Status     │"
+    );
+    println!(
+        "├───────┼────────────┼──────────────┼──────────────┼──────────────┼──────────────┼────────┼──────────┼─────────────┼───────────────────────────┤"
+    );
+}
 
-    let mut total_allocated_mb = 0u64;
-    let mut max_safe_pct = 0u64;
-    let mut peak_zram = 0u64;
-    let mut peak_vram = 0u64;
-    let mut peak_ssd = 0u64;
-    let mut peak_total_swap = 0u64;
-    let mut peak_pressure = 1.0f64;
-    let mut readings_count = 0usize;
-    let mut active_cycles_done = 0usize;
-
-    // Phase 1: 1%-by-1% Micro-Step Ramp
+fn run_ramp_phase(
+    opts: &StressOptions,
+    term_signal: &AtomicBool,
+    last_heartbeat: &AtomicU64,
+    chunks: &Mutex<Vec<Vec<u8>>>,
+    ram_total_mb: u64,
+    state: &mut StressExecutionState,
+) {
     let effective_target = if opts.tier3_target_pct.is_some() {
         1000
     } else {
@@ -528,10 +534,15 @@ pub fn run(opts: &StressOptions) -> Result<(), String> {
         let lat_ms = probe_allocation_latency_ms();
         let (tot_swap, z_mb, v_mb, s_mb) = read_swap_tiers();
 
-        let reading =
-            compute_telemetry_reading(lat_ms, psi_full, total_allocated_mb, ram_total_mb, tot_swap);
-        peak_pressure = peak_pressure.max(reading.pressure_index);
-        readings_count += 1;
+        let reading = compute_telemetry_reading(
+            lat_ms,
+            psi_full,
+            state.total_allocated_mb,
+            ram_total_mb,
+            tot_swap,
+        );
+        state.peak_pressure = state.peak_pressure.max(reading.pressure_index);
+        state.readings_count += 1;
         append_telemetry_log(&opts.telemetry_log, &reading);
 
         let sysctl_min_free_mb = read_sysctl_min_free_mb();
@@ -561,18 +572,18 @@ pub fn run(opts: &StressOptions) -> Result<(), String> {
                 println!(
                     "│ {:>4}%  │ {:>8} MB │ {:>8} MB │ {:>8} MB │ {:>8} MB │ {:>8} MB │ {:>5.1}% │ {:>6.2}ms │ {:>11} │ 🛑 RAM FLOOR REACHED      │",
                     current_target,
-                    total_allocated_mb,
-                    peak_zram,
-                    peak_vram,
-                    peak_ssd,
-                    peak_total_swap,
+                    state.total_allocated_mb,
+                    state.peak_zram,
+                    state.peak_vram,
+                    state.peak_ssd,
+                    state.peak_total_swap,
                     psi_full,
                     lat_ms,
                     reading.gauge
                 );
                 println!(
                     "\n[🛑 SAFETY FLOOR REACHED] Available RAM reached floor ({} MB <= {} MB). Halted at {}% (Zero Hang Protection).",
-                    avail_mb, hard_floor, max_safe_pct
+                    avail_mb, hard_floor, state.max_safe_pct
                 );
             }
             break;
@@ -580,7 +591,6 @@ pub fn run(opts: &StressOptions) -> Result<(), String> {
 
         if psi_full >= opts.max_psi_full {
             if is_multi_tier {
-                // Transient PSI spike during heavy multi-tier swap; damp and wait up to 5s
                 let mut calmed = false;
                 for _ in 0..10 {
                     if term_signal.load(Ordering::Relaxed) {
@@ -598,18 +608,18 @@ pub fn run(opts: &StressOptions) -> Result<(), String> {
                         println!(
                             "│ {:>4}%  │ {:>8} MB │ {:>8} MB │ {:>8} MB │ {:>8} MB │ {:>8} MB │ {:>5.1}% │ {:>6.2}ms │ {:>11} │ ⚠️  PSI LIMIT DAMPING     │",
                             current_target,
-                            total_allocated_mb,
-                            peak_zram,
-                            peak_vram,
-                            peak_ssd,
-                            peak_total_swap,
+                            state.total_allocated_mb,
+                            state.peak_zram,
+                            state.peak_vram,
+                            state.peak_ssd,
+                            state.peak_total_swap,
                             psi_full,
                             lat_ms,
                             reading.gauge
                         );
                         println!(
                             "\n[⚠️  PRESSURE DAMPING] PSI Full pressure sustained ({:.1}%) >= {:.1}%. Halted at {}%.",
-                            psi_full, opts.max_psi_full, max_safe_pct
+                            psi_full, opts.max_psi_full, state.max_safe_pct
                         );
                     }
                     break;
@@ -619,18 +629,18 @@ pub fn run(opts: &StressOptions) -> Result<(), String> {
                     println!(
                         "│ {:>4}%  │ {:>8} MB │ {:>8} MB │ {:>8} MB │ {:>8} MB │ {:>8} MB │ {:>5.1}% │ {:>6.2}ms │ {:>11} │ ⚠️  PSI LIMIT DAMPING     │",
                         current_target,
-                        total_allocated_mb,
-                        peak_zram,
-                        peak_vram,
-                        peak_ssd,
-                        peak_total_swap,
+                        state.total_allocated_mb,
+                        state.peak_zram,
+                        state.peak_vram,
+                        state.peak_ssd,
+                        state.peak_total_swap,
                         psi_full,
                         lat_ms,
                         reading.gauge
                     );
                     println!(
                         "\n[⚠️  PRESSURE DAMPING] PSI Full pressure ({:.1}%) >= {:.1}%. Halted at {}%.",
-                        psi_full, opts.max_psi_full, max_safe_pct
+                        psi_full, opts.max_psi_full, state.max_safe_pct
                     );
                 }
                 break;
@@ -642,18 +652,18 @@ pub fn run(opts: &StressOptions) -> Result<(), String> {
                 println!(
                     "│ {:>4}%  │ {:>8} MB │ {:>8} MB │ {:>8} MB │ {:>8} MB │ {:>8} MB │ {:>5.1}% │ {:>6.2}ms │ {:>11} │ ⏱️  LATENCY SPIKE DAMP    │",
                     current_target,
-                    total_allocated_mb,
-                    peak_zram,
-                    peak_vram,
-                    peak_ssd,
-                    peak_total_swap,
+                    state.total_allocated_mb,
+                    state.peak_zram,
+                    state.peak_vram,
+                    state.peak_ssd,
+                    state.peak_total_swap,
                     psi_full,
                     lat_ms,
                     reading.gauge
                 );
                 println!(
                     "\n[⏱️  LATENCY SPIKE DAMPING] Memory latency spiked to {:.2} ms >= {:.2} ms. Halted at {}%.",
-                    lat_ms, opts.max_latency_ms, max_safe_pct
+                    lat_ms, opts.max_latency_ms, state.max_safe_pct
                 );
             }
             break;
@@ -687,12 +697,9 @@ pub fn run(opts: &StressOptions) -> Result<(), String> {
         let mut safe_alloc_mb = one_pct_mb.min(avail_mb.saturating_sub(hard_floor)).min(128);
         if safe_alloc_mb == 0 {
             if is_multi_tier && psi_full < opts.max_psi_full {
-                // If MemAvailable has a safe margin (>= 150 MB above kernel watermarks),
-                // inject a 64 MB chunk to keep kswapd actively writing dirty pages to swap
                 if avail_mb >= 150 {
                     safe_alloc_mb = 64;
                 } else {
-                    // RAM is getting close to watermark; pause and let kswapd drain dirty pages to swap
                     thread::sleep(Duration::from_millis(opts.interval_ms.clamp(100, 300)));
                     continue;
                 }
@@ -701,7 +708,6 @@ pub fn run(opts: &StressOptions) -> Result<(), String> {
             }
         }
 
-        // Allocate and dirty pages
         let num_bytes = (safe_alloc_mb as usize) * 1024 * 1024;
         let mut slice = vec![0u8; num_bytes];
         for i in (0..num_bytes).step_by(4096) {
@@ -711,20 +717,20 @@ pub fn run(opts: &StressOptions) -> Result<(), String> {
         if let Ok(mut guard) = chunks.lock() {
             guard.push(slice);
         }
-        total_allocated_mb += safe_alloc_mb;
+        state.total_allocated_mb += safe_alloc_mb;
 
-        peak_zram = peak_zram.max(z_mb);
-        peak_vram = peak_vram.max(v_mb);
-        peak_ssd = peak_ssd.max(s_mb);
-        peak_total_swap = peak_total_swap.max(tot_swap);
+        state.peak_zram = state.peak_zram.max(z_mb);
+        state.peak_vram = state.peak_vram.max(v_mb);
+        state.peak_ssd = state.peak_ssd.max(s_mb);
+        state.peak_total_swap = state.peak_total_swap.max(tot_swap);
 
-        max_safe_pct = current_target;
+        state.max_safe_pct = current_target;
 
         if !opts.json {
             println!(
                 "│ {:>4}%  │ {:>8} MB │ {:>8} MB │ {:>8} MB │ {:>8} MB │ {:>8} MB │ {:>5.1}% │ {:>6.2}ms │ {:>11} │ {:<25} │",
                 current_target,
-                total_allocated_mb,
+                state.total_allocated_mb,
                 z_mb,
                 v_mb,
                 s_mb,
@@ -739,137 +745,149 @@ pub fn run(opts: &StressOptions) -> Result<(), String> {
         thread::sleep(Duration::from_millis(opts.interval_ms));
         current_target += opts.step_pct;
     }
+}
 
-    // Phase 2 & 3: Active Page Swapper & Cycler (Only in Battery Mode or when hold_sec > 0)
-    if opts.battery || opts.hold_sec > 0 {
-        if !opts.json {
-            println!("{}", "═".repeat(105));
-            println!(
-                " 🌊 PHASE 2 & 3: ACTIVE PAGE CYCLER & TIER TRAFFIC (Holding Peak {}% for {}s)",
-                max_safe_pct, opts.hold_sec
-            );
-            println!(
-                " (Cycling dirty pages between RAM, ZRAM, and GPU VRAM to animate live speedometer graphs)"
-            );
-            println!("{}", "═".repeat(105));
-        }
-
-        let hold_end = Instant::now() + Duration::from_secs(opts.hold_sec);
-        let mut cycle: usize = 0;
-        while Instant::now() < hold_end && !term_signal.load(Ordering::Relaxed) {
-            cycle += 1;
-            last_heartbeat.store(
-                SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs(),
-                Ordering::Relaxed,
-            );
-
-            // Modify chunk pages smoothly to stimulate active tier traffic without saturating kernel queues
-            if let Ok(mut guard) = chunks.lock()
-                && !guard.is_empty()
-            {
-                let len = guard.len();
-                let idx = (cycle.wrapping_mul(7)) % len;
-                let target_chunk = &mut guard[idx];
-                let chunk_len = target_chunk.len();
-                let limit = chunk_len.min(16 * 1024 * 1024);
-                for offset in (0..limit).step_by(16384) {
-                    target_chunk[offset] = (cycle as u8).wrapping_add((offset & 0xFF) as u8);
-                }
-            }
-
-            let (_, free_mb) = read_mem_info();
-            let (tot_swap, z_mb, v_mb, s_mb) = read_swap_tiers();
-            peak_zram = peak_zram.max(z_mb);
-            peak_vram = peak_vram.max(v_mb);
-            peak_ssd = peak_ssd.max(s_mb);
-            peak_total_swap = peak_total_swap.max(tot_swap);
-            let psi_full = read_psi_full();
-            let lat_ms = probe_allocation_latency_ms();
-
-            let reading = compute_telemetry_reading(
-                lat_ms,
-                psi_full,
-                total_allocated_mb,
-                ram_total_mb,
-                tot_swap,
-            );
-            peak_pressure = peak_pressure.max(reading.pressure_index);
-            readings_count += 1;
-            active_cycles_done += 1;
-            append_telemetry_log(&opts.telemetry_log, &reading);
-
-            if !opts.json {
-                print!(
-                    " [🌊 Cycle #{:>2}] Idx: {:>4.1} {} Swap: {:>5} MB │ Free RAM: {:>5} MB │ PSI: {:>4.1}% │ Lat: {:.2}ms\r",
-                    cycle,
-                    reading.pressure_index,
-                    reading.gauge,
-                    tot_swap,
-                    free_mb,
-                    psi_full,
-                    lat_ms
-                );
-                let _ = io::stdout().flush();
-            }
-            thread::sleep(Duration::from_millis(500));
-        }
-        if !opts.json {
-            println!();
-        }
+fn run_active_cycler_phase(
+    opts: &StressOptions,
+    term_signal: &AtomicBool,
+    last_heartbeat: &AtomicU64,
+    chunks: &Mutex<Vec<Vec<u8>>>,
+    ram_total_mb: u64,
+    state: &mut StressExecutionState,
+) {
+    if !opts.battery && opts.hold_sec == 0 {
+        return;
     }
 
-    // Phase 4: Atomic Flash-Reclaim Benchmark Phase
+    if !opts.json {
+        println!("{}", "═".repeat(105));
+        println!(
+            " 🌊 PHASE 2 & 3: ACTIVE PAGE CYCLER & TIER TRAFFIC (Holding Peak {}% for {}s)",
+            state.max_safe_pct, opts.hold_sec
+        );
+        println!(
+            " (Cycling dirty pages between RAM, ZRAM, and GPU VRAM to animate live speedometer graphs)"
+        );
+        println!("{}", "═".repeat(105));
+    }
+
+    let hold_end = Instant::now() + Duration::from_secs(opts.hold_sec);
+    let mut cycle: usize = 0;
+    while Instant::now() < hold_end && !term_signal.load(Ordering::Relaxed) {
+        cycle += 1;
+        last_heartbeat.store(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+            Ordering::Relaxed,
+        );
+
+        if let Ok(mut guard) = chunks.lock()
+            && !guard.is_empty()
+        {
+            let len = guard.len();
+            let idx = (cycle.wrapping_mul(7)) % len;
+            let target_chunk = &mut guard[idx];
+            let chunk_len = target_chunk.len();
+            let limit = chunk_len.min(16 * 1024 * 1024);
+            for offset in (0..limit).step_by(16384) {
+                target_chunk[offset] = (cycle as u8).wrapping_add((offset & 0xFF) as u8);
+            }
+        }
+
+        let (_, free_mb) = read_mem_info();
+        let (tot_swap, z_mb, v_mb, s_mb) = read_swap_tiers();
+        state.peak_zram = state.peak_zram.max(z_mb);
+        state.peak_vram = state.peak_vram.max(v_mb);
+        state.peak_ssd = state.peak_ssd.max(s_mb);
+        state.peak_total_swap = state.peak_total_swap.max(tot_swap);
+        let psi_full = read_psi_full();
+        let lat_ms = probe_allocation_latency_ms();
+
+        let reading = compute_telemetry_reading(
+            lat_ms,
+            psi_full,
+            state.total_allocated_mb,
+            ram_total_mb,
+            tot_swap,
+        );
+        state.peak_pressure = state.peak_pressure.max(reading.pressure_index);
+        state.readings_count += 1;
+        state.active_cycles_done += 1;
+        append_telemetry_log(&opts.telemetry_log, &reading);
+
+        if !opts.json {
+            print!(
+                " [🌊 Cycle #{:>2}] Idx: {:>4.1} {} Swap: {:>5} MB │ Free RAM: {:>5} MB │ PSI: {:>4.1}% │ Lat: {:.2}ms\r",
+                cycle, reading.pressure_index, reading.gauge, tot_swap, free_mb, psi_full, lat_ms
+            );
+            let _ = io::stdout().flush();
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+    if !opts.json {
+        println!();
+    }
+}
+
+fn run_reclaim_phase(
+    opts: &StressOptions,
+    chunks: &Mutex<Vec<Vec<u8>>>,
+    watchdog_handle: thread::JoinHandle<()>,
+    term_signal: &AtomicBool,
+    state: &StressExecutionState,
+) -> StressReport {
     let t_reclaim_start = Instant::now();
     if let Ok(mut guard) = chunks.lock() {
         guard.clear();
     }
     let reclaim_duration = t_reclaim_start.elapsed();
     let reclaim_sec = reclaim_duration.as_secs_f64().max(0.001);
-    let reclaim_speed_gbs = ((total_allocated_mb as f64 / 1024.0) / reclaim_sec).min(100.0);
+    let reclaim_speed_gbs = ((state.total_allocated_mb as f64 / 1024.0) / reclaim_sec).min(100.0);
 
     term_signal.store(true, Ordering::Relaxed);
     let _ = watchdog_handle.join();
 
     thread::sleep(Duration::from_millis(500));
     let (_, post_free_ram) = read_mem_info();
-    let (post_swap, _, _, _) = read_swap_tiers();
     let (cap1, cap2, cap3) = read_swap_tier_capacities();
 
-    let report = StressReport {
+    StressReport {
         battery_mode: opts.battery,
         cascade_mode: opts.cascade,
-        max_safe_pct,
-        total_allocated_mb,
-        peak_swap_mb: peak_total_swap,
-        tier1_zram_mb: peak_zram,
-        tier1_zram_pct: (peak_zram * 100)
+        max_safe_pct: state.max_safe_pct,
+        total_allocated_mb: state.total_allocated_mb,
+        peak_swap_mb: state.peak_total_swap,
+        tier1_zram_mb: state.peak_zram,
+        tier1_zram_pct: (state.peak_zram * 100)
             .checked_div(cap1.total_mb)
             .unwrap_or(cap1.pct),
-        tier2_vram_mb: peak_vram,
-        tier2_vram_pct: (peak_vram * 100)
+        tier2_vram_mb: state.peak_vram,
+        tier2_vram_pct: (state.peak_vram * 100)
             .checked_div(cap2.total_mb)
             .unwrap_or(cap2.pct),
-        tier3_ssd_mb: peak_ssd,
-        tier3_ssd_pct: (peak_ssd * 100)
+        tier3_ssd_mb: state.peak_ssd,
+        tier3_ssd_pct: (state.peak_ssd * 100)
             .checked_div(cap3.total_mb)
             .unwrap_or(cap3.pct),
-        peak_pressure_index: peak_pressure,
-        telemetry_readings_count: readings_count,
-        active_io_cycles_completed: active_cycles_done,
+        peak_pressure_index: state.peak_pressure,
+        telemetry_readings_count: state.readings_count,
+        active_io_cycles_completed: state.active_cycles_done,
         reclaim_duration_ms: reclaim_duration.as_secs_f64() * 1000.0,
         reclaim_speed_gbs,
         post_reclaim_free_ram_mb: post_free_ram,
         status: "PASS_ZERO_PANIC".to_string(),
-    };
+    }
+}
 
+fn print_stress_report(report: &StressReport, opts: &StressOptions) -> Result<(), String> {
     if opts.json {
-        let json_out = serde_json::to_string_pretty(&report)
+        let json_out = serde_json::to_string_pretty(report)
             .map_err(|e| format!("failed to serialize stress report: {e}"))?;
         println!("{json_out}");
     } else {
+        let (post_swap, _, _, _) = read_swap_tiers();
         println!("{}", "═".repeat(105));
         println!(" 🧹 PHASE 4: ATOMIC MEMORY RECLAIM & FLASH DEALLOCATION BENCHMARK");
         println!("{}", "═".repeat(105));
@@ -882,7 +900,10 @@ pub fn run(opts: &StressOptions) -> Result<(), String> {
             report.reclaim_speed_gbs
         );
         println!("[✓] Post-Reclaim Swap:      {} MB", post_swap);
-        println!("[✓] Post-Reclaim Free RAM:  {} MB available", post_free_ram);
+        println!(
+            "[✓] Post-Reclaim Free RAM:  {} MB available",
+            report.post_reclaim_free_ram_mb
+        );
         println!("{}", "-".repeat(105));
         println!(" 📊 STRESS BATTERY QUALIFICATION REPORT:");
         println!(
@@ -934,6 +955,52 @@ pub fn run(opts: &StressOptions) -> Result<(), String> {
         );
         println!("{}", "═".repeat(105));
     }
+    Ok(())
+}
+
+pub fn run(opts: &StressOptions) -> Result<(), String> {
+    let term_signal = Arc::new(AtomicBool::new(false));
+    let last_heartbeat = Arc::new(AtomicU64::new(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    ));
+
+    let chunks = Arc::new(Mutex::new(Vec::<Vec<u8>>::new()));
+    let watchdog_handle =
+        spawn_watchdog(chunks.clone(), last_heartbeat.clone(), term_signal.clone());
+
+    let (ram_total_mb, ram_avail_init) = read_mem_info();
+    let (swap_init_total, _, _, _) = read_swap_tiers();
+
+    print_stress_header(opts, ram_total_mb, ram_avail_init, swap_init_total);
+
+    let mut state = StressExecutionState {
+        peak_pressure: 1.0,
+        ..Default::default()
+    };
+
+    run_ramp_phase(
+        opts,
+        &term_signal,
+        &last_heartbeat,
+        &chunks,
+        ram_total_mb,
+        &mut state,
+    );
+    run_active_cycler_phase(
+        opts,
+        &term_signal,
+        &last_heartbeat,
+        &chunks,
+        ram_total_mb,
+        &mut state,
+    );
+
+    let report = run_reclaim_phase(opts, &chunks, watchdog_handle, &term_signal, &state);
+
+    print_stress_report(&report, opts)?;
 
     archive_and_compare_benchmark(&report, opts.json);
 
@@ -997,7 +1064,6 @@ fn archive_and_compare_benchmark(report: &StressReport, suppress_stdout: bool) {
     let timestamp_str = format_system_time(SystemTime::now());
     let current_path = history_dir.join(format!("benchmark-{timestamp_str}.json"));
 
-    // Check if previous benchmark exists to print comparison diff
     if !suppress_stdout {
         let prev_opt = fs::read_to_string(&latest_path)
             .ok()


### PR DESCRIPTION
## What
Addressed code health issue in `crates/ramshared-cli/src/stress.rs` where the `run` function was monolithic (~400 lines). Decomposed `run` into modular helper functions: `spawn_watchdog`, `print_stress_header`, `run_ramp_phase`, `run_active_cycler_phase`, `run_reclaim_phase`, and `print_stress_report`, using `StressExecutionState` to track execution metrics.

## Why
Decomposing the long function improves maintainability, testability, and readability while keeping identical runtime behavior.

## Verification
- Ran `cargo test -p ramshared-cli --bin ramshared stress::tests` and verified all 9 tests pass.
- Verified code formatting with `cargo fmt --check`.

## Result
Reduced `run` function to a high-level orchestration function of ~30 lines without altering functionality or breaking tests.

## Labels
type:refactor
area:cli

## Commits
| Commit | Message |
| --- | --- |
| 0ae346161e6d0fea5ca93ad339806e322d5ce225 | refactor(cli): decompose overly long stress run function into helper modules |


---
*PR created automatically by Jules for task [2715082784992005780](https://jules.google.com/task/2715082784992005780) started by @emersonbusson*