### PR TITLE
docs(resilience): document WSL2 ACPI suspension limitations

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -492,6 +492,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "agent-findings-reports",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "architecture",
+      "canonicalSource": "ARCHITECTURE.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-06T12:00:00Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/power-lifecycle-wsl2d-main.md
+++ b/docs/jules/findings/power-lifecycle-wsl2d-main.md
@@ -1,0 +1,10 @@
+# Finding Report: WSL2 VM suspend detection and state preservation
+
+## Objective
+Detect WSL2 VM pause events and preserve volatile block device state cleanly in `crates/ramshared-wsl2d/src/main.rs`.
+
+## Analysis
+Implementing ACPI S3/S4 sleep/wake detection in `crates/ramshared-wsl2d/src/main.rs` is an architectural scope trap. This daemon operates in WSL2 user-space. Within WSL2, Hyper-V completely abstracts and hides host ACPI events (like suspend/resume) from the guest Linux kernel and user-space processes. Therefore, standard signal handling or ACPI event interception cannot be used to synchronously flush block device states before the host goes to sleep.
+
+## Conclusion
+This feature request is invalid for WSL2 user-space. The daemon cannot intercept system freeze or suspend signals, as these are inherently invisible to the guest VM. We must produce this FINDING_ONLY report to document the limitation without modifying the code.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 274,
+    "classified": 271,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,18 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/power-lifecycle-wsl2d-main.md",
+      "disposition": "classified",
+      "ruleId": "agent-findings-reports",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "ARCHITECTURE.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Summary
Documented that WSL2 user-space cannot intercept ACPI suspend/resume events as Hyper-V hides them.
## Issue
WSL2 VM suspend detection and state preservation
## Responsible
ResilienceChaos100
## Commits
| Commit | What it did | Why it did it | Details |
| 032deff62cd8b08795f51b78f5be8249e3febff4 | docs(resilience): document WSL2 ACPI suspension limitations | Hyper-V hides these events in WSL2 | Added FINDING_ONLY report. |
| ef6bbaf6a988247c547d19406f43275cb76bc14d | docs(resilience): update documentation inventory | Update inventory metadata. | Document lifecycle update. |
## Labels
type:resilience
## Validation
`cargo test -p ramshared-wsl2d && ./scripts/docs-check.sh`
## Rollback trigger
Revert if the finding report is incorrect.

---
*PR created automatically by Jules for task [15100535704600836705](https://jules.google.com/task/15100535704600836705) started by @emersonbusson*