### PR TITLE
⚡ perf(agent): eliminate unnecessary dev clone in SwapOff handler

### DIFF
--- a/crates/ramshared-agent/src/main.rs
+++ b/crates/ramshared-agent/src/main.rs
@@ -479,8 +479,7 @@ fn handle_msg(
         }
         Msg::SwapOff { slice } => {
             let dev = active
-                .get(&slice)
-                .cloned()
+                .remove(&slice)
                 .unwrap_or_else(|| format!("{}{}", cfg.nbd_base, slice));
             cmd_tx.send(ExecCmd::Off { slice, dev }).is_ok()
         }


### PR DESCRIPTION
## Title
⚡ perf(agent): eliminate unnecessary dev clone in SwapOff handler

## Description
### 💡 What
Replaced `active.get(&slice).cloned()` with `active.remove(&slice)` in `handle_msg` when processing `Msg::SwapOff`.

### 🎯 Why
`active.get(&slice).cloned()` was creating a heap-allocated `String` clone of the device path on every `SwapOff` message while leaving the device in the `active` map (which had to be removed later when `ExecResult::Off` returned). Using `active.remove(&slice)` moves the owned `String` out of the map directly without heap allocation or cloning.

### 📊 Measured Improvement
Eliminates 1 heap allocation/clone per `SwapOff` command in `ramshared-agent`.

## Labels
type:perf, area:agent

## Commits
- 36f7ebd31e55aa96f87e2bdcd257f36152f87231

---
*PR created automatically by Jules for task [2298529740377070236](https://jules.google.com/task/2298529740377070236) started by @emersonbusson*