### PR TITLE
feat: validate disk performance counter availability

### DIFF
--- a/scripts/windows/Measure-RamSharedDiskIo.ps1
+++ b/scripts/windows/Measure-RamSharedDiskIo.ps1
@@ -34,6 +34,14 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+
+try {
+    $null = Get-CimInstance -ClassName Win32_PerfFormattedData_PerfDisk_PhysicalDisk -MaxCount 1 -ErrorAction Stop
+    $null = Get-CimInstance -ClassName Win32_PerfFormattedData_PerfDisk_LogicalDisk -MaxCount 1 -ErrorAction Stop
+} catch {
+    throw [System.Management.Automation.ItemNotFoundException]::new("Performance counters PhysicalDisk or LogicalDisk unavailable: $($_.Exception.Message)")
+}
+
 function L($m) { Write-Host ("[{0}] {1}" -f (Get-Date -Format "HH:mm:ss"), $m) }
 
 function Get-Sha256Hex {


### PR DESCRIPTION
## Resumo
Add guard clauses to validate disk performance counter availability before measurement.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
| d2d5cbc | Add guard checks for PhysicalDisk and LogicalDisk | Fail fast if WMI/CIM performance counters are missing or empty | Enforce reliability by throwing ItemNotFoundException |
## Issue
Issue: N/A
## Responsavel
Responsavel: Jules
## Labels
Labels: type:scripts,area:reliability
## Validacao
Validation: pwsh -c "Invoke-ScriptAnalyzer -Path scripts/windows/Measure-RamSharedDiskIo.ps1" || true
## Rollback trigger
Rollback trigger: Revert if the performance counter guard fails spuriously on healthy systems.

---
*PR created automatically by Jules for task [17256075504065452337](https://jules.google.com/task/17256075504065452337) started by @emersonbusson*