### PR TITLE
feat: idempotent cascade activation

### DIFF
--- a/scripts/safety/cascade-up.sh
+++ b/scripts/safety/cascade-up.sh
@@ -67,6 +67,11 @@ if [[ -n $VRAM_OVERRIDE ]]; then
   EXPECTED_APPROVAL="activate:$RELEASE_VERSION:vram=$VRAM_MIB:zram=$ZRAM_MIB"
 fi
 [[ ${RAMSHARED_NBD_LIFECYCLE_APPROVAL:-} == "$EXPECTED_APPROVAL" ]] || refuse APPROVAL_MISSING
+
+if command -v systemctl >/dev/null 2>&1 && systemctl is-active --quiet ramshared-cascade.service 2>/dev/null; then
+  refuse ALREADY_ACTIVE
+fi
+
 RAMSHARED_NBD_VRAM_MIB=$VRAM_MIB "$PREFLIGHT" --check
 
 printf 'NBD_LIFECYCLE_STATE=EXECUTING\n'


### PR DESCRIPTION
## Summary\nCheck if cascade is already active before attempting re-activation to prevent double-mount.\n\n## Commits\n| Commit | What was done | Why it was done | Details |\n|---|---|---|---|\n| a0a0283acb64f34581968642ed64b71ab2d5f76d | feat: idempotent cascade activation | check if cascade is already active before attempting re-activation to prevent double-mount | Checked if `ramshared-cascade.service` is already active and refused if it is |\n\n## Issue\nN/A, no issue linked.\n\n## Owner\nOpsInfra-100\n\n## Labels\ntype:scripts,area:core\n\n## Validation\nshellcheck scripts/safety/cascade-up.sh\n\n## Rollback trigger\nactivation fails on inactive cascade

---
*PR created automatically by Jules for task [6867691880407698929](https://jules.google.com/task/6867691880407698929) started by @emersonbusson*