### PR TITLE
⚡ perf(cli): eliminate unnecessary clone in FakeExecution wait_for_completion

### DIFF
--- a/crates/ramshared-cli/src/workload.rs
+++ b/crates/ramshared-cli/src/workload.rs
@@ -1930,7 +1930,7 @@ mod tests {
         }
 
         fn wait_for_completion(&mut self) -> ScopeCompletion {
-            ScopeCompletion::Terminal(self.result.clone())
+            ScopeCompletion::Terminal(std::mem::replace(&mut self.result, Ok(None)))
         }
     }
 


### PR DESCRIPTION
## What
Eliminated unnecessary clone of `self.result` in `FakeExecution::wait_for_completion` by taking ownership via `std::mem::replace`.

## Why
`self.result.clone()` performed an unnecessary allocation and copy of the `Result<Option<i32>, String>` payload on every completion wait. Since `wait_for_completion` takes `&mut self`, taking ownership via `std::mem::replace` avoids cloning.

## Measured Improvement
Impractical to benchmark microsecond test fixture execution directly; however, removing `Result::clone` eliminates heap allocation when `self.result` contains an `Err(String)`.

## Labels
type:perf, area:cli

## Commits
| Commit | Message |
| --- | --- |
| 38ef7ec3823ae89fcdfb4189c1ae60c44e1c2246 | perf(cli): eliminate unnecessary clone in FakeExecution wait_for_completion |

---
*PR created automatically by Jules for task [15078556331292170362](https://jules.google.com/task/15078556331292170362) started by @emersonbusson*