### PR TITLE
feat: hardware-accelerated CRC32-SIMD verification over 4096-byte memory pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +638,9 @@ dependencies = [
 [[package]]
 name = "ramshared-integrity"
 version = "0.1.0"
+dependencies = [
+ "crc32fast",
+]
 
 [[package]]
 name = "ramshared-tier"

--- a/crates/ramshared-integrity/Cargo.toml
+++ b/crates/ramshared-integrity/Cargo.toml
@@ -10,3 +10,6 @@ publish.workspace = true
 [lints.clippy]
 unwrap_used = "deny"
 expect_used = "deny"
+
+[dependencies]
+crc32fast = "1.3.2"

--- a/crates/ramshared-integrity/src/hash.rs
+++ b/crates/ramshared-integrity/src/hash.rs
@@ -6,17 +6,11 @@ use std::fmt;
 
 pub const DEFAULT_BLOCK_SIZE: usize = 4096;
 
-const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
-const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
-
-/// FNV-1a 64-bit hash over block bytes.
+/// SIMD-accelerated CRC32 checksum over block bytes.
 pub fn block_hash(data: &[u8]) -> u64 {
-    let mut h = FNV_OFFSET;
-    for &b in data {
-        h ^= b as u64;
-        h = h.wrapping_mul(FNV_PRIME);
-    }
-    h
+    let mut hasher = crc32fast::Hasher::new();
+    hasher.update(data);
+    hasher.finalize() as u64
 }
 
 /// Semantic error for block verification failures.
@@ -112,6 +106,25 @@ mod tests {
         assert_eq!(block_hash(&a), block_hash(&b));
         b[2048] ^= 0x01;
         assert_ne!(block_hash(&a), block_hash(&b));
+    }
+
+    #[test]
+    fn chaos_adversarial_bit_flips_and_burst_corruptions() {
+        let mut t = ChecksumTable::new(8);
+        let data = vec![0xABu8; 4096];
+        assert!(t.record(0, &data));
+
+        // Single-bit flip
+        let mut single_bit = data.clone();
+        single_bit[2048] ^= 0x01;
+        assert_eq!(t.verify(0, &single_bit), Some(false));
+
+        // Multi-bit burst corruption
+        let mut burst = data.clone();
+        for i in 1000..1010 {
+            burst[i] ^= 0xFF;
+        }
+        assert_eq!(t.verify(0, &burst), Some(false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Hardware-accelerated CRC32-SIMD verification over 4096-byte memory pages.

## Issue
N/A

## Responsible
Jules

## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| 25cf90aeaa8249230bc4a9461a7d87ef01d55299 | Replaced FNV-1a with CRC32-SIMD | Faster block integrity checks | Uses crc32fast crate |

## Labels
type:resilience

## Validation
cargo test -p ramshared-integrity

## Rollback trigger
Revert if CRC32 performance degrades or hardware incompatibilities arise.

---
*PR created automatically by Jules for task [9774999635508310028](https://jules.google.com/task/9774999635508310028) started by @emersonbusson*