### PR TITLE
fix(agent): Add concurrent attach/detach locking

### DIFF
--- a/crates/ramshared-agent/src/swap.rs
+++ b/crates/ramshared-agent/src/swap.rs
@@ -140,6 +140,8 @@ impl std::fmt::Display for SwapError {
 
 impl std::error::Error for SwapError {}
 
+static SWAP_OP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 pub fn attach_swap_with<F>(
     endpoint: &NbdEndpoint,
     export: &str,
@@ -150,6 +152,8 @@ pub fn attach_swap_with<F>(
 where
     F: FnMut(&str, &[String]) -> Result<()>,
 {
+    let _guard = SWAP_OP_LOCK.lock().map_err(|_| SwapError::Other("lock poisoned".into()))?;
+
     run_cmd("nbd-client", &nbd_args(endpoint, export, dev)).map_err(|e| {
         let msg = format!("nbd-client: {e}");
         SwapError::from_io_err(e, msg)
@@ -181,6 +185,8 @@ pub fn detach_swap_with<F>(dev: &str, mut run_cmd: F) -> std::result::Result<(),
 where
     F: FnMut(&str, &[String]) -> Result<()>,
 {
+    let _guard = SWAP_OP_LOCK.lock().map_err(|_| SwapError::Other("lock poisoned".into()))?;
+
     run_cmd("swapoff", &[dev.to_string()]).map_err(|e| {
         let msg = format!("swapoff: {e}");
         SwapError::from_io_err(e, msg)
@@ -340,5 +346,60 @@ mod tests {
             .expect("should succeed within bounds");
         validate_swap_resize(64 * 1024 * 1024, 64 * 1024 * 1024)
             .expect("should succeed at exact bounds");
+    }
+
+    #[test]
+    fn concurrent_swap_attach_detach_lock_safety() {
+        use std::sync::{Arc, Mutex};
+        use std::thread;
+
+        let inflight = Arc::new(Mutex::new(0));
+
+        let ep = NbdEndpoint::Unix {
+            path: "/sock".into(),
+        };
+
+        let mut handles = vec![];
+
+        // Thread 1: attach
+        let inflight_clone = Arc::clone(&inflight);
+        let ep_clone = ep.clone();
+        handles.push(thread::spawn(move || {
+            let _ = attach_swap_with(
+                &ep_clone,
+                "export",
+                "/dev/nbd0",
+                None,
+                |_, _| {
+                    let mut count = inflight_clone.lock().unwrap();
+                    assert!(*count == 0, "Race detected: concurrent swap operations");
+                    *count += 1;
+                    drop(count);
+                    thread::sleep(std::time::Duration::from_millis(50));
+                    let mut count = inflight_clone.lock().unwrap();
+                    *count -= 1;
+                    Ok(())
+                },
+            );
+        }));
+
+        // Thread 2: detach
+        let inflight_clone2 = Arc::clone(&inflight);
+        handles.push(thread::spawn(move || {
+            let _ = detach_swap_with("/dev/nbd0", |_, _| {
+                let mut count = inflight_clone2.lock().unwrap();
+                assert!(*count == 0, "Race detected: concurrent swap operations");
+                *count += 1;
+                drop(count);
+                thread::sleep(std::time::Duration::from_millis(50));
+                let mut count = inflight_clone2.lock().unwrap();
+                *count -= 1;
+                Ok(())
+            });
+        }));
+
+        for h in handles {
+            h.join().unwrap();
+        }
     }
 }


### PR DESCRIPTION
## Summary
Added global mutex `SWAP_OP_LOCK` to `attach_swap_with` and `detach_swap_with` to serialize concurrent NBD setup/teardown.

## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| 8dfdbcc094e475a0f4bb0b52f7761d3e877757fb | Added Mutex to swap operations | Prevent race conditions during concurrent swap attach/detach | Prevents NBD failures and panics during high-pressure ops |

## Labels
type:resilience,area:core

## Validation
Executed `cargo test --manifest-path crates/ramshared-agent/Cargo.toml && cargo clippy -- -D warnings`

## Rollback trigger
Revert if agent deadlocks or swap operations stall.

---
*PR created automatically by Jules for task [1857054709859455208](https://jules.google.com/task/1857054709859455208) started by @emersonbusson*