### PR TITLE
chore(scripts): add guard clauses for rpmbuild and spec file validation

### DIFF
--- a/scripts/package/build-rpm-package.sh
+++ b/scripts/package/build-rpm-package.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 VERSION="${1:-${RAMSHARED_PACKAGE_VERSION:-v0.9.0-beta.2}}"
 VERSION_CLEAN="${VERSION#v}"
-RPM_VERSION="$(echo "$VERSION_CLEAN" | sed "s/-beta\./.beta/")"
+RPM_VERSION="${VERSION_CLEAN//-beta./.beta}"
 ARCH="x86_64"
 
 OUT_DIR="$ROOT/artifacts/packages"
@@ -15,6 +15,18 @@ RPM_ROOT="$OUT_DIR/rpmbuild"
 SPEC_FILE="$RPM_ROOT/SPECS/ramshared.spec"
 
 echo "==> Building RPM package for RamShared ${VERSION} (${ARCH})..."
+
+# Guard clause: Verify rpmbuild exists
+if ! command -v rpmbuild >/dev/null 2>&1; then
+  echo "ERROR: rpmbuild is not installed. Please install rpm-build package." >&2
+  exit 69
+fi
+
+# Guard clause: Verify rpmspec exists
+if ! command -v rpmspec >/dev/null 2>&1; then
+  echo "ERROR: rpmspec is not installed. Please install rpm package." >&2
+  exit 69
+fi
 
 # Ensure release binaries exist
 CLI_BIN="$ROOT/target/release/ramshared"
@@ -29,7 +41,7 @@ fi
 
 if [[ ! -x "$CLI_BIN" || ! -x "$DAEMON_BIN" ]]; then
   echo "ERROR: Target release binaries not found ($CLI_BIN / $DAEMON_BIN)" >&2
-  exit 1
+  exit 74
 fi
 
 # Clean previous build root
@@ -79,11 +91,13 @@ fi
 - Official v0.9.0-beta.2 Linux RPM release with hardware DMA & ublk support.
 SPEC_EOF
 
-if command -v rpmbuild >/dev/null 2>&1; then
-  echo "==> Executing rpmbuild..."
-  rpmbuild --define "_topdir $RPM_ROOT" -bb "$SPEC_FILE"
-  cp "$RPM_ROOT"/RPMS/*/*.rpm "$OUT_DIR/" 2>/dev/null || true
-  echo "✓ RPM package built under $OUT_DIR/"
-else
-  echo "==> rpmbuild not installed on host. Spec generated at $SPEC_FILE (PASS)."
+# Guard clause: Validate spec file syntax
+if ! rpmspec -q "$SPEC_FILE" >/dev/null 2>&1; then
+  echo "ERROR: Invalid RPM spec file syntax in $SPEC_FILE" >&2
+  exit 78
 fi
+
+echo "==> Executing rpmbuild..."
+rpmbuild --define "_topdir $RPM_ROOT" -bb "$SPEC_FILE"
+cp "$RPM_ROOT"/RPMS/*/*.rpm "$OUT_DIR/" 2>/dev/null || true
+echo "✓ RPM package built under $OUT_DIR/"


### PR DESCRIPTION
## Summary
Added guard clauses to validate that rpmbuild and rpmspec binaries are installed prior to executing package builds. Integrated semantic exit codes (EX_UNAVAILABLE, EX_IOERR, EX_CONFIG) from sysexits.h for missing binaries, unavailable targets, and spec validation failures. Fixed shellcheck issue SC2001 by using parameter expansion instead of echo piped to sed. Verified that the .spec file syntax is evaluated using rpmspec before executing the rpmbuild operation.

## Commits
| Commit | Summary | Reason | Details |
|---|---|---|---|
| 70e7f7944ce2f57b1f5e2d674c153cbba3ebdd98 | chore(scripts): add guard clauses for rpmbuild and spec file validation | Apply guard clauses, validate rpmbuild/rpmspec binaries, fix shellcheck, and use semantic exit codes | Added command existence checks with early returns and exit codes 69/74/78, fixed SC2001. |

## Issue
OpsInfra100/2026-09-06/packaging/079

## Owner
OpsInfra-100

## Labels
type:scripts, type:packaging, area:packaging

## Validation
shellcheck scripts/package/build-rpm-package.sh

## Rollback trigger
If rpm package building fails on CI systems due to unrecognized exit codes or missing binaries previously ignored.

---
*PR created automatically by Jules for task [2684406618323418806](https://jules.google.com/task/2684406618323418806) started by @emersonbusson*