### PR TITLE
docs: report on absence of dirty cache pages in origin_cache

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -492,6 +492,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "finding-power-lifecycle-090",
+      "pattern": "docs/jules/findings/*.md",
+      "owner": "reliability",
+      "canonicalSource": "docs/jules/findings/power-lifecycle-090.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-06T12:00:00Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/power-lifecycle-090.md
+++ b/docs/jules/findings/power-lifecycle-090.md
@@ -1,0 +1,13 @@
+# Finding: WriteThroughCacheBackend does not buffer dirty cache pages
+
+## Context
+Task: Ensure all dirty cache pages are committed to storage before system enters sleep state.
+Target File: crates/ramshared-block/src/origin_cache.rs
+
+## Evidence
+The target file `crates/ramshared-block/src/origin_cache.rs` implements `WriteThroughCacheBackend`. As the name and implementation imply, this is a write-through cache. Any write operation via `write_at` or `write_at_with_options` delegates synchronously to the origin storage first (`self.write_origin(off, data)?`), before attempting to update the cache.
+
+Because the cache is strictly write-through, there are no "dirty cache pages" residing in VRAM that are uncommitted to the origin storage. Implementing a synchronous write cache flush for power lifecycle events (ACPI S3/S4) to ensure dirty cache pages are committed is an architectural scope trap, as the cache by definition does not buffer dirty pages in user-space.
+
+## Conclusion
+No code changes can or should be made to flush dirty cache pages, as they do not exist. Therefore, this is a FINDING_ONLY report.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 274,
+    "classified": 271,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,18 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/power-lifecycle-090.md",
+      "disposition": "classified",
+      "ruleId": "finding-power-lifecycle-090",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "reliability",
+      "canonicalSource": "docs/jules/findings/power-lifecycle-090.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Summary
Report that WriteThroughCacheBackend does not buffer dirty cache pages, making a flush operation impossible.

## Issue
compulsory cache sync before sleep to eliminate data loss

## Responsible
ResilienceChaos100/2026-09-06/power-lifecycle/090

## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| 00bebf5 | docs: report on absence of dirty cache pages in origin_cache | The WriteThroughCacheBackend does not buffer dirty blocks in user-space; it synchronously delegates writes to origin storage, making the implementation of a dirty cache flush a scope trap. | N/A |
| 0b0bf0c3d0e4bd8a1bba481524d7794f38bc68b3 | docs: regenerate documentation inventory | Added a new document lifecycle policy which required re-generating the inventory. | N/A |

## Labels
type:resilience

## Validation
`cargo test -p ramshared-block && ./scripts/docs-check.sh`

## Rollback trigger
Revert if the inventory is broken.

---
*PR created automatically by Jules for task [373275901453714338](https://jules.google.com/task/373275901453714338) started by @emersonbusson*