### PR TITLE
docs: generate FINDING_ONLY report for dxgkrnl ACPI S3/S4 sleep trap

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -492,6 +492,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "reliability",
+      "canonicalSource": "docs/governance/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-06T12:00:00Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/dxg-acpi-s3-s4-trap.md
+++ b/docs/jules/findings/dxg-acpi-s3-s4-trap.md
@@ -1,0 +1,12 @@
+# FINDING_ONLY: GPU memory handle re-validation after host sleep and resume
+
+## Context
+Task: Implement GPU memory handle re-validation upon system wake from ACPI S3/S4 sleep in `crates/ramshared-dxg/src/lib.rs`.
+
+## Analysis
+This task represents an architectural scope trap. The `ramshared-dxg` crate operates as a user-space library inside WSL2, which is a Hyper-V managed virtual machine. Hyper-V does not expose host-level ACPI S3/S4 sleep/wake events to the WSL2 guest kernel. Instead, the VM state is seamlessly paused and resumed by the Windows host. Therefore, it is architecturally impossible for a user-space application within WSL2 to detect or directly handle ACPI S3/S4 power lifecycle events.
+
+Furthermore, `ramshared-dxg` merely maintains a lightweight adapter handle to query WDDM budget information via the `/dev/dxg` interface. It does not map or manage persistent GPU shared resource handles or device memory allocations that would require re-validation upon system resume.
+
+## Conclusion
+No code modifications have been made to `crates/ramshared-dxg/src/lib.rs`. Attempting to implement ACPI S3/S4 handlers in a WSL2 user-space crate is an architectural scope mismatch.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 274,
+    "classified": 271,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,18 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/dxg-acpi-s3-s4-trap.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "reliability",
+      "canonicalSource": "docs/governance/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Summary
Generated a FINDING_ONLY report to document the architectural scope trap of implementing GPU memory handle re-validation upon system wake from ACPI S3/S4 sleep in `crates/ramshared-dxg/src/lib.rs`. ACPI sleep events are handled transparently by the host hypervisor and cannot be natively intercepted by a user-space WSL2 application.

## Issue
N/A

## Responsible
jules

## Commits
| Commit | What it did | Why it did | Details |
|---|---|---|---|
| af6bf2b8a63248610b9d72723169eb4977a58b2a | docs: generate FINDING_ONLY report for dxgkrnl ACPI S3/S4 sleep trap | Document the architectural impossibility of intercepting host sleep events in WSL2 user space. | Created `docs/jules/findings/dxg-acpi-s3-s4-trap.md` |

## Labels
type:resilience

## Validation
`cargo test -p ramshared-dxg && ./scripts/docs-check.sh`

## Rollback trigger
Revert if the finding report is inaccurate.

---
*PR created automatically by Jules for task [4256697760892435172](https://jules.google.com/task/4256697760892435172) started by @emersonbusson*