### PR TITLE
test(psi): add resilience fuzz test

### DIFF
--- a/crates/ramshared-agent/src/psi.rs
+++ b/crates/ramshared-agent/src/psi.rs
@@ -179,6 +179,22 @@ mod tests {
     }
 
     #[test]
+    fn parse_psi_fuzz_missing_field() {
+        let s = "some avg10=1.23 total=999\n\
+                 full avg10=0.00 avg60=0.00 avg300=0.00 total=0\n";
+        let p = parse_psi(s);
+        assert!(p.is_none());
+    }
+
+    #[test]
+    fn parse_psi_fuzz_malformed_field() {
+        let s = "some avg10=1.23 avg60=abc total=999\n\
+                 full avg10=0.00 avg60=0.00 avg300=0.00 total=0\n";
+        let p = parse_psi(s);
+        assert!(p.is_none());
+    }
+
+    #[test]
     fn parse_psi_no_some_line_is_none() {
         assert!(parse_psi("full avg10=1.0 avg60=2.0 avg300=3.0 total=5\n").is_none());
     }


### PR DESCRIPTION
## Summary
Added fuzz testing for partial/corrupted metrics.
## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| c783d79d05e98e100c026d036d47c1af66bdb375 | Add fuzz tests | Verify psi parser resilience | Adds red tests to psi parser |
## Labels
type:test,type:resilience
## Validation
`cargo test --manifest-path crates/ramshared-agent/Cargo.toml`
`cargo clippy --manifest-path crates/ramshared-agent/Cargo.toml -- -D warnings`
## Rollback trigger
Test failures on valid psi formats.

---
*PR created automatically by Jules for task [2937971165140918637](https://jules.google.com/task/2937971165140918637) started by @emersonbusson*