### PR TITLE
fix(packaging): use semantic exit codes in RPM build script

### DIFF
--- a/scripts/package/build-rpm-package.sh
+++ b/scripts/package/build-rpm-package.sh
@@ -23,13 +23,13 @@ DAEMON_BIN="$ROOT/target/release/ramsharedd"
 if [[ ! -x "$CLI_BIN" || ! -x "$DAEMON_BIN" ]]; then
   echo "==> Binaries missing in target/release, skipping cargo or building if available"
   if command -v cargo >/dev/null 2>&1; then
-    cargo build -p ramshared-cli -p ramshared-wsl2d --release || true
+    cargo build -p ramshared-cli -p ramshared-wsl2d --release || exit 74
   fi
 fi
 
 if [[ ! -x "$CLI_BIN" || ! -x "$DAEMON_BIN" ]]; then
   echo "ERROR: Target release binaries not found ($CLI_BIN / $DAEMON_BIN)" >&2
-  exit 1
+  exit 65
 fi
 
 # Clean previous build root
@@ -81,8 +81,8 @@ SPEC_EOF
 
 if command -v rpmbuild >/dev/null 2>&1; then
   echo "==> Executing rpmbuild..."
-  rpmbuild --define "_topdir $RPM_ROOT" -bb "$SPEC_FILE"
-  cp "$RPM_ROOT"/RPMS/*/*.rpm "$OUT_DIR/" 2>/dev/null || true
+  rpmbuild --define "_topdir $RPM_ROOT" -bb "$SPEC_FILE" || exit 74
+  cp "$RPM_ROOT"/RPMS/*/*.rpm "$OUT_DIR/" 2>/dev/null || exit 73
   echo "✓ RPM package built under $OUT_DIR/"
 else
   echo "==> rpmbuild not installed on host. Spec generated at $SPEC_FILE (PASS)."


### PR DESCRIPTION
## Summary
Updated `scripts/package/build-rpm-package.sh` to use specific, semantic exit codes for failures, aligning with infrastructure hardening principles (sysexits.h). Modified prep failure to exit 65 (EX_NOINPUT), build failure to exit 74 (EX_IOERR), and install failure to exit 73 (EX_CANTCREAT).
## Commits
| Commit | What it did | Why it did it | Details |
|---|---|---|---|
| 9b45eaf9480a44d8265158222e9f74e2b29edb2e | Modified scripts/package/build-rpm-package.sh to use semantic exit codes (65, 74, 73) | To comply with guard clauses and fail-fast principles | Changed exit 1 and silent failures with || true to the requested codes |
## Issue
#80
## Owner
OpsInfra-100
## Labels
type:scripts, type:packaging, area:packaging
## Validation
shellcheck scripts/package/build-rpm-package.sh
## Rollback trigger
Unexpected failures in CI builds due to new exit codes or bash pipeline behavior.

---
*PR created automatically by Jules for task [16554227323184451319](https://jules.google.com/task/16554227323184451319) started by @emersonbusson*