### PR TITLE
ci: add PR concurrency grouping to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
Add concurrency group with cancel-in-progress: true keyed on branch/PR to prevent parallel waste.
## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 1ff91e914d6ccc81dedbe75ab1daccfc16b94aaf | Add PR concurrency grouping to ci workflow | To prevent duplicate parallel runs on the same PR. | Modified .github/workflows/ci.yml |
## Issue
N/A
## Owner
Jules
## Labels
type:ci, area:workflows
## Validation
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml
## Rollback trigger
Revert if valid CI runs are cancelled.

---
*PR created automatically by Jules for task [979758427126908732](https://jules.google.com/task/979758427126908732) started by @emersonbusson*