### PR TITLE
scripts: add guard clauses to Wait-Win11LabReady.ps1

### DIFF
--- a/scripts/windows/Wait-Win11LabReady.ps1
+++ b/scripts/windows/Wait-Win11LabReady.ps1
@@ -55,6 +55,16 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Error -ErrorId "MissingAdministratorPrivilege" -Message "Administrator privileges are required to manage Hyper-V."
+    throw [System.UnauthorizedAccessException]::new("Administrator privileges are required to manage Hyper-V.")
+}
+
+if (-not (Get-Module -ListAvailable -Name Hyper-V)) {
+    Write-Error -ErrorId "MissingHyperVModule" -Message "The Hyper-V PowerShell module is not available."
+    throw [System.Management.Automation.ItemNotFoundException]::new("The Hyper-V PowerShell module is not available.")
+}
+
 . (Join-Path $PSScriptRoot "Invoke-GuestPsDirectBounded.ps1")
 
 function Normalize-Win11LabReadyThumbprint {


### PR DESCRIPTION
## Summary
Added explicit guard clauses at the beginning of `scripts/windows/Wait-Win11LabReady.ps1` to verify Administrator privileges and the presence of the Hyper-V module. If either check fails, the script now cleanly aborts using `Write-Error` with specific `-ErrorId` and throws typed exceptions (`[System.UnauthorizedAccessException]` and `[System.Management.Automation.ItemNotFoundException]`). This ensures fail-fast behavior per RamShared architectural guidelines.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| f7259a1 | Add Administrator and Hyper-V module guard clauses to Wait-Win11LabReady.ps1 | To enforce fail-fast infrastructure guidelines and prevent cryptic cascading failures. | <details>Added `[Security.Principal.WindowsPrincipal]` checks and `Get-Module` validations at the top of the script, following `$ErrorActionPreference = "Stop"`.</details> |

## Issue
Fixes #008

## Assignee
@user

## Labels
type:scripts,area:infrastructure

## Validation
- `pwsh -c "Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser" && pwsh -c "Invoke-ScriptAnalyzer -Path scripts/windows/Wait-Win11LabReady.ps1"` executed successfully.

## Rollback trigger
Revert if the script incorrectly fails in testing environments where permissions are strictly managed via delegation rather than raw Administrator elevation, or if the Hyper-V module is intentionally loaded dynamically after script initialization.

---
*PR created automatically by Jules for task [13327614599100106122](https://jules.google.com/task/13327614599100106122) started by @emersonbusson*