### PR TITLE
docs: generate FINDING_ONLY report for bad memory block quarantine

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -492,6 +492,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "agent-findings",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "reliability",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-06T12:00:00Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/README.md
+++ b/docs/jules/findings/README.md
@@ -1,0 +1,1 @@
+# Findings

--- a/docs/jules/findings/bad_memory_quarantine.md
+++ b/docs/jules/findings/bad_memory_quarantine.md
@@ -1,0 +1,11 @@
+# Findings: Bad memory block quarantine and exclusion list management
+
+The task requests the implementation of a "quarantine list of damaged memory sectors, preventing subsequent allocations on bad spans" in `crates/ramshared-integrity/src/lib.rs`.
+
+However, `ramshared-integrity` is purely a library for block integrity verification (checksumming and pattern matching). It only provides the mathematical and data structures to detect data corruption (`ChecksumTable`, `block_hash`, `verify_block`, `fill_block`). It does not handle memory allocation, block device management, caching logic, or "spans".
+
+Memory management, VRAM caching, and block device allocation are handled in completely different layers (such as `crates/ramshared-vram`, `crates/ramshared-block`, or the GPU integration layers like `ramshared-cuda` / `ramshared-vulkan`).
+
+Adding stateful allocation exclusion lists or a "quarantine" manager within the `ramshared-integrity` pure logic library is an architectural scope trap. A verification library should not contain the state for the system's memory allocator.
+
+Therefore, this is a FINDING_ONLY report and no code changes are made to `crates/ramshared-integrity/src/lib.rs`.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 275,
+    "classified": 272,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,30 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/README.md",
+      "disposition": "classified",
+      "ruleId": "agent-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "reliability",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
+    },
+    {
+      "path": "docs/jules/findings/bad_memory_quarantine.md",
+      "disposition": "classified",
+      "ruleId": "agent-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "reliability",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Summary
Generated FINDING_ONLY report for bad memory block quarantine since it is an architectural scope trap.

## Issue
bad memory block quarantine and exclusion list management

## Responsible
ResilienceChaos100/2026-09-06/data-integrity/058

## Commits
| Commit | What it did | Why it did | Details |
|---|---|---|---|
| adab336dd42a8c8adde26f532d29221ea7142fd7 | docs: generate FINDING_ONLY report for bad memory block quarantine | Memory management is an architectural trap for ramshared-integrity. | Document only. |

## Labels
type:resilience

## Validation
`cargo test -p ramshared-integrity && ./scripts/docs-check.sh`

## Rollback trigger
Not applicable, document only.

---
*PR created automatically by Jules for task [9809499086242922704](https://jules.google.com/task/9809499086242922704) started by @emersonbusson*