### PR TITLE
fix(resilience): handle lease timer skew reconciliation after host sleep

### DIFF
--- a/crates/ramshared-broker/src/arbiter.rs
+++ b/crates/ramshared-broker/src/arbiter.rs
@@ -481,7 +481,10 @@ mod tests {
             slice(0, Some(1), SliceState::Active),
             slice(1, Some(2), SliceState::Active),
         ];
-        assert_eq!(count_moves(&arb.tick(t0, &t_move, &slices, None).unwrap()), 1);
+        assert_eq!(
+            count_moves(&arb.tick(t0, &t_move, &slices, None).unwrap()),
+            1
+        );
 
         // Simulate a system clock backward jump (e.g. host sleep)
         let t_past = t0 - Duration::from_secs(10);

--- a/crates/ramshared-broker/src/arbiter.rs
+++ b/crates/ramshared-broker/src/arbiter.rs
@@ -243,7 +243,7 @@ impl Arbiter {
         // (2) COUNTERFACTUAL (safety; before cooldown). There is no counterfactual of a revert.
         let mut moved = false;
         if let Some(rec) = self.last_move {
-            if now.duration_since(rec.at) > self.cfg.cf_window {
+            if now.saturating_duration_since(rec.at) > self.cfg.cf_window {
                 self.last_move = None; // window expired
             } else if let Some(from_now) = owner_psi(tenants, rec.from)
                 && from_now > self.cfg.cf_factor * rec.from_psi_at_move
@@ -468,6 +468,29 @@ mod tests {
                 to: 1
             })
         );
+    }
+
+    #[test]
+    fn clock_jump_backwards_after_sleep_does_not_panic() {
+        let mut c = cfg();
+        c.streak = 1;
+        let mut arb = Arbiter::new(c);
+        let t0 = Instant::now();
+        let t_move = [tv(1, 2.0, 1), tv(2, 20.0, 1)];
+        let slices = [
+            slice(0, Some(1), SliceState::Active),
+            slice(1, Some(2), SliceState::Active),
+        ];
+        assert_eq!(count_moves(&arb.tick(t0, &t_move, &slices, None).unwrap()), 1);
+
+        // Simulate a system clock backward jump (e.g. host sleep)
+        let t_past = t0 - Duration::from_secs(10);
+        let t_after = [tv(1, 6.0, 0), tv(2, 5.0, 2)];
+
+        let a = arb.tick(t_past, &t_after, &slices, None).unwrap();
+        // Since saturating_duration_since returns 0 which is not > cf_window, and
+        // the conditions for a revert are met, it should perform the revert without panicking.
+        assert_eq!(count_moves(&a), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Issue\nN/A\n\n## Responsible\nN/A\n\n## Summary\nResolve system clock jump panics during lease timer reconciliation after host sleep by using saturating_duration_since.\n\n## Commits\n| Commit | What it did | Why it did | Details |\n|---|---|---|---|\n| 148075afe33070a7cd56648c6dd05636d0023028 | Replace duration_since with saturating_duration_since in arbiter cf_window evaluation | Prevent clock jump panics (e.g. host sleep/resume) | Changes duration_since to saturating_duration_since in crates/ramshared-broker/src/arbiter.rs |\n\n## Labels\ntype:resilience, type:refactor\n\n## Validation\n`cargo test --manifest-path crates/ramshared-broker/Cargo.toml`\n\n## Rollback trigger\nRevert if the arbiter crashes due to clock skew or fails to migrate slices correctly during counterfactual tests.

---
*PR created automatically by Jules for task [10584151604310511224](https://jules.google.com/task/10584151604310511224) started by @emersonbusson*