### PR TITLE
feat: io_uring ring buffer drain and re-arming after system wake

### DIFF
--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -495,6 +495,14 @@ impl UblkServer {
         Ok(())
     }
 
+    /// Drains pending CQEs and re-arms io_uring submission queues with FETCH commands
+    /// after a host resume or recovery event.
+    pub fn drain_and_rearm_after_wake(&mut self) -> io::Result<Vec<UblkCompletion>> {
+        let completions = self.drain();
+        self.submit_initial_fetch()?;
+        Ok(completions)
+    }
+
     /// Drains available CQEs (non-blocking).
     pub fn drain(&mut self) -> Vec<UblkCompletion> {
         self.ring
@@ -833,6 +841,37 @@ mod tests {
             .push(0, 2, 0, 0)
             .expect_err("expected ring full error");
         assert_eq!(err.raw_os_error(), Some(libc::EBUSY));
+
+        drop(server);
+        drop(file);
+        fs::remove_file(path).expect("remove fixture");
+    }
+
+    #[test]
+    fn ublk_server_drain_and_rearm_after_wake_recovers_ring() {
+        let page = page_size();
+        let (path, file) = regular_file_fixture("ublk-drain-rearm", page);
+        let mut server = UblkServer::new(file.as_raw_fd(), 2, page).expect("server fixture");
+
+        // Simulate a pending completion
+        let ts = types::Timespec::new().sec(0).nsec(1_000_000); // 1ms
+        let entry = opcode::Timeout::new(&ts as *const _).build().user_data(42);
+        let timeout_entry: squeue::Entry128 = entry.into();
+
+        // SAFETY: The timespec struct outlives the kernel submission, and the server ring is local.
+        unsafe {
+            server
+                .ring
+                .submission()
+                .push(&timeout_entry)
+                .expect("push timeout");
+        }
+        server.ring.submit_and_wait(1).expect("submit timeout");
+
+        let completions = server.drain_and_rearm_after_wake().expect("drain and rearm");
+        assert_eq!(completions.len(), 1);
+        assert_eq!(completions[0].tag, 42);
+        assert_eq!(completions[0].result, -libc::ETIME);
 
         drop(server);
         drop(file);

--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -868,7 +868,9 @@ mod tests {
         }
         server.ring.submit_and_wait(1).expect("submit timeout");
 
-        let completions = server.drain_and_rearm_after_wake().expect("drain and rearm");
+        let completions = server
+            .drain_and_rearm_after_wake()
+            .expect("drain and rearm");
         assert_eq!(completions.len(), 1);
         assert_eq!(completions[0].tag, 42);
         assert_eq!(completions[0].result, -libc::ETIME);


### PR DESCRIPTION
## Issue
Resolves #091

## Responsible
@ResilienceChaos100

## Resumo
Implemented `drain_and_rearm_after_wake` for `UblkServer` to gracefully handle pending CQEs and re-arm io_uring submission queues after a host resume or recovery event.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 7b59c9ca1e1422312720a440b302af54dee4c2f6 | Added `drain_and_rearm_after_wake` to `UblkServer` and a unit test | To prevent block device I/O hanging after a host resume by clearing pending CQEs and re-issuing FETCH commands | <details><summary>Details</summary>The new function first drains existing CQEs and then submits the initial fetch commands to re-arm the ring, returning the drained completions.</details> |

## Labels
type:resilience, area:core

## Validacao
`cargo test -p ramshared-uring && cargo clippy -p ramshared-uring -- -D warnings && ./scripts/docs-check.sh` were executed successfully.

## Rollback trigger
Kernel panic or process hang due to UblkCompletion errors.

---
*PR created automatically by Jules for task [11343241866656949871](https://jules.google.com/task/11343241866656949871) started by @emersonbusson*