### PR TITLE
fix: validate WSL process PID existence before attaching monitor

### DIFF
--- a/scripts/windows/Watch-RamSharedWsl.ps1
+++ b/scripts/windows/Watch-RamSharedWsl.ps1
@@ -776,6 +776,10 @@ function Invoke-GuardianWatchTerminationTail {
 }
 
 function Invoke-GuardianWatch {
+    $wslProcess = Get-Process -Name vmmemWSL -ErrorAction SilentlyContinue
+    if ($null -eq $wslProcess -or -not (Get-Process -Id $wslProcess.Id -ErrorAction SilentlyContinue)) {
+        throw [System.Management.Automation.ItemNotFoundException]::new("Target vmmemWSL process not found. Guest must be running before attaching guardian.")
+    }
     if (-not (Test-AbsoluteWindowsPath -Path $ArtifactRoot)) { throw "ArtifactRoot must be an absolute Windows path" }
     Test-SealedGuardianIdentity
     Assert-GuardianTaskXmlSeal


### PR DESCRIPTION
## Resumo\nvalidate WSL process PID existence before attaching monitor in Watch-RamSharedWsl.ps1\n\n## Commits\n| Commit | O que fez | Por que fez | Detalhes |\n| --- | --- | --- | --- |\n| 9c8a78a62342dd8265234408562a75dc6ed256cc | fix: validate WSL process PID existence before attaching monitor | Guard check that target WSL process is running using Get-Process with -ErrorAction SilentlyContinue before attaching the monitor in Invoke-GuardianWatch. | Validates process existence via ID check against physical limits to fail-fast. |\n\n## Issue\nN/A\n\n## Responsavel\nN/A\n\n## Labels\ntype:scripts,area:reliability\n\n## Validacao\n`pwsh -c \"Invoke-ScriptAnalyzer -Path scripts/windows/Watch-RamSharedWsl.ps1\"`\n\n## Rollback trigger\nIf the process check throws an unexpected ItemNotFoundException incorrectly.

---
*PR created automatically by Jules for task [274359908436106400](https://jules.google.com/task/274359908436106400) started by @emersonbusson*