### PR TITLE
fix(scripts): add guard clause for KERNEL_SRC checkpatch availability

### DIFF
--- a/scripts/ci/check-kernel-checkpatch.sh
+++ b/scripts/ci/check-kernel-checkpatch.sh
@@ -14,8 +14,22 @@ CHECKPATCH="$CACHE_DIR/checkpatch.pl"
 SPELLING="$CACHE_DIR/spelling.txt"
 CONST_STRUCTS="$CACHE_DIR/const_structs.checkpatch"
 
+KERNEL_SRC="${KERNEL_SRC:-}"
+
+if [[ -n "$KERNEL_SRC" ]]; then
+  if [[ ! -d "$KERNEL_SRC" ]]; then
+    echo "FAIL: KERNEL_SRC directory not found at $KERNEL_SRC" >&2
+    exit 69 # EX_UNAVAILABLE
+  fi
+  if [[ ! -x "$KERNEL_SRC/scripts/checkpatch.pl" ]]; then
+    echo "FAIL: checkpatch.pl not found or not executable at $KERNEL_SRC/scripts/checkpatch.pl" >&2
+    exit 69 # EX_UNAVAILABLE
+  fi
+  CHECKPATCH="$KERNEL_SRC/scripts/checkpatch.pl"
+fi
+
 # Download checkpatch.pl from torvalds/linux if not cached
-if [[ ! -x "$CHECKPATCH" ]]; then
+if [[ -z "$KERNEL_SRC" ]] && [[ ! -x "$CHECKPATCH" ]]; then
   mkdir -p "$CACHE_DIR"
   echo "  Downloading checkpatch.pl from torvalds/linux..."
   curl -sSfL "https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl" -o "$CHECKPATCH" || {


### PR DESCRIPTION
## Summary
This PR adds a guard clause to `scripts/ci/check-kernel-checkpatch.sh` to validate the `KERNEL_SRC` path and the availability of `checkpatch.pl` before execution, ensuring fail-fast behavior with semantic exit codes.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 514a4f7a58d63adf5c065b07cb45c26d072cbb2a | Add KERNEL_SRC validation | To enforce infrastructure hardening principles by failing fast on missing dependencies. | The script now verifies `KERNEL_SRC` exists and contains an executable `checkpatch.pl` before running. |
| 156355c4427b6e00321ebc68c7de9288dbf72e09 | Remove finding document | Remove obsolete finding. | N/A |

## Issue
N/A

## Owner
jules

## Labels
type:scripts, area:ci

## Validation
`shellcheck scripts/ci/check-kernel-checkpatch.sh`

## Rollback trigger
If the CI script fails incorrectly due to valid `KERNEL_SRC` paths being rejected.

---
*PR created automatically by Jules for task [15030990237588720194](https://jules.google.com/task/15030990237588720194) started by @emersonbusson*