### PR TITLE
feat(scripts): add CancelKeyPress handler to RamSharedWsl guardian

### DIFF
--- a/scripts/windows/Watch-RamSharedWsl.ps1
+++ b/scripts/windows/Watch-RamSharedWsl.ps1
@@ -784,6 +784,16 @@ function Invoke-GuardianWatch {
     New-Item -ItemType Directory -Path $runDirectory | Out-Null
     $eventPath = Join-Path $runDirectory "guardian-events.jsonl"
     $telemetryPath = Join-Path $ArtifactRoot "windows-telemetry.jsonl"
+
+    [console]::TreatControlCAsInput = $false
+    $cancelHandler = [ConsoleCancelEventHandler]({
+        param($sender, $e)
+        $e.Cancel = $true
+        Write-GuardianEvent -Path $eventPath -Event "guardian_stopped" -Data @{ reason = "CancelKeyPress" }
+        Write-HostTelemetryRing -Path $telemetryPath
+        [Environment]::Exit(0)
+    }.GetNewClosure())
+    [Console]::add_CancelKeyPress($cancelHandler)
     Write-GuardianEvent -Path $eventPath -Event "guardian_started" -Data @{ heartbeat = $HeartbeatPath; stale_after_seconds = $StaleAfterSec }
     while ($true) {
         # A current heartbeat must be observed before any HEALTHY proof can be

--- a/scripts/windows/Watch-RamSharedWsl.ps1
+++ b/scripts/windows/Watch-RamSharedWsl.ps1
@@ -785,17 +785,23 @@ function Invoke-GuardianWatch {
     $eventPath = Join-Path $runDirectory "guardian-events.jsonl"
     $telemetryPath = Join-Path $ArtifactRoot "windows-telemetry.jsonl"
 
-    [console]::TreatControlCAsInput = $false
-    $cancelHandler = [ConsoleCancelEventHandler]({
-        param($sender, $e)
-        $e.Cancel = $true
-        Write-GuardianEvent -Path $eventPath -Event "guardian_stopped" -Data @{ reason = "CancelKeyPress" }
-        Write-HostTelemetryRing -Path $telemetryPath
-        [Environment]::Exit(0)
-    }.GetNewClosure())
-    [Console]::add_CancelKeyPress($cancelHandler)
+    try {
+        $script:GuardianStopRequested = $false
+        [console]::TreatControlCAsInput = $false
+        $cancelHandler = [ConsoleCancelEventHandler]({
+            param($sender, $e)
+            $e.Cancel = $true
+            # Workaround for runspace corruption: do not execute complex PowerShell cmdlets
+            # on the .NET ThreadPool thread. Signal the main loop to exit gracefully.
+            $script:GuardianStopRequested = $true
+        }.GetNewClosure())
+        [Console]::add_CancelKeyPress($cancelHandler)
+    } catch {
+        # Headless/CI environments may throw IOException when accessing [Console]
+    }
     Write-GuardianEvent -Path $eventPath -Event "guardian_started" -Data @{ heartbeat = $HeartbeatPath; stale_after_seconds = $StaleAfterSec }
-    while ($true) {
+    try {
+        while (-not $script:GuardianStopRequested) {
         # A current heartbeat must be observed before any HEALTHY proof can be
         # published. Never let a boot probe race ahead of stale-heartbeat
         # detection and advertise health during a watchdog incident.
@@ -840,6 +846,13 @@ function Invoke-GuardianWatch {
         if ($tail.action -eq "ERROR") { Write-Error "guardian preserved evidence after terminate failure: $eventPath"; return 2 }
         Start-Sleep -Seconds $PollSec
         continue
+    }
+    } finally {
+        Write-GuardianEvent -Path $eventPath -Event "guardian_stopped" -Data @{ reason = "CancelKeyPress" }
+        Write-HostTelemetryRing -Path $telemetryPath
+        try {
+            [Console]::remove_CancelKeyPress($cancelHandler)
+        } catch { }
     }
 }
 


### PR DESCRIPTION
## Resumo\nAdiciona handler para `CancelKeyPress` (`Ctrl+C`) em `scripts/windows/Watch-RamSharedWsl.ps1` (Invoke-GuardianWatch), garantindo que o buffer de telemetria seja persistido e um evento de `guardian_stopped` seja emitido antes do processo encerrar de forma gracefully. Utiliza `.GetNewClosure()` para garantir que o escopo lexical capture `$eventPath` e `$telemetryPath` no momento de criacao do event handler.\n\n## Commits\n| Commit | O que fez | Por que fez | Detalhes |\n|---|---|---|---|\n| `74ef8b301fd682ec57167e672258de564dd08ac2` | Adicionou CancelKeyPress handler ao Invoke-GuardianWatch | Para fechar handlers e buffers de telemetria em Ctrl+C graciosamente | <details><summary>detalhes</summary>**Arquivos:** scripts/windows/Watch-RamSharedWsl.ps1<br>**Validacao:** PSScriptAnalyzer / manual review<br>**Risco/rollback:** Falha ao iniciar devido a erro no event handler. Rollback se houver travamento no shutdown.</details> |\n\n## Issue\nCloses #N/A\n\n## Responsavel\n@jules\n\n## Labels\ntype:scripts area:core\n\n## Validacao\n- [x] Gates de build/test do escopo tocado\n- [ ] `./scripts/docs-check.sh` (se tocou docs/specs ou gerou PRD/SPEC/IMPL)\n- [ ] SSDV3: SPEC/IMPL atualizados e citados (ou N/A — mudança não estrutural / só scripts)\n\n## Rollback trigger\nSe houver vazamento de memória com o script falhando ou fechamento abrupto que acione corrupção dos buffers de telemetria, será revertido.

---
*PR created automatically by Jules for task [7280471157402878623](https://jules.google.com/task/7280471157402878623) started by @emersonbusson*