### PR TITLE
feat(ci): enforce English-only constraint on code comments and identifiers

### DIFF
--- a/.github/workflows/comment-language.yml
+++ b/.github/workflows/comment-language.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check added repository text uses canonical English
+      - name: Check added repository text and identifiers use canonical English
         run: >-
           node tools/ci/check-comment-language.mjs
           --diff "origin/${{ github.base_ref }}"

--- a/tools/ci/check-comment-language.mjs
+++ b/tools/ci/check-comment-language.mjs
@@ -160,10 +160,12 @@ function addQuotedUnits(segment, line, units, ext) {
   let quote = null
   let start = -1
   let escaped = false
+  let lastEnd = 0
   for (let index = 0; index < segment.length; index++) {
     const character = segment[index]
     if (!quote) {
       if (character === '"' || character === "'" || character === '`') {
+        addUnit(units, line, segment.slice(lastEnd, index), 'identifier', ext)
         quote = character
         start = index + 1
       }
@@ -181,7 +183,11 @@ function addQuotedUnits(segment, line, units, ext) {
       addUnit(units, line, segment.slice(start, index), 'source-text', ext)
       quote = null
       start = -1
+      lastEnd = index + 1
     }
+  }
+  if (!quote && lastEnd < segment.length) {
+    addUnit(units, line, segment.slice(lastEnd), 'identifier', ext)
   }
 }
 

--- a/tools/ci/check-comment-language.test.mjs
+++ b/tools/ci/check-comment-language.test.mjs
@@ -157,11 +157,26 @@ test('multiline_comment_state_is_bounded', () => {
 test('english_comment_and_identifier_are_ignored', () => {
   const findings = scanText('src/example.rs', [
     '// bounded English comment',
-    `let ${HIGH} = true;`,
+    `let endpoint = true;`,
     'let endpoint = "https://example.invalid/ready";',
     '',
   ].join('\n'))
   assert.deepEqual(findings, [])
+})
+
+test('identifier_is_scanned', () => {
+  const findings = scanText('src/example.rs', [
+    '// bounded English comment',
+    `let ${HIGH} = true;`,
+    'let endpoint = "https://example.invalid/ready";',
+    '',
+  ].join('\n'))
+  assert.deepEqual(findings, [{
+    path: 'src/example.rs',
+    line: 2,
+    rule: 'LANG-PT-001',
+    scope: 'identifier'
+  }])
 })
 
 test('quoted_source_text_and_declared_comment_anchors_are_scanned', (t) => {


### PR DESCRIPTION
## Summary
Enforce English-only constraint on code identifiers by extracting and checking source text segments outside of strings and comments.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| dd0711fc4e8cde2e12512793536849ee0cab7e11 | feat(ci): enforce English-only constraint on code comments and identifiers | To ensure repository governance requires English identifiers. | Added 'identifier' scoping inside `addQuotedUnits` and updated GitHub action. |

## Issue
#073

## Owner
jules

## Labels
type:ci
area:ci-workflows

## Validation
~/.local/bin/actionlint .github/workflows/comment-language.yml

## Rollback trigger
Revert if language validation falsely flags valid machine-generated or explicitly localized strings.

---
*PR created automatically by Jules for task [16113471625830508017](https://jules.google.com/task/16113471625830508017) started by @emersonbusson*