### PR TITLE
ci: add guard conditions for packaging tool availability

### DIFF
--- a/.github/workflows/release-packaging.yml
+++ b/.github/workflows/release-packaging.yml
@@ -33,6 +33,22 @@ jobs:
         with:
           toolchain: 1.98.0
 
+      - name: Validate Packaging Prerequisites
+        run: |
+          set -euo pipefail
+          if ! command -v cargo >/dev/null 2>&1; then
+            echo "Error: cargo is not available" >&2
+            exit 69
+          fi
+          if ! command -v dpkg-deb >/dev/null 2>&1; then
+            echo "Error: dpkg-deb is not available" >&2
+            exit 69
+          fi
+          if ! command -v rpmbuild >/dev/null 2>&1; then
+            echo "Error: rpmbuild is not available" >&2
+            exit 69
+          fi
+
       - name: Build Release Binaries
         run: cargo build --release --locked
 


### PR DESCRIPTION
## Summary
Added Validate Packaging Prerequisites step in release-packaging.yml to fail fast if cargo, dpkg-deb, or rpmbuild are missing.
## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| f91de2f354aa0983ba59509f0a751b269cb38a30 | Add Validate Packaging Prerequisites step | Enforce guard clauses and fail-fast for missing build tools. | Added bash script with set -euo pipefail and exit 69 semantic error codes. |
## Issue
OpsInfra100/2026-09-06/ci-workflows/065
## Owner
OpsInfra100
## Labels
type:ci, type:scripts, type:packaging, area:ci-workflows
## Validation
~/go/bin/actionlint .github/workflows/release-packaging.yml
## Rollback trigger
Revert if the release packaging workflow incorrectly fails on runners where the tools are actually present or installed in a non-standard PATH.

---
*PR created automatically by Jules for task [10894495707670324654](https://jules.google.com/task/10894495707670324654) started by @emersonbusson*