### PR TITLE
feat: validate swap paths before detach

### DIFF
--- a/scripts/safety/swap-sanitize.sh
+++ b/scripts/safety/swap-sanitize.sh
@@ -109,12 +109,21 @@ PY
   rm -f -- "$owned_devices_file"
   ((${#owned_devices[@]} > 0)) || { echo 'swapoff_refused_no_owned_devices' >&2; exit 2; }
 
+  if [[ ! -f "$proc_swaps" ]]; then
+    echo "swapoff_refused_proc_swaps_missing" >&2
+    exit 74 # EX_IOERR
+  fi
+
   swap_names=$(awk 'NR > 1 { print $1 }' "$proc_swaps")
   swapped=0
   for device in "${owned_devices[@]}"; do
     if ! grep -Fqx -- "$device" <<<"$swap_names"; then
       echo "swapoff_skipped_not_live=$device"
       continue
+    fi
+    if [[ ! -e "$device" ]]; then
+      echo "swapoff_refused_device_not_found=$device" >&2
+      exit 74 # EX_IOERR
     fi
     echo "swapoff $device"
     if ! swapoff "$device"; then


### PR DESCRIPTION
## Summary
Cross-reference and validate swap devices via physical path existence checks against `/proc/swaps` prior to executing `swapoff`.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 0b82d117f2a6e74d3930ceac38558e20b634d92e | Added path sanity tests before detach | Prevent unsafe swapoff on missing elements | Used EX_IOERR (74) and explicitly checked `$proc_swaps` and `$device` paths. |

## Issue
Issue: N/A

## Owner
Owner: Jules

## Labels
Labels: type:scripts,area:core,type:security

## Validation
`shellcheck scripts/safety/swap-sanitize.sh`

## Rollback trigger
Rollback trigger: Device unregistration causes invalid system state

---
*PR created automatically by Jules for task [10470028960256895699](https://jules.google.com/task/10470028960256895699) started by @emersonbusson*