### PR TITLE
docs(architecture): add finding for D3 power state query scope trap

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -492,6 +492,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-06T12:00:00Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/D3-POWER-STATE.md
+++ b/docs/jules/findings/D3-POWER-STATE.md
@@ -1,0 +1,11 @@
+# Finding: GPU D3 Power State Query
+
+The task requests implementing GPU power state query and low-power D3 state detection in `crates/ramshared-cuda/src/probe.rs` to avoid dispatching VRAM allocations while the GPU is in a low-power D3 state.
+
+Based on the architectural specifications and trap guidelines, this is an architectural scope trap. The `crates/ramshared-cuda` module strictly provides a safe wrapper over the CUDA Driver API (`libcuda`) loaded at runtime for VRAM cascade tier memory management. Querying hardware-level ACPI / D3 power states directly bypasses the high-level CUDA APIs and violates the layer abstraction for a pure CUDA driver wrapper. Such power management querying belongs to system-level daemons or Windows-specific integration crates (like `ramshared-dxg`), not the agnostic CUDA driver API abstraction.
+
+The current implementation of `crates/ramshared-cuda/src/probe.rs` is limited to bounding three-offset CUDA probe planning, entirely based on mathematical offset and pattern generation without direct hardware power-state probing.
+
+Modifying `probe.rs` to handle D3 state detection would introduce hidden statefulness and hardware-specific ACPI/WDDM polling loops into a pure memory probe planning logic module.
+
+Therefore, this request is an architectural scope trap and no code changes should be made to `probe.rs`.

--- a/docs/jules/findings/README.md
+++ b/docs/jules/findings/README.md
@@ -1,0 +1,3 @@
+# Findings
+
+This directory contains finding reports for architectural scope traps and other architectural observations.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 275,
+    "classified": 272,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,30 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/D3-POWER-STATE.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
+    },
+    {
+      "path": "docs/jules/findings/README.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "architecture",
+      "canonicalSource": "docs/jules/findings/README.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Issue
GPU power state query and low-power D3 state detection

## Responsible
ResilienceChaos100

## Resumo
Rejects the implementation of GPU D3 power state query in crates/ramshared-cuda/src/probe.rs as an architectural scope trap. The ramshared-cuda module strictly provides a safe wrapper over the CUDA Driver API. Querying hardware-level ACPI/D3 power states directly bypasses the high-level APIs and violates the layer abstraction. A finding report was created in docs/jules/findings/D3-POWER-STATE.md.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 79ac2dd2c00269f4795350726cf36d2f5c1d803a | docs(architecture): add finding for D3 power state query scope trap | The task requests implementing GPU D3 state query in the CUDA API wrapper layer. This is an architectural scope trap because it breaks abstraction. Finding report created to document the rejection. | Created finding report docs/jules/findings/D3-POWER-STATE.md |

## Labels
type:resilience

## Validacao
cargo test -p ramshared-cuda && ./scripts/docs-check.sh

## Rollback trigger
Revert if the finding report is incorrect.

---
*PR created automatically by Jules for task [1224097835418641653](https://jules.google.com/task/1224097835418641653) started by @emersonbusson*