### PR TITLE
docs: report architectural scope trap for quarantine in isolated_origin

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -492,6 +492,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "jules-findings-reports",
+      "pattern": "docs/jules/findings/*.md",
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-07T06:49:57Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/README.md
+++ b/docs/jules/findings/README.md
@@ -1,0 +1,3 @@
+# Jules Findings
+
+This directory contains finding reports.

--- a/docs/jules/findings/concurrency_quarantine_trap.md
+++ b/docs/jules/findings/concurrency_quarantine_trap.md
@@ -1,0 +1,10 @@
+# Concurrency Test and Quarantine Repair Trap
+
+The task instructions mention implementing a "concurrency test for simultaneous readback and quarantine repair" in `crates/ramshared-block/src/isolated_origin.rs`.
+However, `isolated_origin.rs` implements an authoritative origin I/O with a bounded, revocable cache boundary. The cache is best-effort and fail-closed, and it is explicitly stated that "The origin never depends on a cache response for correctness" and "cache mutations are non-blocking and any queue, transport, protocol, or timeout fault permanently revokes that client".
+The module does not contain "quarantine repair" functionality or any data plane memory buffer/span isolation logic (which would belong to an integrity or allocation abstraction, and the prompt states `crates/ramshared-integrity` only does checksumming and `crates/ramshared-block/src/sparse_vram.rs` uses a direct-mapped page table where compaction/quarantine would cause data corruption).
+Furthermore, adding concurrency logic directly in `isolated_origin.rs` or `ramshared-block` layer which is supposed to be the foundational block I/O layer, violates the architecture where the block layer expects the transport/cache to be non-blocking and fail-closed instead of doing complex concurrent "repair" operations inline. The memory states explicitly memory/buffer abstractions shouldn't do direct driver API calls or blocking communication in hot paths.
+
+This is an architectural scope trap. The task is asking for a concurrency test and repair logic in a file that is a pure best-effort cache interface.
+
+As instructed by memory, I am producing this `FINDING_ONLY` report and will update the document lifecycle policy.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 275,
+    "classified": 272,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,30 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/README.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings-reports",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
+    },
+    {
+      "path": "docs/jules/findings/concurrency_quarantine_trap.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings-reports",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Summary
We produced a FINDING_ONLY report because adding a concurrency test for readback and quarantine repair in crates/ramshared-block/src/isolated_origin.rs violates the system's strict architectural separation, as this file only implements a fail-closed, best-effort cache for block I/O.
## Issue
Architectural scope trap
## Responsible
jules
## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| c389446a1c1a964101563510d7fa25e880c6003a | Created finding report | To document the architectural scope trap | Created `docs/jules/findings/concurrency_quarantine_trap.md` and registered in governance policy |
## Labels
type:refactor, type:resilience
## Validation
`cargo test -p ramshared-block && ./scripts/docs-check.sh`
## Rollback trigger
Revert if the finding report is incorrect.

---
*PR created automatically by Jules for task [11604390602100288950](https://jules.google.com/task/11604390602100288950) started by @emersonbusson*