### PR TITLE
docs: generate FINDING_ONLY report for quarantine architectural trap

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -492,6 +492,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "jules-finding-data-integrity-071-quarantine",
+      "pattern": "docs/jules/findings/data-integrity-071-quarantine.md",
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/data-integrity-071-quarantine.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-06T00:00:00Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/data-integrity-071-quarantine.md
+++ b/docs/jules/findings/data-integrity-071-quarantine.md
@@ -1,0 +1,10 @@
+# Finding: Architectural Scope Trap - Quarantine List in ramshared-integrity
+
+## Observation
+The task requested to implement a quarantine list of damaged memory sectors and prevent subsequent allocations on bad spans in `crates/ramshared-integrity/src/lib.rs`.
+
+## Analysis
+This is an architectural scope trap. The `ramshared-integrity` crate is a pure logic library for block integrity verification (checksumming and pattern matching) and does not handle memory allocation or stateful block device management. Adding a stateful quarantine list or memory allocation prevention here violates the architectural design.
+
+## Action Taken
+Created this FINDING_ONLY report without modifying the code in `crates/ramshared-integrity/src/lib.rs`.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 274,
+    "classified": 271,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,18 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/data-integrity-071-quarantine.md",
+      "disposition": "classified",
+      "ruleId": "jules-finding-data-integrity-071-quarantine",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/data-integrity-071-quarantine.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Issue
data-integrity-071

## Responsible
ResilienceChaos100

## Summary
Generated FINDING_ONLY report to document the architectural scope trap regarding quarantine lists in ramshared-integrity.

## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| ca83a7b6c3e24b4efb9d65339f38b193d3678ebc | Created finding report | The requested quarantine functionality is an architectural scope trap. | N/A |

## Labels
type:resilience

## Validation
rm update_routes.py && ./scripts/docs-check.sh

## Rollback trigger
If the finding report is incorrect.

---
*PR created automatically by Jules for task [13597800461059021847](https://jules.google.com/task/13597800461059021847) started by @emersonbusson*