### PR TITLE
docs: generate FINDING_ONLY report for origin cache flush checksums

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -492,6 +492,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-07T06:36:34Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/070-origin-checksum.md
+++ b/docs/jules/findings/070-origin-checksum.md
@@ -1,0 +1,7 @@
+# FINDING_ONLY: Origin Cache Dirty Block Checksum Verification
+
+## Target
+`crates/ramshared-block/src/isolated_origin.rs`
+
+## Analysis
+The task requested verifying checksums of dirty origin cache blocks before marking them clean during flush operations. However, this is an architectural scope trap. The `AuthoritativeOriginBackend` in `isolated_origin.rs` does not buffer dirty blocks in user-space. Writes are immediately passed to the underlying `OriginStorage::write_all_at()`, and a single `origin_dirty` boolean flag is set to `true`. When `flush()` is called, `sync_dirty_origin()` invokes `OriginStorage::sync_data()`, delegating to the OS (e.g., via `fsync`) to flush the OS page cache. Since there are no dirty blocks buffered in user-space, and the OS page cache is opaque, we cannot calculate or verify block checksums during the flush operation in this file. Implementing a user-space block buffer here would unnecessarily duplicate OS functionality and violate the design of the thin authoritative backend.

--- a/docs/jules/findings/README.md
+++ b/docs/jules/findings/README.md
@@ -1,0 +1,3 @@
+# Findings
+
+Canonical source for architectural findings.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 275,
+    "classified": 272,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,30 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/070-origin-checksum.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
+    },
+    {
+      "path": "docs/jules/findings/README.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Summary
Validated that the architectural scope trap requested checksum verification on OS page cache flushes, which is impossible without unnecessary user-space buffering that violates authoritative origin design. Generated a FINDING_ONLY report.

## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| 7b4bb512540299900e7fefd70769d21e52aa2662 | docs: generate FINDING_ONLY report for origin cache flush checksums | Documented architectural scope trap regarding OS page cache checksums. | Added `docs/jules/findings/070-origin-checksum.md` |

## Labels
type:resilience

## Validation
`cargo test --manifest-path crates/ramshared-block/Cargo.toml && ./scripts/docs-check.sh`

## Rollback trigger
If the underlying origin storage interface needs to be rewritten to include checksum verification at the device layer.

## Issue
#1

## Responsible
jules

---
*PR created automatically by Jules for task [10367258498032688454](https://jules.google.com/task/10367258498032688454) started by @emersonbusson*