### PR TITLE
ci(kernel): add hash-based caching for kernel build artifacts

### DIFF
--- a/.github/workflows/kernel-ci.yml
+++ b/.github/workflows/kernel-ci.yml
@@ -69,6 +69,16 @@ jobs:
         if: matrix.compiler == 'clang'
         run: sudo apt-get update -qq && sudo apt-get install -y -qq clang
 
+      - name: Cache kernel build objects
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            drivers/block/ramshared/*.o
+            drivers/block/ramshared/*.ko
+            tools/benchmarks/*
+          key: ${{ runner.os }}-kernel-build-${{ matrix.compiler }}-${{ matrix.arch }}-${{ hashFiles('drivers/block/ramshared/**/*', 'tools/benchmarks/**/*') }}
+          restore-keys: ${{ runner.os }}-kernel-build-${{ matrix.compiler }}-${{ matrix.arch }}-
+
       - name: Run build matrix (${{ matrix.compiler }} / ${{ matrix.arch }})
         run: ./scripts/ci/check-kernel-build-matrix.sh "${{ matrix.compiler }}" "${{ matrix.arch }}"
 


### PR DESCRIPTION
## Summary
Added actions/cache@v4 step in kernel-build-matrix to cache kernel driver and benchmark object files. The cache key includes compiler, architecture, and source tree hashes, and fallback restore-keys are provided to speed up incremental CI builds.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 2df10dc41e5c2a54fd64dee06ccfb1440918b01f | Add actions/cache to kernel-ci.yml | Speed up incremental builds by caching object files | Keys off OS, compiler, arch, and source file hashes, uses restore-keys |

## Issue
OpsInfra100/2026-09-06/ci-workflows/061

## Owner
jules

## Labels
type:ci, area:scripts

## Validation
./actionlint .github/workflows/kernel-ci.yml

## Rollback trigger
Revert if cache step fails consistently or if there are false cache hits causing stale code compilation failures.

---
*PR created automatically by Jules for task [15987190242585128340](https://jules.google.com/task/15987190242585128340) started by @emersonbusson*