### PR TITLE
chore(scripts): add guard clauses for ublk kernel module

### DIFF
--- a/scripts/kernel/qemu-ublk-daemon.sh
+++ b/scripts/kernel/qemu-ublk-daemon.sh
@@ -58,8 +58,19 @@ if $BB insmod /modules/ublk_drv.ko 2>/tmp/e; then
   echo "KTEST-INSMOD=ok"
 else
   echo "KTEST-INSMOD=fail: $($BB cat /tmp/e)"
+  echo "=====KTEST-END====="
+  $BB poweroff -f
+  exit 69
 fi
-[ -e /dev/ublk-control ] && echo "KTEST-UBLK-CONTROL=present" || echo "KTEST-UBLK-CONTROL=absent"
+
+if [ -c /dev/ublk-control ]; then
+  echo "KTEST-UBLK-CONTROL=present"
+else
+  echo "KTEST-UBLK-CONTROL=absent"
+  echo "=====KTEST-END====="
+  $BB poweroff -f
+  exit 69
+fi
 
 # 2) starts the daemon in the isolated generic-Linux QEMU guest (--force for best-effort mlockall)
 /ramsharedd --transport ublk --backend ram \


### PR DESCRIPTION
## Summary
Added guard clauses to validate that the ublk_drv module is loaded and the /dev/ublk-control character device is accessible before proceeding with daemon execution. If either condition fails, the script exits early with a semantic error code 69 (EX_UNAVAILABLE) to satisfy fail-fast infrastructure principles.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 5fc9193a8ee30c9936f0329ccb9193e71e00e53c | chore(scripts): add guard clauses for ublk kernel module | To validate `ublk_drv` is loaded and `/dev/ublk-control` is accessible before executing the daemon, satisfying infrastructure hardening principles. | Adds explicit early returns using `exit 69` (EX_UNAVAILABLE) to ensure fail-fast behavior. |

## Issue
Validate that ublk_drv module is loaded and /dev/ublk-control character device is accessible.

## Owner
Jules

## Labels
type:scripts

## Validation
```bash
shellcheck scripts/kernel/qemu-ublk-daemon.sh
```

## Rollback trigger
Unexpected failures in QEMU isolation tests.

---
*PR created automatically by Jules for task [17648295963924916141](https://jules.google.com/task/17648295963924916141) started by @emersonbusson*