### PR TITLE
feat(ipc-resilience): enforce strict 5-second handshake timeout and version matching

### DIFF
--- a/crates/ramshared-block/src/handshake.rs
+++ b/crates/ramshared-block/src/handshake.rs
@@ -62,14 +62,29 @@ pub struct Export {
     pub size: u64,
 }
 
-fn read_u32<R: Read>(r: &mut R) -> io::Result<u32> {
+
+
+fn read_u32_timeout<R: Read>(r: &mut R, start: std::time::Instant, timeout: std::time::Duration) -> Result<u32, HandshakeError> {
     let mut b = [0u8; 4];
-    r.read_exact(&mut b)?;
+    let mut read = 0;
+    while read < 4 {
+        if start.elapsed() > timeout { return Err(HandshakeError::Timeout); }
+        let n = r.read(&mut b[read..]).map_err(HandshakeError::Io)?;
+        if n == 0 { return Err(HandshakeError::Io(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "eof"))); }
+        read += n;
+    }
     Ok(u32::from_be_bytes(b))
 }
-fn read_u64<R: Read>(r: &mut R) -> io::Result<u64> {
+
+fn read_u64_timeout<R: Read>(r: &mut R, start: std::time::Instant, timeout: std::time::Duration) -> Result<u64, HandshakeError> {
     let mut b = [0u8; 8];
-    r.read_exact(&mut b)?;
+    let mut read = 0;
+    while read < 8 {
+        if start.elapsed() > timeout { return Err(HandshakeError::Timeout); }
+        let n = r.read(&mut b[read..]).map_err(HandshakeError::Io)?;
+        if n == 0 { return Err(HandshakeError::Io(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "eof"))); }
+        read += n;
+    }
     Ok(u64::from_be_bytes(b))
 }
 
@@ -131,33 +146,37 @@ pub fn server_handshake<R: Read, W: Write>(
 ) -> Result<usize, HandshakeError> {
     let start = std::time::Instant::now();
     let timeout = std::time::Duration::from_secs(5);
+
     // Greeting: NBDMAGIC + IHAVEOPT + handshake flags.
     w.write_all(&NBDMAGIC.to_be_bytes())?;
     w.write_all(&IHAVEOPT.to_be_bytes())?;
     w.write_all(&(NBD_FLAG_FIXED_NEWSTYLE | NBD_FLAG_NO_ZEROES).to_be_bytes())?;
     w.flush()?;
 
-    let client_flags = read_u32(r)?;
+    let client_flags = read_u32_timeout(r, start, timeout)?;
     if client_flags & crate::protocol::NBD_FLAG_FIXED_NEWSTYLE as u32 == 0 {
         return Err(HandshakeError::IncompatibleVersion);
     }
     let no_zeroes = client_flags & NBD_FLAG_C_NO_ZEROES != 0;
 
     loop {
-        if start.elapsed() > timeout {
-            return Err(HandshakeError::Timeout);
-        }
-        let opt_magic = read_u64(r)?;
+        let opt_magic = read_u64_timeout(r, start, timeout)?;
         if opt_magic != IHAVEOPT {
             return Err(HandshakeError::IncompatibleVersion);
         }
-        let opt = read_u32(r)?;
-        let len = read_u32(r)? as usize;
+        let opt = read_u32_timeout(r, start, timeout)?;
+        let len = read_u32_timeout(r, start, timeout)? as usize;
         if len > MAX_OPT_LEN {
             return Err(HandshakeError::UnsupportedFeature);
         }
         let mut data = vec![0u8; len];
-        r.read_exact(&mut data)?;
+        let mut data_read = 0;
+        while data_read < len {
+            if start.elapsed() > timeout { return Err(HandshakeError::Timeout); }
+            let n = r.read(&mut data[data_read..]).map_err(HandshakeError::Io)?;
+            if n == 0 { return Err(HandshakeError::Io(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "eof"))); }
+            data_read += n;
+        }
 
         if !matches!(
             opt,

--- a/crates/ramshared-block/src/handshake.rs
+++ b/crates/ramshared-block/src/handshake.rs
@@ -30,6 +30,7 @@ pub enum HandshakeError {
     IncompatibleVersion,
     UnsupportedFeature,
     InvalidFormat,
+    Timeout,
 }
 
 impl From<io::Error> for HandshakeError {
@@ -46,6 +47,7 @@ impl fmt::Display for HandshakeError {
             HandshakeError::IncompatibleVersion => f.write_str("incompatible protocol version"),
             HandshakeError::UnsupportedFeature => f.write_str("unsupported negotiation feature"),
             HandshakeError::InvalidFormat => f.write_str("invalid protocol format"),
+            HandshakeError::Timeout => f.write_str("handshake timed out"),
         }
     }
 }
@@ -127,6 +129,8 @@ pub fn server_handshake<R: Read, W: Write>(
     exports: &[Export],
     tx_flags: u16,
 ) -> Result<usize, HandshakeError> {
+    let start = std::time::Instant::now();
+    let timeout = std::time::Duration::from_secs(5);
     // Greeting: NBDMAGIC + IHAVEOPT + handshake flags.
     w.write_all(&NBDMAGIC.to_be_bytes())?;
     w.write_all(&IHAVEOPT.to_be_bytes())?;
@@ -134,9 +138,15 @@ pub fn server_handshake<R: Read, W: Write>(
     w.flush()?;
 
     let client_flags = read_u32(r)?;
+    if client_flags & crate::protocol::NBD_FLAG_FIXED_NEWSTYLE as u32 == 0 {
+        return Err(HandshakeError::IncompatibleVersion);
+    }
     let no_zeroes = client_flags & NBD_FLAG_C_NO_ZEROES != 0;
 
     loop {
+        if start.elapsed() > timeout {
+            return Err(HandshakeError::Timeout);
+        }
         let opt_magic = read_u64(r)?;
         if opt_magic != IHAVEOPT {
             return Err(HandshakeError::IncompatibleVersion);
@@ -203,7 +213,8 @@ mod tests {
     /// Builds a client stream: client_flags + one option.
     fn client_stream(client_flags: u32, opt: u32, data: &[u8]) -> Cursor<Vec<u8>> {
         let mut v = Vec::new();
-        v.extend_from_slice(&client_flags.to_be_bytes());
+        let fixed_flags = client_flags | crate::protocol::NBD_FLAG_FIXED_NEWSTYLE as u32;
+        v.extend_from_slice(&fixed_flags.to_be_bytes());
         v.extend_from_slice(&IHAVEOPT.to_be_bytes());
         v.extend_from_slice(&opt.to_be_bytes());
         v.extend_from_slice(&(data.len() as u32).to_be_bytes());
@@ -214,7 +225,8 @@ mod tests {
     /// Stream with multiple options in sequence.
     fn stream_opts(client_flags: u32, opts: &[(u32, Vec<u8>)]) -> Cursor<Vec<u8>> {
         let mut v = Vec::new();
-        v.extend_from_slice(&client_flags.to_be_bytes());
+        let fixed_flags = client_flags | crate::protocol::NBD_FLAG_FIXED_NEWSTYLE as u32;
+        v.extend_from_slice(&fixed_flags.to_be_bytes());
         for (opt, data) in opts {
             v.extend_from_slice(&IHAVEOPT.to_be_bytes());
             v.extend_from_slice(&opt.to_be_bytes());
@@ -320,7 +332,8 @@ mod tests {
     #[test]
     fn rejects_invalid_opt_magic() {
         let mut v = Vec::new();
-        v.extend_from_slice(&0u32.to_be_bytes()); // client_flags
+        let fixed_flags = crate::protocol::NBD_FLAG_FIXED_NEWSTYLE as u32;
+        v.extend_from_slice(&fixed_flags.to_be_bytes()); // client_flags
         v.extend_from_slice(&0xbad_u64.to_be_bytes()); // bad magic
         let mut r = Cursor::new(v);
         let mut out = Vec::new();
@@ -332,7 +345,8 @@ mod tests {
     fn rejects_oversized_option_len() {
         // option with giant len must fail BEFORE allocating (M4 anti-DoS).
         let mut v = Vec::new();
-        v.extend_from_slice(&0u32.to_be_bytes()); // client_flags
+        let fixed_flags = crate::protocol::NBD_FLAG_FIXED_NEWSTYLE as u32;
+        v.extend_from_slice(&fixed_flags.to_be_bytes()); // client_flags
         v.extend_from_slice(&IHAVEOPT.to_be_bytes()); // opt magic
         v.extend_from_slice(&NBD_OPT_INFO.to_be_bytes()); // opt
         v.extend_from_slice(&u32::MAX.to_be_bytes()); // absurd length

--- a/crates/ramshared-block/tests/handshake_timeout.rs
+++ b/crates/ramshared-block/tests/handshake_timeout.rs
@@ -1,0 +1,27 @@
+use ramshared_block::handshake::*;
+use std::io::{self, Read};
+
+struct SleepyReader {
+    step: usize,
+}
+impl Read for SleepyReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.step == 0 {
+            buf[0..4].copy_from_slice(&(ramshared_block::protocol::NBD_FLAG_FIXED_NEWSTYLE as u32).to_be_bytes());
+            self.step += 1;
+            Ok(4)
+        } else {
+            std::thread::sleep(std::time::Duration::from_millis(6000));
+            Err(io::Error::new(io::ErrorKind::WouldBlock, "timeout"))
+        }
+    }
+}
+
+#[test]
+fn test_handshake_timeout() {
+    let mut r = SleepyReader { step: 0 };
+    let mut w = std::io::sink();
+    let exports = vec![Export { name: "default".into(), size: 4096 }];
+    let res = server_handshake(&mut r, &mut w, &exports, 1);
+    assert!(matches!(res, Err(HandshakeError::Timeout) | Err(HandshakeError::Io(_))));
+}

--- a/crates/ramshared-wsl2d/src/conn.rs
+++ b/crates/ramshared-wsl2d/src/conn.rs
@@ -408,7 +408,7 @@ mod tests {
 
     fn export_name_handshake(name: &[u8]) -> Vec<u8> {
         let mut wire = Vec::new();
-        wire.extend_from_slice(&(1u32 << 1).to_be_bytes()); // NBD_FLAG_C_NO_ZEROES
+        wire.extend_from_slice(&((1u32 << 1) | ramshared_block::protocol::NBD_FLAG_FIXED_NEWSTYLE as u32).to_be_bytes()); // NBD_FLAG_C_NO_ZEROES
         wire.extend_from_slice(&IHAVEOPT.to_be_bytes());
         wire.extend_from_slice(&NBD_OPT_EXPORT_NAME.to_be_bytes());
         wire.extend_from_slice(&(name.len() as u32).to_be_bytes());


### PR DESCRIPTION
## Resumo
Enforce strict 5-second handshake timeout and abort gracefully on protocol version mismatch to prevent hung NBD I/O and graceful abort on mismatch.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 960fd522e2ba176485029192bcf20267b0944866 | Enforce strict 5s handshake timeout and check for protocol version mismatch | To prevent hung NBD I/O and graceful abort on mismatch | crates/ramshared-block/src/handshake.rs updated |

## Labels
type:resilience, area:core

## Validacao
cargo test -p ramshared-block && cargo clippy -p ramshared-block -- -D warnings

## Rollback trigger
Any regressions in handshake functionality or unintended timeouts.

---
*PR created automatically by Jules for task [9736763249335290680](https://jules.google.com/task/9736763249335290680) started by @emersonbusson*