### PR TITLE
ci: guard release tag format and changelog

### DIFF
--- a/.github/workflows/release-publication.yml
+++ b/.github/workflows/release-publication.yml
@@ -73,6 +73,20 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
 
+      - name: Validate semantic version tag and changelog
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "Error: Tag '$RELEASE_TAG' does not match semantic version format"
+            exit 64
+          fi
+          VERSION="${RELEASE_TAG#v}"
+          if ! grep -q "^## \[$VERSION\]" CHANGELOG.md; then
+            echo "Error: CHANGELOG.md entry for '$VERSION' not found."
+            exit 69
+          fi
+
       - name: Validate exact publication request identity
         shell: bash
         run: |
@@ -137,6 +151,20 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
+
+      - name: Validate semantic version tag and changelog
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "Error: Tag '$RELEASE_TAG' does not match semantic version format"
+            exit 64
+          fi
+          VERSION="${RELEASE_TAG#v}"
+          if ! grep -q "^## \[$VERSION\]" CHANGELOG.md; then
+            echo "Error: CHANGELOG.md entry for '$VERSION' not found."
+            exit 69
+          fi
 
       # The protected dispatch binds target tag, source SHA, and integrity run ID.
       - name: Validate exact protected dispatch identity


### PR DESCRIPTION
## Summary
Added guard conditions for release tag format and changelog existence to comply with infrastructure hardening guidelines.
## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 8a14c622d718def72b3e9d5f83ec08dc28f60287 | Added guard clauses to Release Publication workflow | To validate semantic tag format and changelog entry | Added early exit steps with specific sysexits.h codes |
## Issue
guard conditions for release tag format and changelog existence
## Owner
OpsInfra100/2026-09-06/ci-workflows/067
## Labels
type:ci
## Validation
./actionlint .github/workflows/release-publication.yml
## Rollback trigger
Revert if the validation logic falsely rejects valid semantic version tags or valid changelog entries.

---
*PR created automatically by Jules for task [14104423714494334826](https://jules.google.com/task/14104423714494334826) started by @emersonbusson*