### PR TITLE
docs: add FINDING_ONLY report for checksum mismatch trap

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -492,6 +492,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "architecture",
+      "canonicalSource": "ARCHITECTURE.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-06T12:00:00Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/checksum-trap.md
+++ b/docs/jules/findings/checksum-trap.md
@@ -1,0 +1,8 @@
+# FINDING_ONLY: checksum mismatch rejection in serve()
+
+## Rationale
+The task instructed to implement rejection of corrupted block packets with semantic `ChecksumMismatch` error in `crates/ramshared-block/src/request.rs`. The `serve()` function receives raw byte array payload: `pub fn serve<B: BlockBackend + ?Sized>(req: &Request, payload: &[u8], backend: &mut B) -> ServeOutcome`. However, the NBD protocol header `Request` (as defined in `protocol.rs`) does not include a hash field or checksum of the payload to verify against. A checksum could only be verified if the client had sent one, which requires a custom protocol extension, not standard NBD. Furthermore, the `ChecksumMismatch` error in `crates/ramshared-block/src/protocol.rs` is an error enum specifically for parsing the header (`parse_request()`) or during transmission, which currently returns `TruncatedPayload`, `InvalidHeader`, or `ChecksumMismatch`. But `parse_request()` only processes the header, not the data payload.
+
+Adding a checksum verification within `serve()` would require either changing the NBD header (breaking protocol) or computing the hash of the data, but what is it compared against? `ChecksumTable` from `ramshared-integrity` is for storing and verifying hashes of blocks *after* they are written and read back, not for verifying incoming packets over the wire against a checksum that doesn't exist in the packet.
+
+Implementing "ChecksumMismatch" validation on incoming write packets in `serve()` without a wire-provided checksum is impossible without breaking NBD compatibility or hallucinating expected hashes.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 274,
+    "classified": 271,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,18 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/checksum-trap.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "ARCHITECTURE.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Issue
rejection of corrupted block packets with semantic ChecksumMismatch error

## Responsible
ResilienceChaos100

## Summary
Added a FINDING_ONLY report in `docs/jules/findings/checksum-trap.md` explaining why implementing a `ChecksumMismatch` validation in `serve()` is impossible without breaking NBD compatibility, as the NBD header does not provide a checksum.

## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| 1a69e7331495432b72aa5b981ac44ddd01da6362 | Add FINDING_ONLY report and update docs governance | Architectural trap | The NBD header does not provide a checksum for `serve()` to verify against |

## Labels
type:documentation

## Validation
`cargo test -p ramshared-block && ./scripts/docs-check.sh`

## Rollback trigger
Revert if the finding report is incorrect.

---
*PR created automatically by Jules for task [16346868691448045651](https://jules.google.com/task/16346868691448045651) started by @emersonbusson*