### PR TITLE
chore: validate LKML patch format with checkpatch.pl before submission

### DIFF
--- a/scripts/package/generate-kernel-patchset.sh
+++ b/scripts/package/generate-kernel-patchset.sh
@@ -6,8 +6,28 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
+if ! command -v perl >/dev/null 2>&1; then
+    echo "Error: perl is required but not installed." >&2
+    exit 69 # EX_UNAVAILABLE
+fi
+
+if [[ ! -f "scripts/checkpatch.pl" ]]; then
+    echo "Error: scripts/checkpatch.pl not found." >&2
+    exit 69 # EX_UNAVAILABLE
+fi
+
+if [[ ! -x "scripts/checkpatch.pl" ]]; then
+    echo "Error: scripts/checkpatch.pl is not executable." >&2
+    exit 69 # EX_UNAVAILABLE
+fi
+
 OUT_DIR="artifacts/lkml-patchset"
 mkdir -p "$OUT_DIR"
+
+if [[ ! -d "$OUT_DIR" ]]; then
+    echo "Error: Failed to create output directory $OUT_DIR." >&2
+    exit 74 # EX_IOERR
+fi
 
 echo "==> Generating LKML patchset in $OUT_DIR..."
 
@@ -41,3 +61,17 @@ COVER_EOF
 
 echo "✓ Cover letter created: $OUT_DIR/0000-cover-letter.patch"
 echo "✓ LKML patchset generation complete."
+
+echo "==> Validating generated patches with checkpatch.pl..."
+# Find generated patches and validate them
+while IFS= read -r patch_file; do
+    if [[ -f "$patch_file" ]]; then
+        echo "Validating: $patch_file"
+        if ! scripts/checkpatch.pl --strict "$patch_file"; then
+            echo "Error: checkpatch.pl failed on $patch_file." >&2
+            exit 65 # EX_DATAERR
+        fi
+    fi
+done < <(find "$OUT_DIR" -maxdepth 1 -type f -name "*.patch" | sort)
+
+echo "✓ All patches validated successfully."


### PR DESCRIPTION
## Summary
This patch adds a validation step to the generate-kernel-patchset.sh script to run checkpatch.pl --strict on each generated patch and abort if errors are found, enforcing the quality gate.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 1f78f0d141da1ef593624497546e0ed40701cd80 | Added checkpatch.pl --strict validation. | To enforce kernel style on patches. | Included loop over patch files and checks for checkpatch.pl existence. |

## Issue
validate LKML patch format with checkpatch.pl before submission

## Owner
jules

## Labels
type:packaging, area:scripts

## Validation
shellcheck scripts/package/generate-kernel-patchset.sh

## Rollback trigger
If the patch generation process fails in automated CI pipelines.

---
*PR created automatically by Jules for task [10253697745779740894](https://jules.google.com/task/10253697745779740894) started by @emersonbusson*