### PR TITLE
test: add golden master bit-flip test

### DIFF
--- a/crates/ramshared-integrity/src/hash.rs
+++ b/crates/ramshared-integrity/src/hash.rs
@@ -162,4 +162,19 @@ mod tests {
         assert!(t.record(2, &data_65536));
         assert_eq!(t.verify(2, &data_65536), Some(true));
     }
+
+    #[test]
+    fn golden_master_deterministic_bit_flip_injection() {
+        let mut t = ChecksumTable::new(1);
+        let data = vec![0x5A; 4096];
+        assert!(t.record(0, &data));
+
+        for byte_idx in [0, 2048, 4095] {
+            for bit_idx in 0..8 {
+                let mut corrupt = data.clone();
+                corrupt[byte_idx] ^= 1 << bit_idx;
+                assert_eq!(t.verify(0, &corrupt), Some(false));
+            }
+        }
+    }
 }

--- a/test.patch
+++ b/test.patch
@@ -1,0 +1,22 @@
+--- crates/ramshared-integrity/src/hash.rs
++++ crates/ramshared-integrity/src/hash.rs
+@@ -109,4 +109,17 @@
+         assert!(t.record(2, &data_65536));
+         assert_eq!(t.verify(2, &data_65536), Some(true));
+     }
++
++    #[test]
++    fn golden_master_deterministic_bit_flip_injection() {
++        let mut t = ChecksumTable::new(1);
++        let data = vec![0x5A; 4096];
++        assert!(t.record(0, &data));
++
++        for byte_idx in [0, 2048, 4095] {
++            for bit_idx in 0..8 {
++                let mut corrupt = data.clone();
++                corrupt[byte_idx] ^= 1 << bit_idx;
++                assert_eq!(t.verify(0, &corrupt), Some(false));
++            }
++        }
++    }
+ }

--- a/test_flip.rs
+++ b/test_flip.rs
@@ -1,0 +1,2 @@
+use std::fs;
+fn main() {}


### PR DESCRIPTION
## Summary
Add adversarial unit test flipping single bits in memory blocks and asserting checksum rejection.

## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| 6a82d5b40745615db8be14f2e7bf37745946bd96 | Add test golden_master_deterministic_bit_flip_injection | To verify bit-flip detection | Added bit-flipping test logic in hash.rs |

## Labels
type:test, area:core

## Validation
cargo test --manifest-path crates/ramshared-integrity/Cargo.toml
cargo clippy -p ramshared-integrity -- -D warnings

## Rollback trigger
Revert if the golden master test is incorrect

---
*PR created automatically by Jules for task [13788378265028050455](https://jules.google.com/task/13788378265028050455) started by @emersonbusson*