### PR TITLE
test(integrity): add multi-bit burst corruption test

### DIFF
--- a/crates/ramshared-integrity/src/pattern.rs
+++ b/crates/ramshared-integrity/src/pattern.rs
@@ -134,6 +134,24 @@ mod tests {
     }
 
     #[test]
+    fn multi_bit_burst_corruption_breaks_verify() {
+        let mut buf = vec![0u8; 4096];
+        fill_block(&mut buf, 8, Pattern::Sequential);
+        // Multi-bit burst corruption on a single byte
+        buf[2048] ^= 0x5a; // 01011010
+        let Err(err) = verify_block(&buf, 8, Pattern::Sequential) else {
+            panic!("Expected an error for multi-bit burst corrupted buffer");
+        };
+        assert_eq!(
+            err,
+            IntegrityError::CorruptedMemory {
+                offset: 2048,
+                bit_flip_mask: 0x5a,
+            }
+        );
+    }
+
+    #[test]
     fn different_blocks_differ_and_wrong_index_fails() {
         let mut a = vec![0u8; 4096];
         let mut b = vec![0u8; 4096];


### PR DESCRIPTION
## Summary
Added a unit test to verify that `verify_block` successfully catches multi-bit burst corruption scenarios on a single byte.

## Issue
data-integrity/057

## Responsible
ResilienceChaos100

## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| 156355c4427b6e00321ebc68c7de9288dbf72e09 | Previous commit | Base SHA | N/A |
| f82749800214089213e78bce12e9f66eb9cb1664 | test(integrity): add multi-bit burst corruption test | Ensure integrity check logic identifies non-trivial bit flips | Added `multi_bit_burst_corruption_breaks_verify` |

## Labels
type:test, area:core

## Validation
cargo test -p ramshared-integrity
cargo clippy -p ramshared-integrity -- -D warnings

## Rollback trigger
If test suite begins to panic spuriously.

---
*PR created automatically by Jules for task [3353442279562208663](https://jules.google.com/task/3353442279562208663) started by @emersonbusson*