### PR TITLE
test(block): add adversarial packet fuzzing test on protocol decoder

### DIFF
--- a/crates/ramshared-block/src/protocol.rs
+++ b/crates/ramshared-block/src/protocol.rs
@@ -183,4 +183,18 @@ mod tests {
         assert_eq!(Command::from_u16(2), Command::Disc);
         assert_eq!(Command::from_u16(99), Command::Unknown(99));
     }
+
+    #[test]
+    fn adversarial_fuzzing_decoder_zero_panics() {
+        let mut state = 0xdeadbeefu32;
+        let mut next_byte = || {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            (state >> 24) as u8
+        };
+        for _ in 0..100_000 {
+            let len = (next_byte() % 128) as usize;
+            let buf: Vec<u8> = (0..len).map(|_| next_byte()).collect();
+            let _ = parse_request(&buf);
+        }
+    }
 }


### PR DESCRIPTION
## Resumo
Add property-based test feeding random byte sequences into block protocol decoder to verify zero panics under adversarial payload fuzzing.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|--------|-----------|-------------|----------|
| 816f2aba4e6339d3a8f462b5b7e54523c9d03726 | test(block): add adversarial packet fuzzing test on protocol decoder | Verify protocol decoder resilience against malformed packets | LCG RNG fuzzing zero panics |

## Labels
type:test, area:core, type:resilience

## Validacao
cargo test -p ramshared-block && cargo clippy -p ramshared-block -- -D warnings && ./scripts/docs-check.sh

## Rollback trigger
test failure during fuzzing.

---
*PR created automatically by Jules for task [7325240056178750272](https://jules.google.com/task/7325240056178750272) started by @emersonbusson*