### PR TITLE
feat: add integrity telemetry metrics for bit-rot rate and error counts

### DIFF
--- a/crates/ramshared-integrity/src/lib.rs
+++ b/crates/ramshared-integrity/src/lib.rs
@@ -7,6 +7,8 @@
 
 pub mod hash;
 pub mod pattern;
+pub mod telemetry;
 
 pub use hash::{ChecksumMismatchError, ChecksumTable, block_hash};
 pub use pattern::{IntegrityError, Pattern, fill_block, verify_block};
+pub use telemetry::IntegrityTelemetry;

--- a/crates/ramshared-integrity/src/telemetry.rs
+++ b/crates/ramshared-integrity/src/telemetry.rs
@@ -1,0 +1,68 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Debug, Default)]
+pub struct IntegrityTelemetry {
+    pub corrupted_blocks: AtomicU64,
+    pub repaired_pages: AtomicU64,
+    pub quarantine_size_bytes: AtomicU64,
+}
+
+impl IntegrityTelemetry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record_corruption(&self) {
+        self.corrupted_blocks.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_repair(&self) {
+        self.repaired_pages.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn add_quarantine_bytes(&self, bytes: u64) {
+        self.quarantine_size_bytes.fetch_add(bytes, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+
+    #[test]
+    fn test_telemetry_counters() {
+        let telemetry = IntegrityTelemetry::new();
+        telemetry.record_corruption();
+        telemetry.record_repair();
+        telemetry.add_quarantine_bytes(4096);
+
+        assert_eq!(telemetry.corrupted_blocks.load(Ordering::Relaxed), 1);
+        assert_eq!(telemetry.repaired_pages.load(Ordering::Relaxed), 1);
+        assert_eq!(telemetry.quarantine_size_bytes.load(Ordering::Relaxed), 4096);
+    }
+
+    #[test]
+    fn test_telemetry_chaos_concurrent_updates() {
+        let telemetry = Arc::new(IntegrityTelemetry::new());
+        let mut handles = vec![];
+
+        for _ in 0..100 {
+            let t = Arc::clone(&telemetry);
+            handles.push(thread::spawn(move || {
+                t.record_corruption();
+                t.record_repair();
+                t.add_quarantine_bytes(4096);
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(telemetry.corrupted_blocks.load(Ordering::Relaxed), 100);
+        assert_eq!(telemetry.repaired_pages.load(Ordering::Relaxed), 100);
+        assert_eq!(telemetry.quarantine_size_bytes.load(Ordering::Relaxed), 409600);
+    }
+}


### PR DESCRIPTION
## Summary
Added `telemetry.rs` to track atomic counters for detected corrupted blocks, repaired pages, and quarantine size. Exported `IntegrityTelemetry` in `lib.rs`.

## Issue
N/A

## Responsible
Jules

## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| f3cee947231ca24bf2d40f92a07114682bf6a185 | feat: add integrity telemetry metrics for bit-rot rate and error counts | Tracking atomic counters for detected corrupted blocks, repaired pages, and quarantine size provides vital telemetry for the chaos engineering and recovery pipelines. | Added `telemetry.rs` and updated `lib.rs` |

## Labels
type:resilience, area:core

## Validation
cargo test -p ramshared-integrity && cargo clippy -p ramshared-integrity -- -D warnings

## Rollback trigger
Revert if the telemetry struct causes performance regressions or data races.


---
*PR created automatically by Jules for task [13545079615297026691](https://jules.google.com/task/13545079615297026691) started by @emersonbusson*