### PR TITLE
🧹 [code health] FINDING_ONLY report for service.rs panic issue

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -14,6 +14,16 @@
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/*.md",
+      "owner": "documentation-governance",
+      "canonicalSource": "docs/DOCUMENTATION-PARITY.md",
+      "lifecycle": "reviewable",
+      "freshnessDays": 90,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-06T00:00:00Z"
+    },
+    {
       "id": "root-architecture-documents",
       "pattern": "ARCHITECTURE.md",
       "owner": "architecture",

--- a/docs/jules/findings/finding-unsafe-panic-service.md
+++ b/docs/jules/findings/finding-unsafe-panic-service.md
@@ -1,0 +1,9 @@
+# Finding: Unsafe panic!() Call Issue Resolution in service.rs
+
+## Summary
+The code health report flagged an unsafe `panic!()` call in `crates/ramshared-winsvc/src/service.rs` within `IdentityFailGates`.
+Upon code analysis of `crates/ramshared-winsvc/src/service.rs` (lines 470-497), the `IdentityFailGates` struct already implements safe error propagation returning `Err("Gate A must not run after identity refusal".into())` and `Err("volume lock must not run after identity refusal".into())`.
+No active `panic!()` calls exist in production logic within `service.rs`.
+
+## Conclusion
+The codebase already fulfills the safety requirement by returning `Result::Err` for gate refusal operations after identity check failure.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 252,
-    "classified": 249,
+    "total": 253,
+    "classified": 250,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -554,6 +554,18 @@
       },
       "owner": "documentation-governance",
       "canonicalSource": "docs/governance/README.md",
+      "lifecycle": "reviewable",
+      "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/finding-unsafe-panic-service.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "documentation-governance",
+      "canonicalSource": "docs/DOCUMENTATION-PARITY.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
     },


### PR DESCRIPTION
## Summary
Finding report for unsafe panic!() call in service.rs confirming the codebase already safely returns Result::Err.

## Labels
type:refactor
area:core

## Commits
| Hash | Message |
| --- | --- |
| b348ed16aa4341330eb7668864acdb72492e2a98 | docs: add FINDING_ONLY report for service.rs panic issue |

---
*PR created automatically by Jules for task [11439830370271364802](https://jules.google.com/task/11439830370271364802) started by @emersonbusson*