### PR TITLE
feat: validate crash dump and WinDbg prerequisites

### DIFF
--- a/scripts/windows/Recover-GuestVerifierExactRun.ps1
+++ b/scripts/windows/Recover-GuestVerifierExactRun.ps1
@@ -34,6 +34,17 @@ foreach ($path in @($SourcePath, $HelperPath, $PasswordFile)) {
         throw "required recovery input file is missing"
     }
 }
+
+if (-not (Test-Path -LiteralPath "C:\Windows\Minidump" -PathType Container)) {
+    Write-Error -Message "Crash dump directory not found at C:\Windows\Minidump" -ErrorId "MinidumpDirNotFound" -ErrorAction Continue
+    throw [System.IO.DirectoryNotFoundException]::new("Crash dump directory not found at C:\Windows\Minidump")
+}
+
+$windbgPath = "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\windbg.exe"
+if (-not (Test-Path -LiteralPath $windbgPath -PathType Leaf)) {
+    Write-Error -Message "WinDbg not found at $windbgPath" -ErrorId "WinDbgNotFound" -ErrorAction Continue
+    throw [System.IO.FileNotFoundException]::new("WinDbg not found at $windbgPath")
+}
 . $HelperPath
 
 $source = Get-Content -LiteralPath $SourcePath -Raw -ErrorAction Stop


### PR DESCRIPTION
## Summary
Validates crash dump directory and WinDbg exist on the host before attempting exact run recovery.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 1ab0a86e3335d3e9de8d2832604df8644e64a9dc | feat: validate crash dump and WinDbg prerequisites | Validates crash dump directory and WinDbg exist on the host before attempting exact run recovery. | Added guard clauses with System.IO exceptions |

## Issue
Issue: N/A

## Owner
Owner: Jules

## Labels
Labels: type:scripts,area:reliability

## Validation
Validation: pwsh -c 'Invoke-ScriptAnalyzer -Path scripts/windows/Recover-GuestVerifierExactRun.ps1'

## Rollback trigger
If the new checks incorrectly block exact recovery when dumps and WinDbg are present.

---
*PR created automatically by Jules for task [16536697157117429067](https://jules.google.com/task/16536697157117429067) started by @emersonbusson*