### PR TITLE
feat: add zram and swap guard clauses to cascade-controller

### DIFF
--- a/scripts/safety/cascade-controller.sh
+++ b/scripts/safety/cascade-controller.sh
@@ -15,7 +15,7 @@ managed_device=
 refuse() {
   printf 'NBD_CONTROLLER_STATE=REFUSED\n'
   printf 'NBD_CONTROLLER_REASON=%s\n' "$1"
-  exit 1
+  exit "${2:-1}"
 }
 
 [[ $distro =~ ^[A-Za-z0-9._-]+$ ]] || refuse DISTRO_INVALID
@@ -163,6 +163,10 @@ if [[ $mode == recover ]]; then
   managed_device=$(read_marker_value managed_device)
   finish_stop
 fi
+
+command -v modprobe >/dev/null 2>&1 || refuse KMOD_MISSING 69
+modprobe -n zram >/dev/null 2>&1 || ls -d /sys/block/zram* >/dev/null 2>&1 || refuse ZRAM_UNAVAILABLE 69
+[[ -r /proc/swaps ]] || refuse SWAP_UNAVAILABLE 69
 
 # A controller crash or restart may leave a live origin behind. Never start a
 # second lifecycle over that evidence: finish the old teardown first and leave


### PR DESCRIPTION
## Summary
Implemented guard clauses in cascade-controller.sh to check modprobe, zram, and swap availability before executing operations to fail early per infrastructure hardening principles.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 3510cdcd7a23810753645e3da957e760144bbc52 | feat: add zram and swap guard clauses to cascade-controller | Validates physical hardware limits early | <details><summary>Context</summary>Modprobe, zram, and swap existence are validated with explicit error codes</details> |

## Issue
Closes #N/A

## Owner
@jules

## Labels
type:scripts,area:core

## Validation
- `shellcheck scripts/safety/cascade-controller.sh`

## Rollback trigger
If the script fails to activate swap due to bugs in guard clauses.

---
*PR created automatically by Jules for task [2415646601999922195](https://jules.google.com/task/2415646601999922195) started by @emersonbusson*