### PR TITLE
feat: validate prerequisites before ISO download

### DIFF
--- a/scripts/windows/New-LinuxKernelLabVm.ps1
+++ b/scripts/windows/New-LinuxKernelLabVm.ps1
@@ -13,6 +13,11 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$mediaContractPath = Join-Path $PSScriptRoot "Win11LabMediaContract.ps1"
+if (-not (Test-Path -LiteralPath $mediaContractPath -PathType Leaf)) {
+    throw "Win11 lab media contract helper is missing"
+}
+. $mediaContractPath
 
 function Write-Step {
     param([string]$Message)
@@ -50,6 +55,8 @@ if ((Test-Path $IsoPath) -and ((Get-Item $IsoPath).Length -gt 1GB)) {
 }
 
 if ($needDownload) {
+    Assert-Win11LabMediaDownloadPrerequisite -DownloadDirectory (Split-Path -Parent $IsoPath) -TestUrl $IsoUrl
+
     Write-Step ("Downloading Ubuntu 24.04.2 live-server to " + $IsoPath)
     if (Test-Path $IsoPath) {
         Remove-Item $IsoPath -Force

--- a/scripts/windows/Prepare-DualBootRussia.ps1
+++ b/scripts/windows/Prepare-DualBootRussia.ps1
@@ -32,6 +32,11 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$mediaContractPath = Join-Path $PSScriptRoot "Win11LabMediaContract.ps1"
+if (-not (Test-Path -LiteralPath $mediaContractPath -PathType Leaf)) {
+    throw "Win11 lab media contract helper is missing"
+}
+. $mediaContractPath
 function Write-Step($m) { Write-Host "==> $m" -ForegroundColor Cyan }
 
 if (-not (Test-Path "R:\")) { throw "R: missing" }
@@ -60,6 +65,8 @@ $IsoUrl = "https://releases.ubuntu.com/24.04.2/ubuntu-24.04.2-live-server-amd64.
 New-Item -ItemType Directory -Force -Path (Split-Path $RunbookPath), $IsoDir | Out-Null
 
 if ($DownloadIso) {
+    Assert-Win11LabMediaDownloadPrerequisite -DownloadDirectory (Split-Path -Parent $IsoPath) -TestUrl $IsoUrl
+
     if (Test-Path $IsoPath -PathType Leaf) {
         Write-Step "ISO exists: $IsoPath"
     } else {

--- a/scripts/windows/Win11LabMediaContract.ps1
+++ b/scripts/windows/Win11LabMediaContract.ps1
@@ -1011,6 +1011,56 @@ function Assert-Win11LabWorkerIsoNotAttached {
     }
 }
 
+function Assert-Win11LabMediaDownloadPrerequisite {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$DownloadDirectory,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TestUrl
+    )
+
+    if (-not (Test-Path -LiteralPath $DownloadDirectory -PathType Container)) {
+        Write-Error -Message "Download directory missing: $DownloadDirectory" -ErrorId "win11_lab_media_contract_download_directory_missing"
+        throw [System.IO.DirectoryNotFoundException]::new("win11_lab_media_contract_download_directory_missing")
+    }
+
+    try {
+        $fullPath = [System.IO.Path]::GetFullPath($DownloadDirectory)
+        $drivePath = [System.IO.Path]::GetPathRoot($fullPath)
+        $driveInfo = [System.IO.DriveInfo]::new($drivePath)
+        $freeSpace = $driveInfo.AvailableFreeSpace
+
+        if ($freeSpace -lt 16106127360) {
+            Write-Error -Message "Insufficient disk space. Minimum 15 GB required." -ErrorId "win11_lab_media_contract_insufficient_disk_space"
+            throw [System.IO.IOException]::new("win11_lab_media_contract_insufficient_disk_space")
+        }
+    } catch [System.IO.DirectoryNotFoundException] {
+        throw
+    } catch [System.IO.IOException] {
+        throw
+    } catch {
+        Write-Error -Message "Failed to check disk space." -ErrorId "win11_lab_media_contract_disk_space_check_failed"
+        throw [System.InvalidOperationException]::new("win11_lab_media_contract_disk_space_check_failed", $_.Exception)
+    }
+
+    if (-not $TestUrl.StartsWith("https://", [System.StringComparison]::OrdinalIgnoreCase)) {
+        Write-Error -Message "HTTPS connectivity is required." -ErrorId "win11_lab_media_contract_insecure_url"
+        throw [System.ArgumentException]::new("win11_lab_media_contract_insecure_url")
+    }
+
+    try {
+        $response = Invoke-WebRequest -Uri $TestUrl -UseBasicParsing -Method Head -TimeoutSec 10 -ErrorAction Stop
+        $response | Out-Null
+    } catch {
+        Write-Error -Message "Network connectivity failed." -ErrorId "win11_lab_media_contract_network_connectivity_failed"
+        throw [System.Net.WebException]::new("win11_lab_media_contract_network_connectivity_failed", $_.Exception)
+    }
+}
+
 function Invoke-Win11LabMediaWorkerMode {
     [CmdletBinding()]
     param(


### PR DESCRIPTION
## Summary
Implemented guard clauses for disk space and network connectivity before ISO download in Win11LabMediaContract.ps1. Updated scripts to call this prerequisite check before downloading ISOs.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| b3ec320 | Implemented guard clauses | Validate 15 GB free space and HTTPS connectivity | Added Assert-Win11LabMediaDownloadPrerequisite function and integrated it in New-LinuxKernelLabVm.ps1 and Prepare-DualBootRussia.ps1 |

## Issue
N/A

## Owner
N/A

## Labels
type:scripts, type:security, area:packaging

## Validation
pwsh -c 'Invoke-ScriptAnalyzer -Path scripts/windows/Win11LabMediaContract.ps1'

## Rollback trigger
If the prerequisite check blocks legitimate downloads due to incorrect space calculation or false-positive network failures.

---
*PR created automatically by Jules for task [14443240617635574663](https://jules.google.com/task/14443240617635574663) started by @emersonbusson*