### PR TITLE
feat(scripts): add guard clauses and ValidateSet to Run-GuestExhaustive.ps1

### DIFF
--- a/scripts/windows/Run-GuestExhaustive.ps1
+++ b/scripts/windows/Run-GuestExhaustive.ps1
@@ -11,6 +11,7 @@
 #>
 [CmdletBinding()]
 param(
+    [ValidateSet("win11-drill")]
     [string]$VMName = "win11-drill",
     [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
@@ -63,6 +64,19 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+# Guard clause: Ensure Hyper-V module is available
+if (-not (Get-Module -ListAvailable -Name Hyper-V)) {
+    Write-Error -Message "Hyper-V module is not available. Please install the Hyper-V module." -ErrorId "HyperVModuleMissing"
+    throw [System.Management.Automation.ItemNotFoundException]::new("Hyper-V module missing.")
+}
+
+# Guard clause: Ensure VM exists
+$vm = Get-VM -Name $VMName -ErrorAction SilentlyContinue
+if ($null -eq $vm) {
+    Write-Error -Message "Virtual machine '$VMName' does not exist." -ErrorId "VMNotFound"
+    throw [System.Management.Automation.ItemNotFoundException]::new("VM $VMName missing.")
+}
 
 . (Join-Path $PSScriptRoot "Invoke-GuestPsDirectBounded.ps1")
 


### PR DESCRIPTION
## Resumo

Added `[ValidateSet("win11-drill")]` parameter validation to `$VMName` and introduced early guard clauses for Hyper-V module availability and Virtual Machine existence in `scripts/windows/Run-GuestExhaustive.ps1`, strictly adhering to RamShared operational script hardening guidelines.

## Commits

| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| `39c6dfe94da2d2c4c8b4800b497ad0ce58516756` | Added parameter validation and VM prerequisite guard exits. | Fail-fast architecture on missing infrastructure dependencies. | <details><summary>details</summary>**Files:** scripts/windows/Run-GuestExhaustive.ps1<br>**Validation:** PSScriptAnalyzer executed.<br>**Risk/rollback:** PSScriptAnalyzer failures or valid runs rejected.</details> |

## Issue

Closes #1

## Assignee

@jules

## Labels

type:scripts, area:core

## Validation

- [x] `pwsh -c "Invoke-ScriptAnalyzer -Path scripts/windows/Run-GuestExhaustive.ps1"`

## Rollback trigger

Script fails to execute or PSScriptAnalyzer warnings block valid executions.

---
*PR created automatically by Jules for task [13318517949122272021](https://jules.google.com/task/13318517949122272021) started by @emersonbusson*