### PR TITLE
fix: use sysexits.h exit code 69 (EX_UNAVAILABLE) for missing PSI in measure-psi.sh

### DIFF
--- a/scripts/p0/measure-psi.sh
+++ b/scripts/p0/measure-psi.sh
@@ -15,7 +15,7 @@ log() { echo "$LOG_PREFIX $*" >&2; }
 # Preflight: without CONFIG_PSI the file does not exist — the broker depends on PSI (DT-15).
 [ -r "$PSI" ] || {
 	log "ERROR: $PSI is unreadable. Kernel without CONFIG_PSI/PSI_DEFAULT_DISABLED? PSI is required."
-	exit 1
+	exit 69
 }
 
 log "sampling $PSI for ${DURATION}s -> $OUT"


### PR DESCRIPTION
## Summary\nUpdate exit code for missing PSI support in measure-psi.sh to 69 (EX_UNAVAILABLE).\n\n## Commits\n| Commit | What was done | Why it was done | Details |\n|---|---|---|---|\n| 2ce1da0dd4c67b84c2187d2e7abe6deea9039e46 | Changed exit 1 to exit 69 | To conform to sysexits.h semantic exit codes as mandated by hardening principles | Modified scripts/p0/measure-psi.sh |\n\n## Issue\nN/A\n\n## Owner\njules\n\n## Labels\ntype:scripts\narea:infrastructure\n\n## Validation\n`shellcheck scripts/p0/measure-psi.sh`\n\n## Rollback trigger\nIf the script fails to execute in expected environments due to the exit code change.

---
*PR created automatically by Jules for task [13973237790760340857](https://jules.google.com/task/13973237790760340857) started by @emersonbusson*