### PR TITLE
feat(ipc-resilience): implement timeout reaper for inflight block requests

### DIFF
--- a/crates/ramshared-block/src/inflight.rs
+++ b/crates/ramshared-block/src/inflight.rs
@@ -3,10 +3,12 @@
 //! reads or reordered write-after-write. Pure logic; the daemon queries before
 //! queueing the CUDA copy.
 
+use std::time::{Duration, Instant};
+
 /// Set of ranges `[offset, offset+len)` currently inflight.
 #[derive(Default)]
 pub struct Inflight {
-    ranges: Vec<(u64, u64)>,
+    ranges: Vec<(u64, u64, Instant)>,
 }
 
 impl Inflight {
@@ -17,7 +19,7 @@ impl Inflight {
     /// `true` if `[off, off+len)` overlaps some inflight range.
     pub fn conflicts(&self, off: u64, len: u64) -> bool {
         let end = off.saturating_add(len);
-        self.ranges.iter().any(|&(s, e)| off < e && s < end)
+        self.ranges.iter().any(|&(s, e, _)| off < e && s < end)
     }
 
     /// Marks the range as inflight. Returns `false` if it already conflicts (caller should
@@ -26,20 +28,38 @@ impl Inflight {
         if self.conflicts(off, len) {
             return false;
         }
-        self.ranges.push((off, off.saturating_add(len)));
+        self.ranges.push((off, off.saturating_add(len), Instant::now()));
         true
     }
 
     /// Removes the range upon completing the operation.
     pub fn remove(&mut self, off: u64, len: u64) {
         let end = off.saturating_add(len);
-        if let Some(i) = self.ranges.iter().position(|&r| r == (off, end)) {
+        if let Some(i) = self.ranges.iter().position(|&r| r.0 == off && r.1 == end) {
             self.ranges.swap_remove(i);
         }
     }
 
     pub fn is_empty(&self) -> bool {
         self.ranges.is_empty()
+    }
+
+    /// Reaps inflight requests older than `timeout` to prevent deadlocks on a stalled backend.
+    /// Calls the provided `callback` with the offset and length of each reaped request.
+    pub fn reap_timeouts<F>(&mut self, timeout: Duration, mut callback: F)
+    where
+        F: FnMut(u64, u64),
+    {
+        let now = Instant::now();
+        let mut i = 0;
+        while i < self.ranges.len() {
+            if now.saturating_duration_since(self.ranges[i].2) > timeout {
+                let (off, end, _) = self.ranges.swap_remove(i);
+                callback(off, end - off);
+            } else {
+                i += 1;
+            }
+        }
     }
 }
 
@@ -72,5 +92,23 @@ mod tests {
         assert!(f.try_insert(0, 4096));
         assert!(f.try_insert(4096, 4096));
         assert!(f.try_insert(8192, 4096));
+    }
+
+    #[test]
+    fn reap_timeouts_removes_stalled_requests_and_invokes_callback() {
+        let mut f = Inflight::new();
+        assert!(f.try_insert(0, 4096));
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(f.try_insert(8192, 4096));
+
+        let mut reaped = Vec::new();
+        // reap older than 25ms
+        f.reap_timeouts(Duration::from_millis(25), |off, len| {
+            reaped.push((off, len));
+        });
+
+        assert_eq!(reaped, vec![(0, 4096)]);
+        assert!(!f.conflicts(0, 4096)); // older one is reaped
+        assert!(f.conflicts(8192, 4096)); // recent one remains
     }
 }


### PR DESCRIPTION
## Resumo
Implement timeout tracking and a reaper for inflight block requests to prevent deadlocks on slow or stalled backends.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 273801bf2b4d48c0afbd7225a7e4a70a3e359ddd | Added timeout reaper to `Inflight` | Prevent deadlocks on stalled backend | Included `Instant` tracking and `reap_timeouts` method with callback |

## Labels
type:refactor, area:core, type:resilience

## Validacao
`cargo test -p ramshared-block && cargo clippy -p ramshared-block -- -D warnings`

## Rollback trigger
Revert if the reaper removes requests prematurely during heavy but legitimate I/O load, causing data corruption or torn reads.

---
*PR created automatically by Jules for task [13430923428971290936](https://jules.google.com/task/13430923428971290936) started by @emersonbusson*