### PR TITLE
feat: add guard clauses for WSL and disk prerequisites

### DIFF
--- a/scripts/windows/Invoke-NbdBenchmarkMatrix.ps1
+++ b/scripts/windows/Invoke-NbdBenchmarkMatrix.ps1
@@ -317,6 +317,41 @@ function Get-GpuIdentity {
     }
 }
 
+function Assert-WslAndDiskPrerequisite {
+    param(
+        [Parameter(Mandatory = $true)][string]$ArtifactRoot,
+        [Parameter(Mandatory = $true)][string]$Distro
+    )
+    $drive = Split-Path -Path $ArtifactRoot -Qualifier
+    if ([string]::IsNullOrWhiteSpace($drive)) {
+        Write-Error -Message "artifact_root_must_be_windows_drive_path" -ErrorId "InvalidDrive" -Category InvalidArgument
+        throw [System.ArgumentException]::new("artifact_root_must_be_windows_drive_path")
+    }
+    try {
+        $driveInfo = [System.IO.DriveInfo]::new($drive)
+    } catch {
+        Write-Error -Message "drive_not_found" -ErrorId "DriveNotFound" -Category ObjectNotFound
+        throw [System.Management.Automation.ItemNotFoundException]::new("drive_not_found")
+    }
+
+    if ($driveInfo.AvailableFreeSpace -lt 10737418240) {
+        Write-Error -Message "insufficient_disk_space" -ErrorId "InsufficientDiskSpace" -Category ResourceUnavailable
+        throw [System.IO.IOException]::new("insufficient_disk_space")
+    }
+
+    $wslExecutable = Join-Path $env:SystemRoot "System32\wsl.exe"
+    if (-not (Test-Path -LiteralPath $wslExecutable -PathType Leaf)) {
+        Write-Error -Message "wsl_executable_unavailable" -ErrorId "WslNotFound" -Category ObjectNotFound
+        throw [System.Management.Automation.ItemNotFoundException]::new("wsl_executable_unavailable")
+    }
+
+    $checkDistro = (Start-Process -FilePath $wslExecutable -ArgumentList "-d", $Distro, "--", "bash", "-c", "command -v fio && command -v nbd-client" -Wait -NoNewWindow -PassThru)
+    if ($checkDistro.ExitCode -ne 0) {
+        Write-Error -Message "wsl_distro_or_binaries_missing" -ErrorId "WslPrerequisitesMissing" -Category ObjectNotFound
+        throw [System.Management.Automation.ItemNotFoundException]::new("wsl_distro_or_binaries_missing")
+    }
+}
+
 function Assert-InputContract {
     if ($Distro -notmatch '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$') {
         throw "distro_name_invalid"
@@ -3906,6 +3941,7 @@ if (-not [string]::IsNullOrWhiteSpace($ManufacturedSelfTestCase)) {
 }
 
 Assert-InputContract
+Assert-WslAndDiskPrerequisite -ArtifactRoot $ArtifactRoot -Distro $Distro
 New-Item -ItemType Directory -Force -Path $ArtifactRoot | Out-Null
 $planPath = Join-Path $ArtifactRoot $PlanFileName
 if ($PlanOnly) {


### PR DESCRIPTION
## Resumo\nAdded WSL and disk guard clauses to Invoke-NbdBenchmarkMatrix.ps1.\n\n## Commits\n| Commit | O que fez | Por que fez | Detalhes |\n|---|---|---|---|\n| 156355c4427b6e00321ebc68c7de9288dbf72e09 | Base commit | N/A | N/A |\n| 8880ad5c04629ca645db2d14d60332173dc52dc6 | Added guard clauses | Prevent environment-induced failures | Validates disk, wsl.exe, fio, nbd-client |\n\n## Issue\nN/A\n\n## Responsavel\nOpsInfra100/2026-09-06/ps1-windows/003\n\n## Labels\ntype:scripts,type:reliability,type:security,area:reliability\n\n## Validacao\npwsh -c "Invoke-ScriptAnalyzer -Path scripts/windows/Invoke-NbdBenchmarkMatrix.ps1"\n\n## Rollback trigger\nIf script execution is falsely blocked due to WSL invocation delays or false negative file lookups.

---
*PR created automatically by Jules for task [9076341475526353368](https://jules.google.com/task/9076341475526353368) started by @emersonbusson*