### PR TITLE
feat: report architectural scope trap for ramshared-integrity

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -492,6 +492,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "architecture",
+      "canonicalSource": "ARCHITECTURE.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-06T12:00:00Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/quarantine-journal-persistence.md
+++ b/docs/jules/findings/quarantine-journal-persistence.md
@@ -1,0 +1,13 @@
+# Finding: Architectural Scope Trap - ramshared-integrity
+
+**Date**: 2026-09-06
+**Author**: Jules (ResilienceChaos100)
+
+## Observation
+The task requires implementing a "quarantine list of damaged memory sectors" and persistence across daemon restarts within `crates/ramshared-integrity/src/lib.rs`.
+
+## Architectural Constraint
+This is an architectural scope trap. The `ramshared-integrity` crate is a pure logic library responsible only for block integrity verification (such as checksumming and pattern matching). It does not handle memory allocation or stateful block device management.
+
+## Resolution
+As per the architectural specifications, no code changes will be made to `crates/ramshared-integrity/src/lib.rs`. This document serves as the required `FINDING_ONLY` report.


### PR DESCRIPTION
## Issue
N/A
## Responsible
ResilienceChaos100
## Summary
The request to implement persistent state and bad-sector allocation within `ramshared-integrity` is an architectural scope trap. The crate is purely for hashing and block integrity checking, not stateful device management. Created a `FINDING_ONLY` report instead.
## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| 7db05aef8a0d9c43c65a116e2d75e94d5e540d97 | Added `FINDING_ONLY` report | To document the architectural scope trap | N/A |
## Labels
type:resilience
## Validation
Executed `cargo test -p ramshared-integrity`.
## Rollback trigger
Revert if the finding report is incorrect

---
*PR created automatically by Jules for task [17110983737587873993](https://jules.google.com/task/17110983737587873993) started by @emersonbusson*