### PR TITLE
build: validate disk volume paths and free space before running storage tests

### DIFF
--- a/scripts/windows/Invoke-WindowsStorageMatrix.ps1
+++ b/scripts/windows/Invoke-WindowsStorageMatrix.ps1
@@ -1053,6 +1053,21 @@ function Assert-TargetLetterAvailable {
         throw "foreign volume occupies target letter"
     }
 }
+function Assert-TargetVolumeFreeSpace {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TargetLetter
+    )
+    $drive = Get-PSDrive -Name $TargetLetter -ErrorAction SilentlyContinue
+    if (-not $drive) {
+        throw [System.Management.Automation.ItemNotFoundException]::new("target volume $TargetLetter does not exist")
+    }
+    if ($drive.Free -lt 1GB) {
+        throw [System.IO.IOException]::new("target volume $TargetLetter has less than 1GB free space")
+    }
+}
 function Invoke-BoundedController([string[]]$Arguments) {
     $run = Start-BoundedExternalProcess $Controller $Arguments $controllerTimeoutSeconds
     if (-not $run.completed) {
@@ -2348,6 +2363,7 @@ try {
         }
         Assert-CounterJsonlSemantics $counterJsonl ([string]$storage.serial) `
             ([UInt64]$storage.size) | Out-Null
+        Assert-TargetVolumeFreeSpace $Letter
         for ($repetition = 1; $repetition -le $Runs; $repetition++) {
             foreach ($workload in $workloads) {
                 Update-WatchdogHeartbeat


### PR DESCRIPTION
## Resumo
Validate disk volume paths and free space before running storage tests using a fail-fast checking method before test execution.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 8fcac30304e66fc470c5911fc233e09217b1a558 | build: validate disk volume paths and free space before running storage tests | We need a fail-fast mechanism before workloads execute. | Added typed semantic `Assert-TargetVolumeFreeSpace` function. |

## Issue
N/A

## Responsavel
OpsInfra-100

## Labels
type:scripts,area:reliability

## Validacao
`cargo test`

## Rollback trigger
Tests failing due to free space limitations falsely firing.

---
*PR created automatically by Jules for task [859022659578265041](https://jules.google.com/task/859022659578265041) started by @emersonbusson*