### PR TITLE
feat(integrity): implement xxHash3 for high-throughput block hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,9 @@ dependencies = [
 [[package]]
 name = "ramshared-integrity"
 version = "0.1.0"
+dependencies = [
+ "xxhash-rust",
+]
 
 [[package]]
 name = "ramshared-tier"
@@ -1171,6 +1174,12 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "zmij"

--- a/crates/ramshared-integrity/Cargo.toml
+++ b/crates/ramshared-integrity/Cargo.toml
@@ -10,3 +10,6 @@ publish.workspace = true
 [lints.clippy]
 unwrap_used = "deny"
 expect_used = "deny"
+
+[dependencies]
+xxhash-rust = { version = "0.8.18", features = ["xxh3"] }

--- a/crates/ramshared-integrity/src/hash.rs
+++ b/crates/ramshared-integrity/src/hash.rs
@@ -6,17 +6,12 @@ use std::fmt;
 
 pub const DEFAULT_BLOCK_SIZE: usize = 4096;
 
-const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
-const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
 
-/// FNV-1a 64-bit hash over block bytes.
+
+
+/// xxHash3 64-bit hash over block bytes.
 pub fn block_hash(data: &[u8]) -> u64 {
-    let mut h = FNV_OFFSET;
-    for &b in data {
-        h ^= b as u64;
-        h = h.wrapping_mul(FNV_PRIME);
-    }
-    h
+    xxhash_rust::xxh3::xxh3_64(data)
 }
 
 /// Semantic error for block verification failures.


### PR DESCRIPTION
## Issue
Implement xxHash3 64-bit algorithm support for ultra-high-throughput memory blocks

## Responsible
ResilienceChaos100/2026-09-06/data-integrity/073

## Summary
Implemented xxHash3 for high-throughput block hashing in crates/ramshared-integrity/src/hash.rs.

## Commits
| Commit | What it did | Why it did | Details |
| ccbfa676f07f3fbcc9c44b6f824eb97dba51e0c2 | Replaced FNV-1a with xxHash3 | To support ultra-high-throughput checksum calculation | Modified Cargo.toml and hash.rs |

## Labels
type:resilience, area:core

## Validation
cargo test -p ramshared-integrity
cargo clippy -p ramshared-integrity -- -D warnings

## Rollback trigger
Revert if the xxHash3 implementation causes checksum validation errors on unmodified memory blocks.

---
*PR created automatically by Jules for task [12819165573590076256](https://jules.google.com/task/12819165573590076256) started by @emersonbusson*