### PR TITLE
feat: use constant-time comparison for block hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,9 @@ dependencies = [
 [[package]]
 name = "ramshared-integrity"
 version = "0.1.0"
+dependencies = [
+ "subtle",
+]
 
 [[package]]
 name = "ramshared-tier"
@@ -968,6 +971,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/crates/ramshared-integrity/Cargo.toml
+++ b/crates/ramshared-integrity/Cargo.toml
@@ -10,3 +10,6 @@ publish.workspace = true
 [lints.clippy]
 unwrap_used = "deny"
 expect_used = "deny"
+
+[dependencies]
+subtle = "2.6.1"

--- a/crates/ramshared-integrity/src/hash.rs
+++ b/crates/ramshared-integrity/src/hash.rs
@@ -3,6 +3,7 @@
 
 use std::error::Error;
 use std::fmt;
+use subtle::ConstantTimeEq;
 
 pub const DEFAULT_BLOCK_SIZE: usize = 4096;
 
@@ -97,7 +98,7 @@ impl ChecksumTable {
         let Some(expected) = slot else {
             return None;
         };
-        Some(*expected == block_hash(data))
+        Some(expected.ct_eq(&block_hash(data)).into())
     }
 }
 
@@ -161,5 +162,20 @@ mod tests {
 
         assert!(t.record(2, &data_65536));
         assert_eq!(t.verify(2, &data_65536), Some(true));
+    }
+
+    #[test]
+    fn table_verifies_with_constant_time_comparison() {
+        let mut t = ChecksumTable::new(2);
+        let data1 = vec![0x00u8; 4096];
+        let data2 = vec![0xffu8; 4096];
+
+        t.record(0, &data1);
+        t.record(1, &data2);
+
+        assert_eq!(t.verify(0, &data1), Some(true));
+        assert_eq!(t.verify(0, &data2), Some(false));
+        assert_eq!(t.verify(1, &data1), Some(false));
+        assert_eq!(t.verify(1, &data2), Some(true));
     }
 }


### PR DESCRIPTION
## Issue
data-integrity/078

## Responsible
ResilienceChaos100/2026-09-06/data-integrity/078

## Summary
Use constant-time comparison for checksum verification to avoid timing side-channels.

## Commits table
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| 23b9776577eb41457ab3fcb6385ab591f76e1f87 | Use constant-time comparison for block hashes | Prevent timing side-channels during hash verification. | Added `subtle` dependency and updated `ChecksumTable::verify` to use `.ct_eq`. |

## Labels
type:security, type:resilience

## Validation
`cargo test -p ramshared-integrity && cargo clippy -p ramshared-integrity -- -D warnings`

## Rollback trigger
Revert if the constant-time comparison introduces a performance regression or test failures.

---
*PR created automatically by Jules for task [8503719152528681516](https://jules.google.com/task/8503719152528681516) started by @emersonbusson*