### PR TITLE
refactor(scripts): implement exponential backoff retry loop

### DIFF
--- a/scripts/windows/Wait-Win11LabReady.ps1
+++ b/scripts/windows/Wait-Win11LabReady.ps1
@@ -47,9 +47,7 @@ param(
     [ValidateRange(5, 600)]
     [int]$PerAttemptTimeoutSeconds = 120,
     [ValidateRange(1, 180)]
-    [int]$PsDirectConnectTimeoutSeconds = 60,
-    [ValidateRange(1, 30)]
-    [int]$PollIntervalSeconds = 5
+    [int]$PsDirectConnectTimeoutSeconds = 60
 )
 
 Set-StrictMode -Version Latest
@@ -1233,6 +1231,7 @@ catch {
 }
 
 $attemptNumber = 0
+$currentBackoffSeconds = 2
 while (-not $hostBeforeProviderFailed -and [DateTime]::UtcNow -lt $deadlineUtc) {
     $attemptNumber++
     $attemptStartedUtc = [DateTime]::UtcNow
@@ -1325,7 +1324,8 @@ while (-not $hostBeforeProviderFailed -and [DateTime]::UtcNow -lt $deadlineUtc) 
     if ($remainingAfterAttempt -le 0) {
         break
     }
-    Start-Sleep -Seconds ([Math]::Min($PollIntervalSeconds, $remainingAfterAttempt))
+    Start-Sleep -Seconds ([Math]::Min($currentBackoffSeconds, $remainingAfterAttempt))
+    $currentBackoffSeconds = [Math]::Min($currentBackoffSeconds * 2, 300)
 }
 
 if ($null -eq $after) {


### PR DESCRIPTION
## Summary
Implement exponential backoff retry loop (2s, 4s, 8s... max 5min) instead of fixed Sleep intervals in Wait-Win11LabReady.ps1.

## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| 156355c4427b6e00321ebc68c7de9288dbf72e09 | Implement exponential backoff | Prevent continuous aggressive polling | <details><summary>details</summary>**Files:** scripts/windows/Wait-Win11LabReady.ps1<br>**Validation:** pwsh -c 'Invoke-ScriptAnalyzer -Path scripts/windows/Wait-Win11LabReady.ps1' || true<br>**Risk/rollback:** If the backoff causes premature timeouts or regressions in static tests.</details> |

## Issue
N/A

## Owner
N/A

## Labels
type:scripts, area:reliability

## Validation
- [ ] `./scripts/docs-check.sh`
- [x] `pwsh -c 'Invoke-ScriptAnalyzer -Path scripts/windows/Wait-Win11LabReady.ps1' || true`

## Rollback trigger
If the backoff causes premature timeouts or regressions in static tests.

---
*PR created automatically by Jules for task [9456023557456082227](https://jules.google.com/task/9456023557456082227) started by @emersonbusson*