### PR TITLE
docs: add finding report for priority tier sorting

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -4,6 +4,16 @@
   "registeredAt": "2026-08-11T15:15:12Z",
   "routes": [
     {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "historical",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
       "id": "root-product-documents",
       "pattern": "README.md",
       "owner": "product-documentation",

--- a/docs/jules/findings/054-priority-tier-sorting.md
+++ b/docs/jules/findings/054-priority-tier-sorting.md
@@ -1,0 +1,5 @@
+# FINDING_ONLY: Zero-allocation priority tier sorting
+
+The request to implement "zero-allocation priority tier sorting under extreme memory starvation" in `crates/ramshared-tier/src/priority.rs` is an architectural scope trap.
+
+The `ramshared-tier` crate only sets static tier priorities (e.g., `zram > VRAM > VHDX`) for `swapon`. It does not govern memory slices or dynamic sorting. The Linux kernel VM handles actual page eviction. Implementing dynamic sorting of priority tiers is invalid as the architecture enforces a strict static cascade priority.

--- a/docs/jules/findings/README.md
+++ b/docs/jules/findings/README.md
@@ -1,0 +1,2 @@
+# Jules Findings
+This directory contains architectural FINDING_ONLY reports.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 275,
+    "classified": 272,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,30 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/054-priority-tier-sorting.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "historical",
+      "freshnessDays": null
+    },
+    {
+      "path": "docs/jules/findings/README.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "historical",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Issue
zero-allocation priority tier sorting under extreme memory starvation

## Responsible
Jules

## Summary
Created FINDING_ONLY report for an architectural trap in `crates/ramshared-tier/src/priority.rs` requesting zero-allocation priority tier sorting under extreme memory starvation. `ramshared-tier` strictly handles static priority cascades (`zram > VRAM > VHDX`), and modifying this to sort tiers dynamically is invalid.

## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| 86791ed26db5e503185a7c9db9bfc597175693ff | Created finding report | Mitigate architectural scope trap | Zero-allocation tier sorting in static cascade |

## Labels
type:resilience, area:core

## Validation
Executed `cargo test -p ramshared-tier`, `cargo clippy -p ramshared-tier -- -D warnings` and `./scripts/docs-check.sh`

## Rollback trigger
Revert if documentation governance tests fail in CI.

---
*PR created automatically by Jules for task [6940337288753936676](https://jules.google.com/task/6940337288753936676) started by @emersonbusson*