### PR TITLE
build(ci): add artifact checksum generation and signature verification step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,3 +68,45 @@ jobs:
           token: ${{ steps.release-app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Generate Checksums and Signatures
+        if: ${{ steps.target.outputs.run == 'true' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          RELEASE_TAG: ${{ env.RELEASE_TARGET_TAG }}
+        run: |
+          set -euo pipefail
+
+          # Prerequisite checks
+          command -v gh >/dev/null 2>&1 || exit 69
+          command -v sha256sum >/dev/null 2>&1 || exit 69
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release download "$RELEASE_TAG" --dir artifacts/release || true
+          fi
+          if [ -d "artifacts/release" ]; then
+            cd artifacts/release
+            find . -type f -not -name "SHA256SUMS.txt" -exec sha256sum {} + > SHA256SUMS.txt
+            if command -v gpg >/dev/null 2>&1; then
+              for file in *.tar.gz *.deb *.rpm; do
+                if [ -f "$file" ]; then
+                   if [ -f "$file.sig" ]; then
+                     if ! gpg --verify "$file.sig" "$file"; then
+                       echo "Signature verification failed for $file" >&2
+                       exit 65 # EX_DATAERR
+                     fi
+                   elif [ -f "$file.asc" ]; then
+                     if ! gpg --verify "$file.asc" "$file"; then
+                       echo "Signature verification failed for $file" >&2
+                       exit 65 # EX_DATAERR
+                     fi
+                   else
+                     echo "No signature found for $file"
+                   fi
+                fi
+              done
+            fi
+            cd -
+            gh release upload "$RELEASE_TAG" "artifacts/release/SHA256SUMS.txt" --clobber || true
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,11 +79,15 @@ jobs:
           set -euo pipefail
 
           # Prerequisite checks
-          command -v gh >/dev/null 2>&1 || exit 69
-          command -v sha256sum >/dev/null 2>&1 || exit 69
+          if ! command -v gh >/dev/null 2>&1; then
+            exit 69
+          fi
+          if ! command -v sha256sum >/dev/null 2>&1; then
+            exit 69
+          fi
 
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release download "$RELEASE_TAG" --dir artifacts/release || true
+            gh release download "$RELEASE_TAG" --dir artifacts/release ;
           fi
           if [ -d "artifacts/release" ]; then
             cd artifacts/release
@@ -108,5 +112,5 @@ jobs:
               done
             fi
             cd -
-            gh release upload "$RELEASE_TAG" "artifacts/release/SHA256SUMS.txt" --clobber || true
+            gh release upload "$RELEASE_TAG" "artifacts/release/SHA256SUMS.txt" --clobber ;
           fi


### PR DESCRIPTION
## Summary
Added a step in `.github/workflows/release.yml` to generate SHA-256 checksums for release artifacts and optionally verify GPG signatures. This enhances release integrity in accordance with infrastructure hardening principles by validating physical paths and performing checksums on the generated artifacts.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 56ef8c865409cf03d6793036b03260e706d03a89 | Added artifact checksum generation and signature verification step | To enforce release integrity on published artifacts | <details><summary>details</summary>Files: .github/workflows/release.yml<br>Validation: wget -qO actionlint_1.7.3_linux_amd64.tar.gz https://github.com/rhysd/actionlint/releases/download/v1.7.3/actionlint_1.7.3_linux_amd64.tar.gz && tar xzf actionlint_1.7.3_linux_amd64.tar.gz actionlint && ./actionlint .github/workflows/release.yml && rm actionlint<br>Risk/rollback: Removing the step or failure during sha256sum generation</details> |

## Issue
Closes #

## Owner
@jules

## Labels
type:security, area:ci

## Validation
- [x] wget -qO actionlint_1.7.3_linux_amd64.tar.gz https://github.com/rhysd/actionlint/releases/download/v1.7.3/actionlint_1.7.3_linux_amd64.tar.gz && tar xzf actionlint_1.7.3_linux_amd64.tar.gz actionlint && ./actionlint .github/workflows/release.yml && rm actionlint

## Rollback trigger
CI pipeline fails indicating checksum generation failure or syntax error in release.yml workflow.

---
*PR created automatically by Jules for task [15485773332414270326](https://jules.google.com/task/15485773332414270326) started by @emersonbusson*