### PR TITLE
feat: document architectural scope trap for agent local.rs thrashing

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -492,6 +492,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "reviewable",
+      "freshnessDays": 90,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-06T12:00:00Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/README.md
+++ b/docs/jules/findings/README.md
@@ -1,0 +1,14 @@
+# Finding: Anti-thrashing backoff loop in local.rs is an architectural scope trap
+
+**Objective**: Detect memory thrashing loops and apply temporary exponential rate-limiting on swap allocations.
+**Target File**: `crates/ramshared-agent/src/local.rs`
+
+## Evidence
+
+The requested objective targets `crates/ramshared-agent/src/local.rs`. However, this file implements a simple JSON-line local loopback protocol for DCC adapters (`LocalMsg`, `LocalReply`). It has absolutely no relationship to swap allocations, memory thrashing detection, or applying exponential rate-limiting to swap memory.
+
+Furthermore, the `ramshared-agent` is an executor that processes broker commands via NBD. It does not natively govern priority or track host-level memory thrashing. Implementing swap allocation rate-limiting in a local IPC protocol layer introduces a fundamental architectural mismatch.
+
+## Conclusion
+
+This is an architectural scope trap. The modification would incorrectly couple memory management logic to an unrelated IPC protocol layer, breaking the separation of concerns. No changes were made to the source code.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 274,
+    "classified": 271,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -782,6 +782,18 @@
       },
       "owner": "documentation-governance",
       "canonicalSource": "docs/governance/README.md",
+      "lifecycle": "reviewable",
+      "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/README.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
     },


### PR DESCRIPTION
## Summary
Identified an architectural scope trap. The task requested adding an anti-thrashing backoff loop for swap allocations in `crates/ramshared-agent/src/local.rs`. However, `local.rs` simply implements a JSON-line local loopback protocol for DCC adapters and does not manage swap allocations or host-level memory thrashing. Created a `FINDING_ONLY` report to document this mismatch.

## Issue
Prompt ResilienceChaos-100, day 2026-09-06

## Owner
Jules

## Commits
| Commit | What it did | Why it was done | Details |
|---|---|---|---|
| 1abb793a2693f207d69d8dbff9a600319848178c | feat: document architectural scope trap for agent local.rs thrashing | Requested modification targets a local IPC protocol layer instead of swap manager | Created docs/jules/findings/README.md |

## Labels
type:resilience, area:core

## Validation
`cargo test -p ramshared-agent && ./scripts/docs-check.sh`

## Rollback trigger
Revert if the finding report or documentation inventory check causes CI failures.

---
*PR created automatically by Jules for task [13789627174738345555](https://jules.google.com/task/13789627174738345555) started by @emersonbusson*