### PR TITLE
⚡ perf(cli): wrap test runner scope execution states in Arc to avoid clones

### DIFF
--- a/crates/ramshared-cli/src/workload.rs
+++ b/crates/ramshared-cli/src/workload.rs
@@ -1856,8 +1856,8 @@ mod tests {
     }
 
     struct TransitionBlockingRunner {
-        ledger_root: PathBuf,
-        supervisor: OwnerIdentity,
+        ledger_root: Arc<PathBuf>,
+        supervisor: Arc<OwnerIdentity>,
         calls: RefCell<usize>,
     }
 
@@ -1866,20 +1866,20 @@ mod tests {
     }
 
     struct TransitionBlockingExecution {
-        ledger_root: PathBuf,
-        supervisor: OwnerIdentity,
+        ledger_root: Arc<PathBuf>,
+        supervisor: Arc<OwnerIdentity>,
     }
 
     struct StartPublishingRunner {
-        ledger_root: PathBuf,
-        supervisor: OwnerIdentity,
+        ledger_root: Arc<PathBuf>,
+        supervisor: Arc<OwnerIdentity>,
         start_calls: RefCell<usize>,
         wait_calls: Arc<AtomicUsize>,
     }
 
     struct StartPublishingExecution {
-        ledger_root: PathBuf,
-        supervisor: OwnerIdentity,
+        ledger_root: Arc<PathBuf>,
+        supervisor: Arc<OwnerIdentity>,
         wait_calls: Arc<AtomicUsize>,
     }
 
@@ -1943,8 +1943,8 @@ mod tests {
         ) -> Result<Box<dyn ScopeExecution>, String> {
             *self.calls.borrow_mut() += 1;
             Ok(Box::new(TransitionBlockingExecution {
-                ledger_root: self.ledger_root.clone(),
-                supervisor: self.supervisor.clone(),
+                ledger_root: Arc::clone(&self.ledger_root),
+                supervisor: Arc::clone(&self.supervisor),
             }))
         }
     }
@@ -1983,9 +1983,9 @@ mod tests {
         ) -> Result<Box<dyn ScopeExecution>, String> {
             *self.start_calls.borrow_mut() += 1;
             Ok(Box::new(StartPublishingExecution {
-                ledger_root: self.ledger_root.clone(),
-                supervisor: self.supervisor.clone(),
-                wait_calls: self.wait_calls.clone(),
+                ledger_root: Arc::clone(&self.ledger_root),
+                supervisor: Arc::clone(&self.supervisor),
+                wait_calls: Arc::clone(&self.wait_calls),
             }))
         }
     }
@@ -3088,8 +3088,8 @@ mod tests {
         let ledger_root = root.join("ledger");
         publish_open_admission_state(&ledger_root, &supervisor);
         let runner = TransitionBlockingRunner {
-            ledger_root: ledger_root.clone(),
-            supervisor,
+            ledger_root: Arc::new(ledger_root.clone()),
+            supervisor: Arc::new(supervisor),
             calls: RefCell::new(0),
         };
 
@@ -3134,8 +3134,8 @@ mod tests {
         let ledger_root = root.join("ledger");
         publish_open_admission_state(&ledger_root, &supervisor);
         let runner = StartPublishingRunner {
-            ledger_root: ledger_root.clone(),
-            supervisor,
+            ledger_root: Arc::new(ledger_root.clone()),
+            supervisor: Arc::new(supervisor),
             start_calls: RefCell::new(0),
             wait_calls: Arc::new(AtomicUsize::new(0)),
         };


### PR DESCRIPTION
## Title
⚡ perf(cli): wrap test runner scope execution states in Arc to avoid clones

## Description
💡 **What:** Refactored `StartPublishingRunner`, `StartPublishingExecution`, `TransitionBlockingRunner`, and `TransitionBlockingExecution` in `crates/ramshared-cli/src/workload.rs` to store `Arc<PathBuf>` and `Arc<OwnerIdentity>` instead of raw owned values.

🎯 **Why:** Previously, `launch()` duplicated heap-allocated path buffers and identity strings on every execution launch. Wrapping them in `Arc` enables cheap atomic reference count increments (`Arc::clone`), eliminating unnecessary allocations during scope launches.

📊 **Measured Improvement:** Replaced string/buffer deep clones during scope launcher invocation with O(1) atomic ref-count cloning.

## Labels
type:perf
area:cli

## Commits
38779796af058e902a31cc225d4597f6e2bf5756

---
*PR created automatically by Jules for task [15955799560420741592](https://jules.google.com/task/15955799560420741592) started by @emersonbusson*