### PR TITLE
docs: report trap on transparent vram corruption reallocation

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -10,7 +10,9 @@
       "canonicalSource": "README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -20,7 +22,9 @@
       "canonicalSource": "ARCHITECTURE.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -30,7 +34,9 @@
       "canonicalSource": "CHANGELOG.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -40,7 +46,9 @@
       "canonicalSource": "CONTRIBUTING.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -50,7 +58,9 @@
       "canonicalSource": "MANIFESTO.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -60,7 +70,9 @@
       "canonicalSource": "ROADMAP.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -70,7 +82,9 @@
       "canonicalSource": "trovaldo.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -80,7 +94,9 @@
       "canonicalSource": "SECURITY.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -90,7 +106,9 @@
       "canonicalSource": "validation.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -100,7 +118,9 @@
       "canonicalSource": "TASK.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -110,7 +130,9 @@
       "canonicalSource": "superprompt.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -120,7 +142,9 @@
       "canonicalSource": "AGENTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -130,7 +154,9 @@
       "canonicalSource": "CLAUDE.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -140,7 +166,9 @@
       "canonicalSource": ".claude/rules/documentation.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -150,7 +178,9 @@
       "canonicalSource": "docs/DOCUMENTATION-PARITY.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -160,7 +190,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -170,7 +202,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -180,7 +214,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -190,7 +226,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -200,7 +238,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -210,7 +250,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -220,7 +262,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -230,7 +274,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -240,7 +286,9 @@
       "canonicalSource": "validation.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -250,7 +298,9 @@
       "canonicalSource": "validation.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -260,7 +310,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -270,7 +322,9 @@
       "canonicalSource": "docs/SSDV3-PROMPTS.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -280,7 +334,9 @@
       "canonicalSource": "docs/BENCHMARKS.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -290,7 +346,9 @@
       "canonicalSource": "docs/ci/CI-TOPOLOGY.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -300,7 +358,9 @@
       "canonicalSource": "docs/decisions/README.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -310,7 +370,9 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -320,7 +382,9 @@
       "canonicalSource": "docs/labs/LAB-DISK-GUARD.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -330,7 +394,9 @@
       "canonicalSource": "docs/marketing/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -340,7 +406,9 @@
       "canonicalSource": "docs/methodology/kahneman-disciplines.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -350,7 +418,9 @@
       "canonicalSource": "docs/packaging/INSTALLABLES.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -360,7 +430,9 @@
       "canonicalSource": "docs/postmortems/TEMPLATE.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -370,7 +442,9 @@
       "canonicalSource": "docs/reference/REFERENCE-INDEX.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -380,7 +454,9 @@
       "canonicalSource": "docs/security/THREAT-MODEL.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:25:34Z"
     },
     {
@@ -390,7 +466,9 @@
       "canonicalSource": "docs/reliability/GAP-REGISTER.md",
       "lifecycle": "immutable",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -400,7 +478,9 @@
       "canonicalSource": "docs/postmortems/TEMPLATE.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-20T14:49:00Z"
     },
     {
@@ -410,7 +490,9 @@
       "canonicalSource": "docs/reliability/GAP-REGISTER.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -420,7 +502,9 @@
       "canonicalSource": "README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 30,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-20T14:49:00Z"
     },
     {
@@ -430,7 +514,9 @@
       "canonicalSource": "ARCHITECTURE.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-26T13:15:00Z"
     },
     {
@@ -440,7 +526,9 @@
       "canonicalSource": "docs/reviews/README.md",
       "lifecycle": "historical",
       "freshnessDays": null,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -450,7 +538,9 @@
       "canonicalSource": "docs/runbooks/windows-autonomous-broker.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -460,7 +550,9 @@
       "canonicalSource": "drivers/windows/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -470,7 +562,9 @@
       "canonicalSource": "scripts/windows/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-08-11T15:15:12Z"
     },
     {
@@ -480,7 +574,9 @@
       "canonicalSource": "drivers/block/ramshared/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-09-05T14:24:00Z"
     },
     {
@@ -490,7 +586,21 @@
       "canonicalSource": "ARCHITECTURE.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90,
-      "verification": { "state": "unverified" },
+      "verification": {
+        "state": "unverified"
+      },
+      "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/*.md",
+      "owner": "jules",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": {
+        "state": "unverified"
+      },
       "registeredAt": "2026-09-06T12:00:00Z"
     }
   ],

--- a/docs/jules/findings/README.md
+++ b/docs/jules/findings/README.md
@@ -1,0 +1,14 @@
+# Finding: Corrupted sparse page isolation and reallocation
+
+## Summary
+
+The request to "Quarantine corrupted sparse VRAM page and allocate fresh backing block transparently" in `crates/ramshared-block/src/sparse_vram.rs` is an architectural scope trap.
+
+### Rationale
+
+The NBD block device operates as a swap backend where the Linux kernel strictly relies on data durability. If a VRAM chunk becomes corrupted (e.g., bit-rot detected via hashing), allocating a *fresh* backing block transparently behind the kernel's back means the kernel will read zeroed or uninitialized memory for previously swapped-out pages. This fundamentally breaks the memory contract and results in **silent data corruption** of host processes.
+
+According to the High-Availability architectural pillars:
+- **Fail-Safe Defaults:** "If hardware or peer fails, fail closed with typed semantic errors without corrupting data or memory."
+
+Instead of transparently reallocating and returning zeroes, the correct behavior for block storage when data is unrecoverably corrupted is to fail closed. The block device must return a hard I/O error (`IoError`) up the stack, allowing the kernel to take appropriate action (such as killing the specific process that owned the corrupted page), rather than silently handing it corrupted data that could lead to widespread system instability.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 274,
+    "classified": 271,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,18 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/README.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "jules",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Issue
Corrupted sparse page isolation and reallocation

## Responsible
Jules

## Summary
Generated a FINDING_ONLY report to document that transparently replacing corrupted sparse VRAM chunks violates Fail-Safe Defaults by causing silent data corruption.

## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| 436bdacf62e8dba4779ec9abc1ff92152d8e061f | Generated FINDING_ONLY report for VRAM scope trap | To document why transparent reallocation violates the architectural specification | N/A |

## Labels
type:resilience, area:core

## Validation
Executed `cargo test -p ramshared-block` and `./scripts/docs-check.sh`

## Rollback trigger
Revert if the finding report is incorrect.

---
*PR created automatically by Jules for task [12254429176730356299](https://jules.google.com/task/12254429176730356299) started by @emersonbusson*