### PR TITLE
ci: add PSScriptAnalyzer static analysis step for PowerShell scripts

### DIFF
--- a/.github/workflows/windows-static.yml
+++ b/.github/workflows/windows-static.yml
@@ -30,6 +30,23 @@ jobs:
           cargo test -p ramshared-winbroker
           cargo test -p ramshared-winsvc
 
+      - name: PowerShell PSScriptAnalyzer static analysis
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not (Test-Path "scripts/windows")) {
+            throw "Directory scripts/windows does not exist"
+          }
+          if (-not (Get-Command Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue)) {
+            Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+          }
+          $findings = Invoke-ScriptAnalyzer -Path scripts/windows/*.ps1 -Severity Error
+          if ($findings) {
+            $findings | Format-Table
+            Write-Error "PSScriptAnalyzer found Error severity issues" -ErrorId "PSScriptAnalyzerErrors"
+            exit 64
+          }
+
       - name: Static-only Windows suite
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
Add PSScriptAnalyzer static analysis step for PowerShell scripts to windows-static.yml to fail on Error severity findings.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| c9c61e2035478f0437b0e4ede212a23d6377bbba | ci: add PSScriptAnalyzer static analysis step for PowerShell scripts | Fail on Error severity findings | Added to .github/workflows/windows-static.yml |

## Issue
N/A

## Owner
jules

## Labels
type:ci, type:scripts

## Validation
pwsh -c "Invoke-ScriptAnalyzer -Path scripts/windows/*.ps1 -Severity Error"

## Rollback trigger
CI pipeline failures indicating false positive errors or syntax issues.

---
*PR created automatically by Jules for task [4131465292546591895](https://jules.google.com/task/4131465292546591895) started by @emersonbusson*