### PR TITLE
chore(scripts): guard clauses for git-send-email configuration

### DIFF
--- a/scripts/package/send-lkml-patchset.sh
+++ b/scripts/package/send-lkml-patchset.sh
@@ -6,6 +6,12 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
+
+if ! command -v git >/dev/null 2>&1; then
+    echo "❌ Error: git is required but not installed." >&2
+    exit 69
+fi
+
 OUT_DIR="artifacts/lkml-patchset"
 
 EMAIL_AT="@"
@@ -60,8 +66,23 @@ if [ -z "${SMTP_PASS:-}" ]; then
 fi
 
 if [ -z "$SMTP_PASS" ]; then
-    echo "❌ Error: App Password cannot be empty."
-    exit 1
+    echo "❌ Error: App Password cannot be empty." >&2
+    exit 78
+fi
+
+
+# Validate git send-email configuration
+SMTP_SERVER="$(git config --get sendemail.smtpserver || true)"
+SMTP_USER="$(git config --get sendemail.smtpuser || true)"
+
+if [ -z "$SMTP_SERVER" ]; then
+    echo "❌ Error: git config sendemail.smtpserver is missing or empty." >&2
+    exit 78
+fi
+
+if [ -z "$SMTP_USER" ]; then
+    echo "❌ Error: git config sendemail.smtpuser is missing or empty." >&2
+    exit 78
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
Added guard clauses to validate `git send-email` configuration (smtpserver and smtpuser) and check for the presence of the git command before proceeding with the LKML patchset submission. This adheres to infrastructure hardening principles by failing fast with semantic exit codes.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| dc6247622430cfc0364b6fee5c3cc228e5a2e5ef | Added guard clauses for git send-email config | To fail fast on missing prerequisites before sending patches | Checked `smtpserver` and `smtpuser` with exit code 78 and `git` with exit code 69 |

## Issue
OpsInfra100/2026-09-06/packaging/085

## Owner
Jules

## Labels
type:scripts, area:packaging

## Validation
shellcheck scripts/package/send-lkml-patchset.sh

## Rollback trigger
Revert if the script fails to detect valid git-send-email configuration or fails to dispatch the patchset.

---
*PR created automatically by Jules for task [8330391585117637626](https://jules.google.com/task/8330391585117637626) started by @emersonbusson*