### PR TITLE
🧪 test(winsvc): add unit tests for observe_volume_identity

### DIFF
--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1190,18 +1190,15 @@ mod tests {
 
     #[test]
     fn observe_volume_identity_invalid_letter_rejected() {
-        use WindowsHostState::observe_volume_identity;
-
-        let err = observe_volume_identity('C').unwrap_err();
+        let err = WindowsHostState::observe_volume_identity('C').unwrap_err();
         assert!(matches!(err, HostError::Volume(msg) if msg.contains("letter must be D..=Z")));
 
-        let err = observe_volume_identity('A').unwrap_err();
+        let err = WindowsHostState::observe_volume_identity('A').unwrap_err();
         assert!(matches!(err, HostError::Volume(msg) if msg.contains("letter must be D..=Z")));
     }
 
     #[test]
     fn parse_identity_output_succeeds() {
-        use WindowsHostState::parse_identity_output;
         use std::os::windows::process::ExitStatusExt;
 
         let output = Output {
@@ -1209,7 +1206,7 @@ mod tests {
             stdout: b"RAMSHARE VRAMDISK|67108864|ABCDEF0123456789\n".to_vec(),
             stderr: Vec::new(),
         };
-        let observed = parse_identity_output('D', &output).unwrap();
+        let observed = WindowsHostState::parse_identity_output('D', &output).unwrap();
         assert_eq!(observed.letter, 'D');
         assert_eq!(observed.vendor, "RAMSHARE");
         assert_eq!(observed.product, "VRAMDISK");
@@ -1219,7 +1216,6 @@ mod tests {
 
     #[test]
     fn parse_identity_output_handles_failures_and_malformed() {
-        use WindowsHostState::parse_identity_output;
         use std::os::windows::process::ExitStatusExt;
 
         let failed_output = Output {
@@ -1227,7 +1223,7 @@ mod tests {
             stdout: Vec::new(),
             stderr: b"Get-Partition failed".to_vec(),
         };
-        let err = parse_identity_output('D', &failed_output).unwrap_err();
+        let err = WindowsHostState::parse_identity_output('D', &failed_output).unwrap_err();
         assert!(err.to_string().contains("volume identity query failed"));
 
         let bad_size = Output {
@@ -1235,7 +1231,7 @@ mod tests {
             stdout: b"RAMSHARE VRAMDISK|not_a_number|ABCDEF0123456789".to_vec(),
             stderr: Vec::new(),
         };
-        let err = parse_identity_output('D', &bad_size).unwrap_err();
+        let err = WindowsHostState::parse_identity_output('D', &bad_size).unwrap_err();
         assert!(err.to_string().contains("missing disk size"));
 
         let ambiguous = Output {
@@ -1243,7 +1239,7 @@ mod tests {
             stdout: b"RAMSHARE VRAMDISK|67108864|ABCDEF0123456789|extra_field".to_vec(),
             stderr: Vec::new(),
         };
-        let err = parse_identity_output('D', &ambiguous).unwrap_err();
+        let err = WindowsHostState::parse_identity_output('D', &ambiguous).unwrap_err();
         assert!(err.to_string().contains("ambiguous identity output"));
     }
 }

--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1187,4 +1187,63 @@ mod tests {
             .unwrap_err();
         assert!(error.to_string().contains("malformed Get-Disk output"));
     }
+
+    #[test]
+    fn observe_volume_identity_invalid_letter_rejected() {
+        use WindowsHostState::observe_volume_identity;
+
+        let err = observe_volume_identity('C').unwrap_err();
+        assert!(matches!(err, HostError::Volume(msg) if msg.contains("letter must be D..=Z")));
+
+        let err = observe_volume_identity('A').unwrap_err();
+        assert!(matches!(err, HostError::Volume(msg) if msg.contains("letter must be D..=Z")));
+    }
+
+    #[test]
+    fn parse_identity_output_succeeds() {
+        use std::os::windows::process::ExitStatusExt;
+        use WindowsHostState::parse_identity_output;
+
+        let output = Output {
+            status: std::process::ExitStatus::from_raw(0),
+            stdout: b"RAMSHARE VRAMDISK|67108864|ABCDEF0123456789\n".to_vec(),
+            stderr: Vec::new(),
+        };
+        let observed = parse_identity_output('D', &output).unwrap();
+        assert_eq!(observed.letter, 'D');
+        assert_eq!(observed.vendor, "RAMSHARE");
+        assert_eq!(observed.product, "VRAMDISK");
+        assert_eq!(observed.serial, "ABCDEF0123456789");
+        assert_eq!(observed.size_bytes, 67_108_864);
+    }
+
+    #[test]
+    fn parse_identity_output_handles_failures_and_malformed() {
+        use std::os::windows::process::ExitStatusExt;
+        use WindowsHostState::parse_identity_output;
+
+        let failed_output = Output {
+            status: std::process::ExitStatus::from_raw(42),
+            stdout: Vec::new(),
+            stderr: b"Get-Partition failed".to_vec(),
+        };
+        let err = parse_identity_output('D', &failed_output).unwrap_err();
+        assert!(err.to_string().contains("volume identity query failed"));
+
+        let bad_size = Output {
+            status: std::process::ExitStatus::from_raw(0),
+            stdout: b"RAMSHARE VRAMDISK|not_a_number|ABCDEF0123456789".to_vec(),
+            stderr: Vec::new(),
+        };
+        let err = parse_identity_output('D', &bad_size).unwrap_err();
+        assert!(err.to_string().contains("missing disk size"));
+
+        let ambiguous = Output {
+            status: std::process::ExitStatus::from_raw(0),
+            stdout: b"RAMSHARE VRAMDISK|67108864|ABCDEF0123456789|extra_field".to_vec(),
+            stderr: Vec::new(),
+        };
+        let err = parse_identity_output('D', &ambiguous).unwrap_err();
+        assert!(err.to_string().contains("ambiguous identity output"));
+    }
 }

--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1201,8 +1201,8 @@ mod tests {
 
     #[test]
     fn parse_identity_output_succeeds() {
-        use std::os::windows::process::ExitStatusExt;
         use WindowsHostState::parse_identity_output;
+        use std::os::windows::process::ExitStatusExt;
 
         let output = Output {
             status: std::process::ExitStatus::from_raw(0),
@@ -1219,8 +1219,8 @@ mod tests {
 
     #[test]
     fn parse_identity_output_handles_failures_and_malformed() {
-        use std::os::windows::process::ExitStatusExt;
         use WindowsHostState::parse_identity_output;
+        use std::os::windows::process::ExitStatusExt;
 
         let failed_output = Output {
             status: std::process::ExitStatus::from_raw(42),


### PR DESCRIPTION
## Summary

Adds direct unit test coverage for `observe_volume_identity` and `parse_identity_output` in `crates/ramshared-winsvc/src/windows_host.rs`.

## Coverage

- Drive letter range validation ('D'..='Z') in `observe_volume_identity`.
- Successful parsing of volume identity from `std::process::Output` in `parse_identity_output`.
- Error handling for process status failures, malformed size numbers, and ambiguous output fields in `parse_identity_output`.

## Result

Eliminates untested public entry point gap and guarantees error handling behavior under invalid inputs.

## Labels

type:testing area:winsvc

## Commits

| Commit | Description |
| --- | --- |
| bc6bb1c3fc05162be6aeb675cfe726da0d9dde2e | test(winsvc): add unit tests for observe_volume_identity |


---
*PR created automatically by Jules for task [1952211681872632136](https://jules.google.com/task/1952211681872632136) started by @emersonbusson*