### PR TITLE
feat: guard clauses for service state transitions

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,16 @@
+## Resumo
+Added a guard clause to `scripts/windows/Manage-RamSharedOrigin.ps1` to ensure the `RamSharedWinSvc` service is strictly stopped before proceeding with `install` or `uninstall` transactions. This aligns with fail-fast principles, preventing file locks and consistency errors.
+## Commits
+| Commit | O que fez | Por que fez | Detalhes |
+| 156355c4427b6e00321ebc68c7de9288dbf72e09 | Base | Base SHA | <details>N/A</details> |
+| e5dc98fc75f7f74640707c81720a0f4c13ff75b4 | feat: guard clauses for service state transitions | Fail fast on invalid service state | <details>Added Get-Service validation prior to switch block.</details> |
+## Issue
+N/A
+## Responsavel
+@user
+## Labels
+type:scripts,area:infrastructure
+## Validacao
+pwsh -c "Invoke-ScriptAnalyzer -Path scripts/windows/Manage-RamSharedOrigin.ps1"
+## Rollback trigger
+If the guard clause improperly blocks valid uninstallation when the service is absent or legitimately stopped, revert the commit.

--- a/scripts/windows/Manage-RamSharedOrigin.ps1
+++ b/scripts/windows/Manage-RamSharedOrigin.ps1
@@ -399,6 +399,14 @@ if (($LogicalCapacityMiB % 1024) -ne 0) { throw "logical capacity must be whole 
 if (($PhysicalCacheCapMiB % 1024) -ne 0 -or $PhysicalCacheCapMiB -gt $LogicalCapacityMiB) { throw "physical cache cap must be whole GiB and no larger than logical capacity" }
 if ($Action -eq "install" -and $PARTUUID -cne "00000000-0000-0000-0000-000000000000") { throw "Windows assigns the GPT PARTUUID; seal the generated value from the mounted origin VHDX" }
 
+if ($Action -eq "install" -or $Action -eq "uninstall") {
+    $svc = Get-Service -Name "RamSharedWinSvc" -ErrorAction SilentlyContinue
+    if ($null -ne $svc -and $svc.Status -ne 'Stopped') {
+        Write-Error "Service RamSharedWinSvc is in state $($svc.Status); it must be stopped before origin $Action." -ErrorAction Continue -ErrorId "ServiceNotStopped"
+        throw [System.InvalidOperationException]::new("Service RamSharedWinSvc is in state $($svc.Status); it must be stopped before origin $Action.")
+    }
+}
+
 switch ($Action) {
     "install" {
         $transaction = New-OriginInstallTransaction


### PR DESCRIPTION
## Resumo
Added a guard clause to `scripts/windows/Manage-RamSharedOrigin.ps1` to ensure the `RamSharedWinSvc` service is strictly stopped before proceeding with `install` or `uninstall` transactions. This aligns with fail-fast principles, preventing file locks and consistency errors.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
| 156355c4427b6e00321ebc68c7de9288dbf72e09 | Base | Base SHA | <details>N/A</details> |
| 3057143e88f102ae30099c27d37a3822f8b95511 | feat: guard clauses for service state transitions | Fail fast on invalid service state | <details>Added Get-Service validation prior to switch block.</details> |
## Issue
N/A
## Responsavel
@user
## Labels
type:scripts,area:infrastructure
## Validacao
pwsh -c "Invoke-ScriptAnalyzer -Path scripts/windows/Manage-RamSharedOrigin.ps1"
## Rollback trigger
If the guard clause improperly blocks valid uninstallation when the service is absent or legitimately stopped, revert the commit.

---
*PR created automatically by Jules for task [16425779359831577645](https://jules.google.com/task/16425779359831577645) started by @emersonbusson*