### PR TITLE
feat(scripts): return structured error output with IOCTL code and expected response size

### DIFF
--- a/scripts/windows/Invoke-WinDriveIoctlValidation.ps1
+++ b/scripts/windows/Invoke-WinDriveIoctlValidation.ps1
@@ -124,6 +124,23 @@ public static class IoctlVal {
     return ok;
   }
 
+  public static object IoctlEx(SafeFileHandle h, uint code, byte[] input, int outputSize) {
+    uint ret;
+    byte[] ob = outputSize > 0 ? new byte[outputSize] : null;
+    bool ok = DeviceIoControl(h, code, input, input == null ? 0u : (uint)input.Length, ob, outputSize == 0 ? 0u : (uint)outputSize, out ret, IntPtr.Zero);
+    int err = ok ? 0 : Marshal.GetLastWin32Error();
+    string msg = err == 0 ? "" : new System.ComponentModel.Win32Exception(err).Message;
+    var res = new System.Collections.Hashtable();
+    res["IoctlCode"] = code;
+    res["ExpectedSize"] = outputSize;
+    res["ActualSize"] = ret;
+    res["ErrorMessage"] = msg;
+    res["IsSuccess"] = ok;
+    res["ErrorCode"] = err;
+    res["Output"] = ob;
+    return res;
+  }
+
   /* Sync COMMIT for same-process concurrent teardown probe (returns Win32 err; 0=ok). */
   public static int BlockingIoctl(SafeFileHandle h, uint code) {
     uint ret;
@@ -343,6 +360,52 @@ public static class IoctlVal {
 '@
 
 Add-Type -TypeDefinition $cs -ErrorAction Stop
+
+function Invoke-RamSharedIoctl {
+    <#
+    .SYNOPSIS
+      Executes a WinDrive IOCTL and returns a structured PSCustomObject.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [Microsoft.Win32.SafeHandles.SafeFileHandle]$Handle,
+
+        [Parameter(Mandatory=$true)]
+        [uint32]$IoctlCode,
+
+        [byte[]]$InputBuffer,
+
+        [int]$ExpectedOutputSize = 0
+    )
+
+    if ($Handle -eq $null -or $Handle.IsInvalid) {
+        Write-Error "Invalid handle." -ErrorId "InvalidHandle" -ErrorAction Continue
+        throw [System.ArgumentException]::new("Handle is invalid or null.")
+    }
+
+    $res = [IoctlVal]::IoctlEx($Handle, $IoctlCode, $InputBuffer, $ExpectedOutputSize)
+
+    $obj = [PSCustomObject]@{
+        IoctlCode    = $res["IoctlCode"]
+        ExpectedSize = $res["ExpectedSize"]
+        ActualSize   = $res["ActualSize"]
+        ErrorMessage = $res["ErrorMessage"]
+    }
+
+    if (-not $res["IsSuccess"]) {
+        $errRecord = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("IOCTL failed: $($res["ErrorMessage"])"),
+            "IoctlFailed",
+            [System.Management.Automation.ErrorCategory]::InvalidOperation,
+            $obj
+        )
+        Write-Error $errRecord -ErrorAction Continue
+        throw [System.Management.Automation.RuntimeException]::new("IOCTL failed with code $($res["ErrorCode"])")
+    }
+
+    return $obj
+}
 
 function Open-Ctl {
     # FILE_SHARE_READ|WRITE: concurrent probes need a second handle while COMMIT is pended.


### PR DESCRIPTION
## Resumo
Improve diagnostics for WinDrive IOCTLs by adding `IoctlEx` in the embedded C# `IoctlVal` class and `Invoke-RamSharedIoctl` PowerShell function. These modifications return a structured `PSCustomObject` with properties `IoctlCode`, `ExpectedSize`, `ActualSize`, and `ErrorMessage` to enhance error tracking and diagnostic visibility on failure. Error action preference strictness is maintained while allowing for output inspection.

## Commits table
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| `ca69e34268a455f6b6258af1cac95a7b0c3328c7` | Add structured error output with IOCTL code and expected response size | To improve WinDrive diagnostics and meet operational spec | Added `IoctlEx` method and `Invoke-RamSharedIoctl` function to parse and surface errors clearly |

## Issue
N/A

## Responsavel
@emersonbusson

## Labels
type:scripts, area:reliability

## Validacao
`pwsh -c "Invoke-ScriptAnalyzer -Path scripts/windows/Invoke-WinDriveIoctlValidation.ps1"`

## Rollback trigger
If the script fails in CI or throws unexpected exceptions in validation paths.

---
*PR created automatically by Jules for task [6468809854795059002](https://jules.google.com/task/6468809854795059002) started by @emersonbusson*