### PR TITLE
docs: write finding report for residency cache flush scope trap

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -492,6 +492,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "architecture",
+      "canonicalSource": "ARCHITECTURE.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-06T12:00:00Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/081-wsl2d-freeze-signal.md
+++ b/docs/jules/findings/081-wsl2d-freeze-signal.md
@@ -1,0 +1,20 @@
+# Finding Report: WSL2d System Freeze Signal Handler
+
+**Task Title:** system freeze signal handler for synchronous write cache flush
+**Pillar:** power-lifecycle
+**Target File:** crates/ramshared-wsl2d/src/residency.rs
+
+## Analysis
+
+The task requests the implementation of a system freeze / suspend signal handler to intercept host suspend events and synchronously flush all volatile write caches to a non-volatile store in `crates/ramshared-wsl2d/src/residency.rs`.
+
+However, upon inspecting `crates/ramshared-wsl2d/src/residency.rs`, the file is exclusively dedicated to "Canary-based detection of WDDM eviction". It implements pure, stateless data-plane logic (`Canary`, `ResidencySampler`) for feeding sampling data (latency, free memory) and determining if WDDM eviction is occurring, resulting in a `Verdict::Demote`.
+
+Crucially:
+- The module states: "**Pure decision**: fed with samples... decides DEMOTE".
+- It contains no I/O, no system signal handlers, no OS-level interop for suspend/resume signals, and no cache structures to flush.
+- Adding signal handling and synchronous disk I/O logic in this pure-logic sampling module fundamentally violates the architectural separation of concerns.
+
+## Conclusion
+
+Implementing the requested suspend signal handler for cache flushing inside the `residency.rs` pure sampling logic is an architectural scope trap. This module should not manage OS power lifecycle events or perform I/O operations. Thus, I am documenting this finding without writing code.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 274,
+    "classified": 271,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,18 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/081-wsl2d-freeze-signal.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "ARCHITECTURE.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Summary
Documented an architectural scope trap regarding the request to implement a system freeze signal handler and synchronous cache flush in `crates/ramshared-wsl2d/src/residency.rs`. The file is a pure stateless decision module for WDDM eviction based on sampling, containing no OS-level interop or I/O.

## Issue
081

## Responsible
ResilienceChaos100

## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| c5a5a99c9e7ca88fb7489500fcbe9d6913be421f | Added finding report | To document the architectural scope trap | Prevents violating the pure module boundary |

## Labels
type:resilience

## Validation
`./scripts/docs-check.sh`

## Rollback trigger
Revert if the finding report misinterprets the module's pure architectural boundary.

---
*PR created automatically by Jules for task [3203238081299282383](https://jules.google.com/task/3203238081299282383) started by @emersonbusson*