### PR TITLE
ci: configure gitleaks allowlist

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -26,6 +26,7 @@ jobs:
         uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
 
   gitleaks-summary:
     name: gitleaks-summary

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,7 +2,13 @@
 useDefault = true
 
 [allowlist]
-description = "Benchmark fixture metric mistaken for a generic API key"
+description = "Benchmark fixture metric mistaken for a generic API key, and test fixtures"
 regexTarget = "line"
-paths = ['''^tools/ci/check-benchmark-evidence\.test\.mjs$''']
-regexes = ['''^\s*\{ name: 'p99', key: 'nbd_vs_disk_p99_ratio', value: 999 \},\s*$''']
+paths = [
+  '''^tools/ci/check-benchmark-evidence\.test\.mjs$''',
+  '''^tests/fixtures/.*\.json$'''
+]
+regexes = [
+  '''^\s*\{ name: 'p99', key: 'nbd_vs_disk_p99_ratio', value: 999 \},\s*$''',
+  '''"api_key":\s*"[a-zA-Z0-9]{32}"'''
+]


### PR DESCRIPTION
## Summary
Configure gitleaks-action to use the repository's `.gitleaks.toml` configuration to reduce noise by allowing safe patterns in test fixtures.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| e7a94baa8ffb57cbcc5d7d7c1edf45574cb52b18 | Add `GITLEAKS_CONFIG` environment variable and extend allowlist | To tell gitleaks-action where to find the custom allowlist configuration and add test fixture patterns | Modified `.github/workflows/gitleaks.yml` and `.gitleaks.toml` |

## Issue
add allowlist for known false positives and test patterns

## Owner
OpsInfra-100

## Labels
type:ci

## Validation
`actionlint .github/workflows/gitleaks.yml`

## Rollback trigger
Revert if gitleaks fails on unexpected syntax or fails to run due to missing configuration file.

---
*PR created automatically by Jules for task [11778031215929774999](https://jules.google.com/task/11778031215929774999) started by @emersonbusson*