### PR TITLE
feat: validate pagefile size with Get-PSDrive

### DIFF
--- a/scripts/windows/Set-WinPagingFilesConcrete.ps1
+++ b/scripts/windows/Set-WinPagingFilesConcrete.ps1
@@ -39,9 +39,18 @@ function Assert-ValidPagefileSize {
         throw [System.ArgumentOutOfRangeException]::new("RequestedSizeBytes", "Requested pagefile size must be between 1x and 3x physical RAM.")
     }
 
-    $driveRoot = [System.IO.Path]::GetPathRoot($VolumePath)
-    $freeSpace = [System.IO.DriveInfo]::new($driveRoot).AvailableFreeSpace
+    if ($VolumePath -match "^([A-Za-z]):") {
+        $driveLetter = $Matches[1]
+    } else {
+        throw [System.ArgumentException]::new("Invalid volume path format.")
+    }
 
+    $drive = Get-PSDrive -Name $driveLetter -ErrorAction SilentlyContinue
+    if (-not $drive) {
+        throw [System.Management.Automation.ItemNotFoundException]::new("Target volume not found.")
+    }
+
+    $freeSpace = [long]$drive.Free
     if ($SizeBytes -gt $freeSpace) {
         throw [System.IO.IOException]::new("Requested pagefile size exceeds available free space on target volume.")
     }


### PR DESCRIPTION
## Resumo
Replaced DriveInfo with Get-PSDrive to safely validate target volume existence and available free space, throwing semantic typed exceptions.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 49c8afc329f68c042ee946fb0a97f36cdb9b0fc7 | feat: validate pagefile size with Get-PSDrive | Use Get-PSDrive to safely catch missing drives and check available free space, throwing typed exceptions instead of using DriveInfo which does not catch missing drives gracefully. | Replaced DriveInfo usage. |

## Issue
Issue: N/A

## Responsavel
Responsavel: N/A

## Labels
Labels: type:scripts,area:core

## Validacao
pwsh -Command "Invoke-ScriptAnalyzer -Path scripts/windows/Set-WinPagingFilesConcrete.ps1"

## Rollback trigger
If the script fails with Get-PSDrive errors on existing drives or incorrectly calculates free space.

---
*PR created automatically by Jules for task [1896331069540972408](https://jules.google.com/task/1896331069540972408) started by @emersonbusson*