### PR TITLE
build: add guard clauses for debian packaging tools

### DIFF
--- a/scripts/package/build-deb-package.sh
+++ b/scripts/package/build-deb-package.sh
@@ -4,6 +4,14 @@
 # Usage: scripts/package/build-deb-package.sh [version]
 set -euo pipefail
 
+
+for tool in dpkg-deb fakeroot lintian; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "ERROR: Required tool '$tool' is not installed or not in PATH." >&2
+    exit 69
+  fi
+done
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 VERSION="${1:-${RAMSHARED_PACKAGE_VERSION:-v0.9.0-beta.2}}"
 VERSION_CLEAN="${VERSION#v}"


### PR DESCRIPTION
## Summary
Adds guard clauses for Debian packaging tools (dpkg-deb, fakeroot, lintian) with immediate early exit (EX_UNAVAILABLE 69) if missing.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 319701b5ef30f28942aaa5f4e8dd3dc3f8c91e9c | Added guard clauses for dpkg-deb and fakeroot. | Prevents broken builds in the absence of packaging dependencies. | Early validation of dpkg-deb, fakeroot, and lintian in scripts/package/build-deb-package.sh. |

## Issue
N/A

## Owner
OpsInfra100

## Labels
type:packaging, area:packaging

## Validation
shellcheck scripts/package/build-deb-package.sh

## Rollback trigger
Revert if the CI pipeline fails due to early validation in environments where a dummy build was expected (e.g., unforeseen dry runs).

---
*PR created automatically by Jules for task [4037680861780114498](https://jules.google.com/task/4037680861780114498) started by @emersonbusson*