### PR TITLE
🧪 test(wsl2d): add unit tests for uring_smoke::run

### DIFF
--- a/crates/ramshared-wsl2d/src/uring_smoke.rs
+++ b/crates/ramshared-wsl2d/src/uring_smoke.rs
@@ -9,3 +9,22 @@ pub use ramshared_uring::SmokeReport;
 pub fn run(entries: u32) -> std::io::Result<SmokeReport> {
     ramshared_uring::smoke(entries)
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn test_run_valid_entries() {
+        let report = run(4).expect("uring smoke should succeed for valid entries");
+        assert_eq!(report.entries, 4);
+        assert_eq!(report.submitted, 0);
+    }
+
+    #[test]
+    fn test_run_zero_entries_fails() {
+        let result = run(0);
+        assert!(result.is_err(), "uring smoke should fail for zero entries");
+    }
+}


### PR DESCRIPTION
## Summary
Adds unit tests for the public function `run` in `crates/ramshared-wsl2d/src/uring_smoke.rs`.

## Labels
* type:testing
* area:wsl2d

## Coverage
- Tested `uring_smoke::run(entries)` with valid entries (`4`), verifying that `SmokeReport` entries and submitted counts are correct.
- Tested `uring_smoke::run(0)` with zero entries, verifying that invalid entry counts fail as expected.

## Result
Increased unit test coverage for `crates/ramshared-wsl2d/src/uring_smoke.rs`.

## Commits
| Hash | Message |
| --- | --- |
| 78ad7e17ace000c23b2bae7a9c0cfc3728ad924a | test(wsl2d): add unit tests for uring_smoke::run |

---
*PR created automatically by Jules for task [11412931972168481873](https://jules.google.com/task/11412931972168481873) started by @emersonbusson*