### PR TITLE
feat(agent): implement fallback memory metric polling from meminfo

### DIFF
--- a/crates/ramshared-agent/src/psi.rs
+++ b/crates/ramshared-agent/src/psi.rs
@@ -61,13 +61,13 @@ pub fn parse_meminfo_fallback(content: &str) -> Option<PsiSample> {
 }
 
 /// Core logic for `read_psi` with dependency injection for the file path.
-fn read_psi_impl(path: &str) -> Result<PsiSample> {
+fn read_psi_impl(path: &str, meminfo_path: &str) -> Result<PsiSample> {
     match std::fs::read_to_string(path) {
         Ok(raw) => {
-            parse_psi(&raw).ok_or_else(|| Error::new(ErrorKind::InvalidData, "PSI ilegível"))
+            parse_psi(&raw).ok_or_else(|| Error::new(ErrorKind::InvalidData, "PSI unreadable"))
         }
         Err(e) if e.kind() == ErrorKind::NotFound => {
-            let meminfo = std::fs::read_to_string("/proc/meminfo")?;
+            let meminfo = std::fs::read_to_string(meminfo_path)?;
             parse_meminfo_fallback(&meminfo)
                 .ok_or_else(|| Error::new(ErrorKind::InvalidData, "Meminfo unreadable"))
         }
@@ -77,7 +77,7 @@ fn read_psi_impl(path: &str) -> Result<PsiSample> {
 
 /// Reads and parses `/proc/pressure/memory`.
 pub fn read_psi() -> Result<PsiSample> {
-    read_psi_impl("/proc/pressure/memory")
+    read_psi_impl("/proc/pressure/memory", "/proc/meminfo")
 }
 
 /// Parses the content of `/proc/pressure/memory`. Uses the `some` line (partial stall), which is
@@ -342,7 +342,7 @@ mod tests {
     fn read_psi_impl_success() {
         let content = "some avg10=1.23 avg60=4.56 avg300=7.89 total=999\n";
         let path = write_temp_file(content);
-        let psi = read_psi_impl(&path).unwrap();
+        let psi = read_psi_impl(&path, "/proc/meminfo").unwrap();
         assert_eq!(psi.avg10, 1.23);
         assert_eq!(psi.avg60, 4.56);
         assert_eq!(psi.stall_us, 999);
@@ -369,13 +369,19 @@ mod tests {
         // Will try to read /proc/meminfo which should exist and be valid on linux test hosts,
         // but might fail or succeed depending on the environment.
         // We'll just verify it returns a result without panicking.
-        let _ = read_psi_impl("/proc/nonexistent_psi_file_12345");
+        let content = "MemTotal:       1000000 kB\nMemAvailable:   250000 kB\nSwapTotal: 1000 kB\nSwapFree: 500 kB\n";
+        let meminfo_path = write_temp_file(content);
+
+        let psi = read_psi_impl("/proc/nonexistent_psi_file_12345", &meminfo_path).unwrap();
+        assert_eq!(psi.avg10, 75.0);
+
+        std::fs::remove_file(meminfo_path).unwrap();
     }
 
     #[test]
     fn read_psi_impl_invalid_data() {
         let path = write_temp_file("invalid content\n");
-        let err = read_psi_impl(&path).unwrap_err();
+        let err = read_psi_impl(&path, "/proc/meminfo").unwrap_err();
         assert_eq!(err.kind(), ErrorKind::InvalidData);
         std::fs::remove_file(path).unwrap();
     }

--- a/crates/ramshared-agent/src/psi.rs
+++ b/crates/ramshared-agent/src/psi.rs
@@ -11,10 +11,53 @@ use std::io::{Error, ErrorKind, Result};
 use ramshared_broker::model::PsiSample;
 use ramshared_broker::protocol::SwapEntry;
 
+/// Fallback parsing logic mapping `/proc/meminfo` metrics to a synthesized `PsiSample`.
+pub fn parse_meminfo_fallback(content: &str) -> Option<PsiSample> {
+    let mut mem_total = None;
+    let mut mem_available = None;
+    let mut swap_total = None;
+    let mut swap_free = None;
+
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            mem_total = rest.split_whitespace().next().and_then(|s| s.parse::<f32>().ok());
+        } else if let Some(rest) = line.strip_prefix("MemAvailable:") {
+            mem_available = rest.split_whitespace().next().and_then(|s| s.parse::<f32>().ok());
+        } else if let Some(rest) = line.strip_prefix("SwapTotal:") {
+            swap_total = rest.split_whitespace().next().and_then(|s| s.parse::<u64>().ok());
+        } else if let Some(rest) = line.strip_prefix("SwapFree:") {
+            swap_free = rest.split_whitespace().next().and_then(|s| s.parse::<u64>().ok());
+        }
+    }
+
+    let mt = mem_total?;
+    let ma = mem_available?;
+
+    if mt <= 0.0 {
+        return None;
+    }
+
+    let pressure = ((mt - ma) / mt) * 100.0;
+    let st = swap_total.unwrap_or(0);
+    let sf = swap_free.unwrap_or(0);
+
+    Some(PsiSample {
+        avg10: pressure,
+        avg60: pressure,
+        stall_us: st.saturating_sub(sf),
+    })
+}
+
 /// Core logic for `read_psi` with dependency injection for the file path.
 fn read_psi_impl(path: &str) -> Result<PsiSample> {
-    let raw = std::fs::read_to_string(path)?;
-    parse_psi(&raw).ok_or_else(|| Error::new(ErrorKind::InvalidData, "PSI ilegível"))
+    match std::fs::read_to_string(path) {
+        Ok(raw) => parse_psi(&raw).ok_or_else(|| Error::new(ErrorKind::InvalidData, "PSI ilegível")),
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            let meminfo = std::fs::read_to_string("/proc/meminfo")?;
+            parse_meminfo_fallback(&meminfo).ok_or_else(|| Error::new(ErrorKind::InvalidData, "Meminfo unreadable"))
+        }
+        Err(e) => Err(e),
+    }
 }
 
 /// Reads and parses `/proc/pressure/memory`.
@@ -292,8 +335,26 @@ mod tests {
     }
 
     #[test]
+    fn parse_meminfo_fallback_success() {
+        let content = "MemTotal:       1000000 kB\nMemAvailable:   250000 kB\nSwapTotal: 1000 kB\nSwapFree: 500 kB\n";
+        let psi = parse_meminfo_fallback(content).unwrap();
+        assert_eq!(psi.avg10, 75.0);
+        assert_eq!(psi.avg60, 75.0);
+        assert_eq!(psi.stall_us, 500);
+    }
+
+    #[test]
+    fn parse_meminfo_fallback_missing_fields() {
+        let content = "MemTotal:       1000000 kB\n";
+        assert!(parse_meminfo_fallback(content).is_none());
+    }
+
+    #[test]
     fn read_psi_impl_not_found() {
-        assert!(read_psi_impl("/proc/nonexistent_psi_file_12345").is_err());
+        // Will try to read /proc/meminfo which should exist and be valid on linux test hosts,
+        // but might fail or succeed depending on the environment.
+        // We'll just verify it returns a result without panicking.
+        let _ = read_psi_impl("/proc/nonexistent_psi_file_12345");
     }
 
     #[test]

--- a/crates/ramshared-agent/src/psi.rs
+++ b/crates/ramshared-agent/src/psi.rs
@@ -20,13 +20,25 @@ pub fn parse_meminfo_fallback(content: &str) -> Option<PsiSample> {
 
     for line in content.lines() {
         if let Some(rest) = line.strip_prefix("MemTotal:") {
-            mem_total = rest.split_whitespace().next().and_then(|s| s.parse::<f32>().ok());
+            mem_total = rest
+                .split_whitespace()
+                .next()
+                .and_then(|s| s.parse::<f32>().ok());
         } else if let Some(rest) = line.strip_prefix("MemAvailable:") {
-            mem_available = rest.split_whitespace().next().and_then(|s| s.parse::<f32>().ok());
+            mem_available = rest
+                .split_whitespace()
+                .next()
+                .and_then(|s| s.parse::<f32>().ok());
         } else if let Some(rest) = line.strip_prefix("SwapTotal:") {
-            swap_total = rest.split_whitespace().next().and_then(|s| s.parse::<u64>().ok());
+            swap_total = rest
+                .split_whitespace()
+                .next()
+                .and_then(|s| s.parse::<u64>().ok());
         } else if let Some(rest) = line.strip_prefix("SwapFree:") {
-            swap_free = rest.split_whitespace().next().and_then(|s| s.parse::<u64>().ok());
+            swap_free = rest
+                .split_whitespace()
+                .next()
+                .and_then(|s| s.parse::<u64>().ok());
         }
     }
 
@@ -51,10 +63,13 @@ pub fn parse_meminfo_fallback(content: &str) -> Option<PsiSample> {
 /// Core logic for `read_psi` with dependency injection for the file path.
 fn read_psi_impl(path: &str) -> Result<PsiSample> {
     match std::fs::read_to_string(path) {
-        Ok(raw) => parse_psi(&raw).ok_or_else(|| Error::new(ErrorKind::InvalidData, "PSI ilegível")),
+        Ok(raw) => {
+            parse_psi(&raw).ok_or_else(|| Error::new(ErrorKind::InvalidData, "PSI ilegível"))
+        }
         Err(e) if e.kind() == ErrorKind::NotFound => {
             let meminfo = std::fs::read_to_string("/proc/meminfo")?;
-            parse_meminfo_fallback(&meminfo).ok_or_else(|| Error::new(ErrorKind::InvalidData, "Meminfo unreadable"))
+            parse_meminfo_fallback(&meminfo)
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "Meminfo unreadable"))
         }
         Err(e) => Err(e),
     }


### PR DESCRIPTION
## Summary
Implemented fallback memory metric polling when PSI interface is unavailable.

## Commits
| Commit | What it did | Why it did | Details |
| 156355c4427b6e00321ebc68c7de9288dbf72e09 | Add fallback meminfo parsing | Prevent failure if PSI is missing | Fallback using MemAvailable and SwapFree |

## Issue
#038

## Responsible
ResilienceChaos100

## Labels
type:resilience,area:core

## Validation
cargo test && cargo clippy -- -D warnings

## Rollback trigger
Revert if fallback parsing panics or hangs.

---
*PR created automatically by Jules for task [5142396339723560114](https://jules.google.com/task/5142396339723560114) started by @emersonbusson*