### PR TITLE
⚡ move startup LUN serial string clone outside loop

### DIFF
--- a/crates/ramshared-winsvc/src/product_online.rs
+++ b/crates/ramshared-winsvc/src/product_online.rs
@@ -276,10 +276,11 @@ pub fn run_product_online(
     let mut dlink = DriverLink::from_queue(q);
     let startup_lun_deadline = Duration::from_secs(60);
     let startup_lun_started = Instant::now();
+    let serial_arc = Arc::<str>::from(serial_str.as_str());
     loop {
         // The startup LUN identity wait must pump I/O: Windows disk
         // enumeration may issue READs before Get-Disk exposes the device.
-        let want_serial = serial_str.clone();
+        let want_serial = Arc::clone(&serial_arc);
         let want_size = cfg.size_bytes;
         let startup_lun = readonly_host_call_with_io_pump(
             &mut link,


### PR DESCRIPTION
## What
Refactored `run_product_online` in `crates/ramshared-winsvc/src/product_online.rs` to wrap `serial_str` in `Arc<str>` outside the startup LUN polling loop and clone the `Arc` inside the loop instead of performing `serial_str.clone()`.

## Why
`serial_str.clone()` was executed on every iteration of the startup LUN wait loop (every 500 ms while waiting up to 60 seconds for Windows disk enumeration). Cloning `serial_str` allocated a new heap `String` on every attempt.

## Measured Improvement
Wrapping `serial_str` as `Arc<str>` once outside the loop reduces string clone operations during startup LUN wait from N heap allocations (where N is the number of poll attempts) to 0 heap allocations per iteration, replacing heap memory allocations with a zero-allocation reference count increment (`Arc::clone`).

## Labels
- type:perf
- area:core

## Commits
| Commit | Description |
| --- | --- |
| e01a81274ca6741143f702dc2e2337616be2d15d | perf(winsvc): move startup LUN serial string clone outside loop |

---
*PR created automatically by Jules for task [6290637077625197464](https://jules.google.com/task/6290637077625197464) started by @emersonbusson*