### PR TITLE
feat(agent): trigger DemoteAll memory shedding on extreme PSI stall

### DIFF
--- a/crates/ramshared-agent/src/main.rs
+++ b/crates/ramshared-agent/src/main.rs
@@ -350,6 +350,19 @@ fn session(
                         swap_current: psi::read_memcg_swap(),
                         diskstats_io: active.values().filter_map(|d| psi::read_diskstats(d)).sum(),
                     });
+
+                    // Objective: Trigger urgent memory shedding when PSI some/full stall averages exceed 80% over 10-second window.
+                    if sample.avg10 > 80.0 {
+                        eprintln!(
+                            "[agent] extreme memory pressure (avg10={:.2}% > 80%): shedding all swap instances",
+                            sample.avg10
+                        );
+                        if !handle_msg(cfg, Msg::DemoteAll, &mut active, cmd_tx) {
+                            session_err = Some("DemoteAll due to memory pressure failed".into());
+                            break;
+                        }
+                    }
+
                     if let Err(e) = write_msg(&mut w, &Msg::Psi { sample, swaps, mem }) {
                         session_err = Some(e.into());
                         break;

--- a/crates/ramshared-agent/src/psi.rs
+++ b/crates/ramshared-agent/src/psi.rs
@@ -27,9 +27,9 @@ pub fn read_psi() -> Result<PsiSample> {
 ///
 /// Format: `some avg10=0.00 avg60=0.00 avg300=0.00 total=12345`.
 pub fn parse_psi(content: &str) -> Option<PsiSample> {
-    let line = content.lines().find(|l| l.starts_with("some "))?;
+    let some_line = content.lines().find(|l| l.starts_with("some "))?;
     let (mut avg10, mut avg60, mut total) = (None, None, None);
-    for tok in line.split_whitespace() {
+    for tok in some_line.split_whitespace() {
         if let Some(v) = tok.strip_prefix("avg10=") {
             avg10 = v.parse::<f32>().ok();
         } else if let Some(v) = tok.strip_prefix("avg60=") {
@@ -38,8 +38,18 @@ pub fn parse_psi(content: &str) -> Option<PsiSample> {
             total = v.parse::<u64>().ok();
         }
     }
+
+    let mut full_avg10 = 0.0;
+    if let Some(full_line) = content.lines().find(|l| l.starts_with("full ")) {
+        for tok in full_line.split_whitespace() {
+            if let Some(v) = tok.strip_prefix("avg10=") {
+                full_avg10 = v.parse::<f32>().unwrap_or(0.0);
+            }
+        }
+    }
+
     Some(PsiSample {
-        avg10: avg10?,
+        avg10: avg10?.max(full_avg10),
         avg60: avg60?,
         stall_us: total?,
     })
@@ -161,6 +171,16 @@ mod tests {
                  full avg10=0.00 avg60=0.00 avg300=0.00 total=0\n";
         let p = parse_psi(s).unwrap();
         assert_eq!(p.avg10, 1.23);
+        assert_eq!(p.avg60, 4.56);
+        assert_eq!(p.stall_us, 999);
+    }
+
+    #[test]
+    fn parse_psi_full_stall_overrides_some() {
+        let s = "some avg10=85.00 avg60=4.56 avg300=7.89 total=999\n\
+                 full avg10=90.00 avg60=0.00 avg300=0.00 total=0\n";
+        let p = parse_psi(s).unwrap();
+        assert_eq!(p.avg10, 90.00);
         assert_eq!(p.avg60, 4.56);
         assert_eq!(p.stall_us, 999);
     }

--- a/docs/governance/rust-slice-coverage.json
+++ b/docs/governance/rust-slice-coverage.json
@@ -423,7 +423,7 @@
         "-p",
         "ramshared-agent",
         "--files",
-        "crates/ramshared-agent/src/main.rs",
+        "crates/ramshared-agent/src/main.rs,crates/ramshared-agent/src/psi.rs",
         "--min",
         "80",
         "--report-json",
@@ -433,7 +433,8 @@
         "ramshared-agent"
       ],
       "files": [
-        "crates/ramshared-agent/src/main.rs"
+        "crates/ramshared-agent/src/main.rs",
+        "crates/ramshared-agent/src/psi.rs"
       ],
       "min": 80
     },

--- a/docs/specs/no-milestone/memory-broker/SPEC.md
+++ b/docs/specs/no-milestone/memory-broker/SPEC.md
@@ -340,7 +340,7 @@ fixtures issue only `Msg::Status`/reply frames; they never invoke `SwapOn`,
 The canonical per-file coverage owner for this business path is:
 
 ```bash
-node tools/ci/check-rust-slice-coverage.mjs -p ramshared-agent --files crates/ramshared-agent/src/main.rs --min 80 --report-json tmp/memory-broker-agent-cli-cov.json
+node tools/ci/check-rust-slice-coverage.mjs -p ramshared-agent --files crates/ramshared-agent/src/main.rs,crates/ramshared-agent/src/psi.rs --min 80 --report-json tmp/memory-broker-agent-cli-cov.json
 ```
 
 The process tests provide the public-surface validity/refusal evidence (#13),

--- a/tmp-ci-rust-slice-changes.txt
+++ b/tmp-ci-rust-slice-changes.txt
@@ -1,0 +1,4 @@
+crates/ramshared-agent/src/main.rs
+crates/ramshared-agent/src/psi.rs
+docs/governance/rust-slice-coverage.json
+docs/specs/no-milestone/memory-broker/SPEC.md

--- a/tmp-ci-rust-slice-changes.txt
+++ b/tmp-ci-rust-slice-changes.txt
@@ -1,4 +1,0 @@
-crates/ramshared-agent/src/main.rs
-crates/ramshared-agent/src/psi.rs
-docs/governance/rust-slice-coverage.json
-docs/specs/no-milestone/memory-broker/SPEC.md


### PR DESCRIPTION
## Resumo
Emergency memory shedding implementation when memory pressure (PSI some/full stall) exceeds 80% in a 10-second window, triggering a full demotion (`DemoteAll`). `parse_psi` has been adjusted to consider full stalls.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| f92c63c7c80abd8446744b982882e2351c1fbb39 | Add emergency PSI detection and DemoteAll shedding | Prevent OOM killer crashes and hardware panic corruption | Modified `ramshared-agent/src/psi.rs` and `main.rs` |

## Labels
type:resilience, area:core

## Validacao
`cargo test -p ramshared-agent && cargo clippy -p ramshared-agent -- -D warnings`

## Rollback trigger
If there are false positives resulting in early demotion of active swap instances. RULES: No unhandled crashes. MAIN_DIFF: Added full avg10 parsing to `parse_psi` and check for `sample.avg10 > 80.0` in `main.rs` to trigger `Msg::DemoteAll`. FILES: `crates/ramshared-agent/src/psi.rs`, `crates/ramshared-agent/src/main.rs`. INVARIANTS: Idempotent recovery. COUNTERFACTUAL: If we did not check for >80.0, the OOM killer could trigger. RED_TEST: `parse_psi_full_stall_overrides_some`. COVERAGE: Tested full stall logic. REAL_PROOF: Unit tests passed. ROLLBACK: Revert if memory shedding triggers too eagerly. PR_BOUNDARY: do not merge.

---
*PR created automatically by Jules for task [5713640091266902860](https://jules.google.com/task/5713640091266902860) started by @emersonbusson*