### PR TITLE
feat: guard clauses for fio, nbd, and cgroup

### DIFF
--- a/scripts/safety/nbd-benchmark-cell.sh
+++ b/scripts/safety/nbd-benchmark-cell.sh
@@ -178,6 +178,20 @@ if [[ $ACTION == aggregate || $ACTION == run ]]; then
   [[ $CONDITION == idle || $CONDITION == bounded ]] || refuse CONDITION_INVALID
   [[ $TIER_MIB =~ ^(1024|2048|4096)$ ]] || refuse TIER_SIZE_INVALID
   [[ $RUNS == 3 ]] || refuse RUN_COUNT_INVALID
+
+  if [[ $ACTION == run ]]; then
+    command -v fio >/dev/null || refuse FIO_MISSING
+    shopt -s nullglob
+    nbd_devs=("/dev/nbd"*)
+    shopt -u nullglob
+    (( ${#nbd_devs[@]} > 0 )) || refuse NBD_DEVICE_MISSING
+    if [[ -d $CG_ROOT && -f $CG_ROOT/cgroup.controllers ]] && grep -qw memory "$CG_ROOT/cgroup.controllers"; then
+      :
+    else
+      refuse CGROUP_MEMORY_CONTROLLER_MISSING
+    fi
+  fi
+
   configure_timeout_budget
   ALLOCATE_MIB=$((TIER_MIB + 2560))
   MEMORY_MAX_MIB=$((ALLOCATE_MIB + 512))


### PR DESCRIPTION
## Resumo
Added guard clauses in `scripts/safety/nbd-benchmark-cell.sh` to validate `fio` installation, `/dev/nbd*` device existence, and `cgroup v2` memory controller availability before starting the benchmark. This follows the fail-fast principle and prevents obscure downstream failures.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| cb512a5f4916e9ff8cf6fb9f5d9e125aa5ef490b | Added guard clauses for fio, nbd, and cgroup | To validate dependencies and fail fast | Added checks in `scripts/safety/nbd-benchmark-cell.sh` before `configure_timeout_budget` |

## Issue
N/A

## Responsavel
OpsInfra-100

## Labels
type:scripts,area:reliability

## Validacao
`shellcheck scripts/safety/nbd-benchmark-cell.sh || true`

## Rollback trigger
Revert if legitimate benchmark execution is blocked by these checks on supported infrastructure.

---
*PR created automatically by Jules for task [8721812567551194910](https://jules.google.com/task/8721812567551194910) started by @emersonbusson*