### PR TITLE
feat: atomic request ID generation under high concurrent thread contention

### DIFF
--- a/crates/ramshared-block/src/request.rs
+++ b/crates/ramshared-block/src/request.rs
@@ -422,6 +422,10 @@ mod tests {
         all_ids.sort_unstable();
         let len_before = all_ids.len();
         all_ids.dedup();
-        assert_eq!(len_before, all_ids.len(), "Duplicate IDs detected under contention");
+        assert_eq!(
+            len_before,
+            all_ids.len(),
+            "Duplicate IDs detected under contention"
+        );
     }
 }

--- a/crates/ramshared-block/src/request.rs
+++ b/crates/ramshared-block/src/request.rs
@@ -11,6 +11,31 @@ pub const NBD_EACCES: u32 = 13;
 pub const NBD_EINVAL: u32 = 22;
 pub const NBD_ERANGE: u32 = 34;
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Generates monotonically increasing request IDs for lockless tracing.
+pub struct RequestIdGenerator {
+    next: AtomicU64,
+}
+
+impl RequestIdGenerator {
+    pub const fn new() -> Self {
+        Self {
+            next: AtomicU64::new(1),
+        }
+    }
+
+    pub fn next_id(&self) -> u64 {
+        self.next.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+impl Default for RequestIdGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Storage backend error (e.g., CUDA failure in the hot path).
 #[derive(Debug)]
 pub struct IoError(pub String);
@@ -368,5 +393,35 @@ mod tests {
             u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
             NBD_ERANGE
         );
+    }
+
+    #[test]
+    fn concurrent_request_id_allocation_is_unique() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let generator = Arc::new(RequestIdGenerator::new());
+        let mut handles = vec![];
+
+        for _ in 0..10 {
+            let generator = generator.clone();
+            handles.push(thread::spawn(move || {
+                let mut ids = vec![];
+                for _ in 0..1000 {
+                    ids.push(generator.next_id());
+                }
+                ids
+            }));
+        }
+
+        let mut all_ids = vec![];
+        for h in handles {
+            all_ids.extend(h.join().unwrap());
+        }
+
+        all_ids.sort_unstable();
+        let len_before = all_ids.len();
+        all_ids.dedup();
+        assert_eq!(len_before, all_ids.len(), "Duplicate IDs detected under contention");
     }
 }


### PR DESCRIPTION
## Resumo
Implement atomic request ID generator for NBD requests using Lockless AtomicU64 to support high concurrent thread contention.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 156355c4427b6e00321ebc68c7de9288dbf72e09 | baseline | previous commit |   |
| d3bd8c5bee3e94063662a7536bdd79980a854da8 | feat: implement atomic request ID generation | Provide lockless tracing for high concurrency | Lockless AtomicU64 with Relaxed ordering |

## Labels
type:refactor, type:resilience, area:core

## Validacao
cargo test -p ramshared-block && cargo clippy -- -D warnings

## Rollback trigger
Duplicate request IDs observed under load or test regression.

---
*PR created automatically by Jules for task [15356387702367326120](https://jules.google.com/task/15356387702367326120) started by @emersonbusson*