### PR TITLE
docs: add FINDING_ONLY report for sparse vram corruption trap

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -492,6 +492,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "findings-reports",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-06T12:00:00Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/README.md
+++ b/docs/jules/findings/README.md
@@ -1,0 +1,1 @@
+# Findings

--- a/docs/jules/findings/sparse-vram-corruption-trap.md
+++ b/docs/jules/findings/sparse-vram-corruption-trap.md
@@ -1,0 +1,15 @@
+# Finding: Sparse VRAM Corruption Trap
+
+**Date:** 2026-09-06
+**Author:** ResilienceChaos100
+
+## Summary
+The request to implement "atomic page table pointer swapping on corrupted block repair" (allocating a fresh block to replace a corrupted one) in `crates/ramshared-block/src/sparse_vram.rs` has been identified as an architectural scope trap.
+
+## Rationale
+For a block device that acts as swap memory, transparently allocating and returning a fresh, zeroed block instead of failing closed upon data corruption causes silent data corruption for the guest OS. When the host OS or application attempts to read back data that was previously swapped out, returning zeroes instead of throwing an I/O error will lead to unpredictable and disastrous state corruption at the application or kernel level.
+
+The correct behavior is to fail closed (i.e. return an error on read) so that the upper layers (e.g. the Linux kernel via NBD) can handle the swap read error appropriately.
+
+## Conclusion
+No code changes will be made to `sparse_vram.rs` for this specific feature request, as it violates core data-integrity and fail-safe default principles of the architecture.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 275,
+    "classified": 272,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,30 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/README.md",
+      "disposition": "classified",
+      "ruleId": "findings-reports",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
+    },
+    {
+      "path": "docs/jules/findings/sparse-vram-corruption-trap.md",
+      "disposition": "classified",
+      "ruleId": "findings-reports",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Issue
atomic page table pointer swapping on corrupted block repair

## Responsible
ResilienceChaos100

## Summary
Implemented FINDING_ONLY report to document that atomic page table pointer swapping on corrupted block repair is an architectural scope trap, as transparent allocation on read failures causes silent data corruption in block devices.

## Commits table
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| 80e4a6950e9ec0d354a68b7dbf7bf4ab9061c8d8 | docs: add FINDING_ONLY report for sparse vram corruption trap | Rationale: Prevent silent data corruption in block device. | Added report and registered in governance. |

## Labels
type:resilience, area:core

## Validation
cargo test -p ramshared-block && ./scripts/docs-check.sh

## Rollback trigger
Revert if the finding report is incorrect.

---
*PR created automatically by Jules for task [8849119160833928324](https://jules.google.com/task/8849119160833928324) started by @emersonbusson*