### PR TITLE
🧹 replace unsafe unwrap calls in RamBe write_at with IoError error propagation

### DIFF
--- a/crates/ramshared-winsvc/src/driver_link.rs
+++ b/crates/ramshared-winsvc/src/driver_link.rs
@@ -554,8 +554,16 @@ mod tests {
             Ok(())
         }
         fn write_at(&mut self, off: u64, data: &[u8]) -> Result<(), IoError> {
-            *self.writes.lock().unwrap() += 1;
-            *self.last_write.lock().unwrap() = data.to_vec();
+            let mut writes = self
+                .writes
+                .lock()
+                .map_err(|e| IoError(format!("mutex poisoned: {e}")))?;
+            *writes += 1;
+            let mut last_write = self
+                .last_write
+                .lock()
+                .map_err(|e| IoError(format!("mutex poisoned: {e}")))?;
+            *last_write = data.to_vec();
             let o = off as usize;
             self.data[o..o + data.len()].copy_from_slice(data);
             Ok(())


### PR DESCRIPTION
🎯 **What:**
Replaced unsafe `.lock().unwrap()` calls in `RamBe::write_at` in `crates/ramshared-winsvc/src/driver_link.rs` with safe `.lock().map_err(|e| IoError(format!("mutex poisoned: {e}")))?` error propagation.

💡 **Why:**
Using `.unwrap()` on mutex locks can lead to thread panics if a mutex becomes poisoned. Mapping mutex errors to domain-level `IoError` improves codebase health, reliability, and error resilience.

✅ **Verification:**
Ran unit tests using `cargo test -p ramshared-winsvc` and verified that all 128 tests passed.

✨ **Result:**
The unsafe `.unwrap()` calls in `RamBe::write_at` have been safely replaced with `Result` error propagation without changing behavior or breaking existing tests.

## Labels
type:refactor
area:core

## Commits
| Hash | Message |
| --- | --- |
| 4fc458d504dce7342e9ac95e821d81dbbfa3893f | style(winsvc): replace lock unwrap calls with IoError error propagation in RamBe write_at |


---
*PR created automatically by Jules for task [13416787736994532471](https://jules.google.com/task/13416787736994532471) started by @emersonbusson*