### PR TITLE
docs(wsl2d): document dxgkrnl collision kernel BUG incident safeguards

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -472,6 +472,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-05T14:24:00Z"
+    },
+    {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/*.md",
+      "owner": "documentation-governance",
+      "canonicalSource": "docs/DOCUMENTATION-PARITY.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-05T14:24:00Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/dxgkrnl-collision-kernel-bug.md
+++ b/docs/jules/findings/dxgkrnl-collision-kernel-bug.md
@@ -1,0 +1,14 @@
+# Finding: WSL2D dxgkrnl Collision Kernel BUG Incident Safeguards Audit
+
+## Context
+In `crates/ramshared-wsl2d/src/main.rs:2688`, a comment references an incident on 2026-07-03 where a kernel BUG occurred due to collision with `dxgkrnl`.
+
+## Technical Analysis
+- **Root Cause**: Memory locking with `MCL_FUTURE` races with asynchronous CUDA driver initialization and hypervisor memory mapping in `dxgkrnl`, causing host kernel BUG / hangs.
+- **Safeguards Verified**:
+  1. In `crates/ramshared-wsl2d/src/main.rs:4617`, `run_ublk` strictly invokes `runtime.lock_memory(force, false)?`, passing `future = false` to enforce `MCL_CURRENT`-only memory locking.
+  2. Post-init `arm_future_lock` was explicitly removed to avoid re-triggering asynchronous CUDA init races with `dxgkrnl`.
+  3. Preflight scripts (`scripts/safety/preflight.sh`) explicitly check for `FIX_MARKER='MCL_CURRENT-only no caminho ublk+vram'`.
+
+## Conclusion
+The codebase already enforces the necessary safeguards in `run_ublk` and preflight verification to prevent `dxgkrnl` kernel BUG collisions. No additional code changes are required in `crates/ramshared-wsl2d/src/main.rs`.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 252,
-    "classified": 249,
+    "total": 253,
+    "classified": 250,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -556,6 +556,18 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/dxgkrnl-collision-kernel-bug.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "documentation-governance",
+      "canonicalSource": "docs/DOCUMENTATION-PARITY.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Summary
Audit and document dxgkrnl collision kernel BUG incident safeguards in ramshared-wsl2d.

## Labels
- type:documentation
- area:wsl2d

## Commits
| Commit SHA | Message |
| --- | --- |
| 00ad841fc630d166097998710091a079f86e750e | docs(wsl2d): document dxgkrnl collision kernel BUG incident safeguards |


---
*PR created automatically by Jules for task [12609419060468360454](https://jules.google.com/task/12609419060468360454) started by @emersonbusson*