### PR TITLE
docs: report swap integrity scope trap

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -492,6 +492,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "docs-jules-findings-swap-wake",
+      "pattern": "docs/jules/findings/swap_wake.md",
+      "owner": "docs",
+      "canonicalSource": "docs/jules/findings/swap_wake.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-07T07:28:00Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/swap_wake.md
+++ b/docs/jules/findings/swap_wake.md
@@ -1,0 +1,11 @@
+# Architectural Scope Trap: Swap Space Integrity Verification
+
+## Finding
+The instruction to implement "swap space integrity verification after host wake" and verify the swap header "before processing new swap-in requests" in `crates/ramshared-agent/src/swap.rs` is an architectural scope trap.
+
+## Evidence
+1. **Pure Orchestration Logic**: `crates/ramshared-agent/src/swap.rs` is a stateless module that strictly wraps external shell commands (`nbd-client`, `mkswap`, `swapon`, `swapoff`). It contains no resident event loop or mechanisms to intercept ACPI S3/S4 host sleep/wake events.
+2. **Kernel Domain**: Once `swapon` is successfully executed, the Linux kernel's Memory Management (MM) subsystem takes complete ownership of processing swap-in/swap-out requests. User-space utilities like those in `swap.rs` do not process swap I/O operations.
+3. **No I/O Interception**: The file does not perform raw block device I/O, nor can it intercept swap requests before they are processed by the kernel.
+
+Therefore, this functionality cannot be implemented safely in `swap.rs` as it violates the boundary between user-space orchestration and kernel-level memory management.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 274,
+    "classified": 271,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,18 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/swap_wake.md",
+      "disposition": "classified",
+      "ruleId": "docs-jules-findings-swap-wake",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "docs",
+      "canonicalSource": "docs/jules/findings/swap_wake.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Issue
N/A
## Responsible
jules
## Resumo
Reported swap integrity scope trap because crates/ramshared-agent/src/swap.rs is a stateless orchestrator and cannot intercept kernel swap-in requests.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 1c4c8f4cb4a051aa4a49599fb9475cd8ce163406 | docs: report swap integrity scope trap | Rationale: crates/ramshared-agent/src/swap.rs is a stateless orchestrator and cannot intercept kernel swap-in requests. | |
## Labels
type:docs
## Validacao
cargo test -p ramshared-agent && cargo clippy -- -D warnings
## Rollback trigger
Revert if the finding report is incorrect.

---
*PR created automatically by Jules for task [17296167852097999270](https://jules.google.com/task/17296167852097999270) started by @emersonbusson*