### PR TITLE
feat(packaging): validate Debian control file mandatory fields and version format

### DIFF
--- a/scripts/package/build-deb-package.sh
+++ b/scripts/package/build-deb-package.sh
@@ -144,6 +144,33 @@ exit 0
 PRERM_EOF
 chmod 0755 "$STAGE_DIR/DEBIAN/prerm"
 
+# Validate DEBIAN/control fields before build
+CONTROL_FILE="$STAGE_DIR/DEBIAN/control"
+if [[ ! -f "$CONTROL_FILE" ]]; then
+  echo "ERROR: Control file not found at $CONTROL_FILE" >&2
+  exit 69
+fi
+
+if ! grep -qE '^Package:[[:space:]]+[a-z0-9][a-z0-9+.-]+$' "$CONTROL_FILE"; then
+  echo "ERROR: Invalid or missing 'Package' field in control file." >&2
+  exit 78
+fi
+
+if ! grep -qE '^Version:[[:space:]]+([0-9]+:)?[0-9a-zA-Z.+~-]+$' "$CONTROL_FILE"; then
+  echo "ERROR: Invalid or missing 'Version' field in control file." >&2
+  exit 78
+fi
+
+if ! grep -qE '^Architecture:[[:space:]]+[a-zA-Z0-9-]+$' "$CONTROL_FILE"; then
+  echo "ERROR: Invalid or missing 'Architecture' field in control file." >&2
+  exit 78
+fi
+
+if ! grep -qE '^Depends:[[:space:]]+.+$' "$CONTROL_FILE"; then
+  echo "ERROR: Invalid or missing 'Depends' field in control file." >&2
+  exit 78
+fi
+
 # Build the .deb archive
 mkdir -p "$OUT_DIR"
 dpkg-deb --build --root-owner-group "$STAGE_DIR" "$DEB_FILE"


### PR DESCRIPTION
## Summary
Validates mandatory Debian control fields and version formats in the deb packaging script prior to building the archive, failing fast if the metadata is missing or improperly formed.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 7f551c450d1a14e8eb9e01a1447c4698f15b3590 | Added DEBIAN/control validation before build | To ensure the integrity of generated packages | Added regex checks for Package, Version, Architecture, and Depends fields using grep. Fails fast with sysexits.h error codes (69, 78) in case of missing or malformed fields. |

## Issue
validate Debian control file mandatory fields and version format

## Owner
OpsInfra100/2026-09-06/packaging/077

## Labels
type:packaging, area:scripts

## Validation
sudo apt-get update && sudo apt-get install -y shellcheck && shellcheck scripts/package/build-deb-package.sh

## Rollback trigger
If the deb package build inappropriately fails with a false positive control file validation error.

---
*PR created automatically by Jules for task [8964719047545449406](https://jules.google.com/task/8964719047545449406) started by @emersonbusson*