### PR TITLE
chore(ci): guard conditions for WSL2 kernel availability on CI runner

### DIFF
--- a/.github/workflows/wsl2-lab.yml
+++ b/.github/workflows/wsl2-lab.yml
@@ -36,6 +36,18 @@ jobs:
       LAB_REVISION: ${{ github.sha }}
       LAB_ENVIRONMENT: protected-isolated-lab
     steps:
+      - name: Check WSL2 kernel and distro availability
+        run: |
+          set -euo pipefail
+          if ! grep -qi microsoft /proc/version; then
+            echo "Error: WSL2 kernel not detected."
+            exit 69
+          fi
+          if ! command -v wsl.exe >/dev/null 2>&1; then
+            echo "Error: wsl.exe not found for distro interop."
+            exit 69
+          fi
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 


### PR DESCRIPTION
## Summary
Added prerequisite guard conditions to check for WSL2 kernel (`/proc/version`) and distro availability (`wsl.exe`) on the CI runner before proceeding with tests. Adheres to fail-fast principles with sysexits.h `EX_UNAVAILABLE` (69) semantic return codes.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 78a1f741a2a0010df41cf3dd1f567bdf9b349ae5 | chore(ci): guard conditions for WSL2 kernel availability on CI runner | Enforce early fail-fast logic for missing WSL2 dependencies | Added early exit with code 69 if WSL2 kernel or `wsl.exe` are missing |

## Issue
N/A

## Owner
OpsInfra-100

## Labels
type:ci, area:scripts

## Validation
~/.local/bin/actionlint .github/workflows/wsl2-lab.yml

## Rollback trigger
CI lab plan workflows begin to fail immediately on runners that previously succeeded due to incorrect availability evaluation or false negatives on `/proc/version` or `wsl.exe`.

---
*PR created automatically by Jules for task [1956837114484764262](https://jules.google.com/task/1956837114484764262) started by @emersonbusson*