### PR TITLE
🧪 [winsvc] Add tests for active_pagefiles

### DIFF
--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1187,4 +1187,29 @@ mod tests {
             .unwrap_err();
         assert!(error.to_string().contains("malformed Get-Disk output"));
     }
+
+    #[test]
+    fn active_pagefiles_query_returns_result() {
+        let result = WindowsHostState::active_pagefiles();
+        if let Err(err) = result {
+            assert!(matches!(err, HostError::Pagefile(_)));
+        }
+    }
+
+    #[test]
+    fn active_pagefiles_cim_parser_handles_valid_and_invalid_paths() {
+        let output = "C:\\pagefile.sys\n  D:\\swapfile.sys  \n\nE:\\pagefile.sys";
+        let parsed = parse_pagefile_lines(output).unwrap();
+        assert_eq!(
+            parsed,
+            vec![
+                "C:\\pagefile.sys".to_string(),
+                "D:\\swapfile.sys".to_string(),
+                "E:\\pagefile.sys".to_string(),
+            ]
+        );
+
+        let invalid = "invalid_path\nC:\\pagefile.sys";
+        assert!(parse_pagefile_lines(invalid).is_err());
+    }
 }


### PR DESCRIPTION
## Title
🧪 [winsvc] Add tests for active_pagefiles

## Description
🎯 **What:** Adds unit testing coverage for `active_pagefiles` public API and output parsing logic (`parse_pagefile_lines`) in `crates/ramshared-winsvc/src/windows_host.rs`.
📊 **Coverage:** Direct invocation of `WindowsHostState::active_pagefiles()`, plus tests for valid multi-line drive paths (`C:\pagefile.sys`, `D:\swapfile.sys`), empty line filtering, whitespace trimming, and error handling for invalid drive paths.
✨ **Result:** Ensures reliable and deterministic pagefile source path parsing and public API contract coverage.

## Labels
type:testing, area:winsvc

## Commits
| Hash | Message |
| --- | --- |
| ae937993b7f2896cedea6cb7c4ef5a4c88402ad6 | test(winsvc): add test for active_pagefiles line parser and query |

---
*PR created automatically by Jules for task [8061583161946566264](https://jules.google.com/task/8061583161946566264) started by @emersonbusson*