### PR TITLE
ci(workflows): add guard condition to prevent cancellation of protected branches

### DIFF
--- a/.github/workflows/cancel-closed-pr.yml
+++ b/.github/workflows/cancel-closed-pr.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   cancel-closed-pr:
     name: closed-pr-cancellation
-    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref != 'main' && !startsWith(github.event.pull_request.base.ref, 'release/') && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -21,7 +21,6 @@ jobs:
       pull-requests: read
     steps:
       - name: Cancel queued and running checks for the closed pull request
-        if: github.event.pull_request.base.ref != 'main' && !startsWith(github.event.pull_request.base.ref, 'release/')
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |


### PR DESCRIPTION
## Summary
Skip cancellation for PRs targeting protected branches to prevent data loss.
## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| d158b3d5720837e0dfa46d717f3c72c25dbd2a8a | Add guard condition to prevent cancellation of protected branches | To skip cancellation for PRs targeting protected branches to prevent data loss. | Added check in .github/workflows/cancel-closed-pr.yml |
## Issue
add guard condition to prevent cancellation of protected branches
## Owner
OpsInfra100/2026-09-06/ci-workflows/074
## Labels
type:ci, area:ci-workflows
## Validation
~/.local/bin/actionlint .github/workflows/cancel-closed-pr.yml
## Rollback trigger
Revert if GitHub Actions workflow cancel-closed-pr fails or behaves unexpectedly.

---
*PR created automatically by Jules for task [10688485399253713491](https://jules.google.com/task/10688485399253713491) started by @emersonbusson*