### PR TITLE
⚡ perf(cli): preallocate transition owner buffer in quarantine snapshot

### DIFF
--- a/crates/ramshared-cli/src/workload.rs
+++ b/crates/ramshared-cli/src/workload.rs
@@ -800,7 +800,7 @@ fn quarantine_transition_snapshot(lock: &mut LedgerLock) -> Result<(), String> {
     lock.transition_file
         .seek(SeekFrom::Start(0))
         .map_err(|error| format!("read transition owner for recovery: {error}"))?;
-    let mut contents = Vec::new();
+    let mut contents = Vec::with_capacity((MAX_LEDGER_BYTES + 1) as usize);
     (&mut lock.transition_file)
         .take(MAX_LEDGER_BYTES + 1)
         .read_to_end(&mut contents)


### PR DESCRIPTION
⚡ perf(cli): preallocate transition owner buffer in quarantine snapshot

## What
Pre-allocate buffer capacity using `Vec::with_capacity((MAX_LEDGER_BYTES + 1) as usize)` in `quarantine_transition_snapshot` within `crates/ramshared-cli/src/workload.rs`.

## Why
When reading the transition owner record during quarantine snapshot creation, allocating a vector via `Vec::new()` causes repeated dynamic heap reallocations as `read_to_end` populates the buffer up to `MAX_LEDGER_BYTES + 1`. Pre-allocating capacity upfront eliminates these redundant allocations.

## Measured Improvement
Pre-allocating vector capacity eliminates repeated dynamic memory reallocations during quarantine snapshot reads up to 1 MiB.

## Labels
type:perf
area:cli

## Commits
be4903188b429f5e23b880fda6dba0511a9bfbc7

---
*PR created automatically by Jules for task [11375162336258529373](https://jules.google.com/task/11375162336258529373) started by @emersonbusson*