### PR TITLE
feat(packaging): add dry-run mode to LKML dispatcher

### DIFF
--- a/scripts/package/send-lkml-patchset.sh
+++ b/scripts/package/send-lkml-patchset.sh
@@ -37,8 +37,14 @@ echo "Destination: $LKML_TO (Jens Axboe)"
 echo "CC: $LKML_CC"
 echo ""
 
+DRY_RUN=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+    DRY_RUN=1
+    shift
+fi
+
 # Check if password is already configured in git or environment
-if [ -z "${SMTP_PASS:-}" ]; then
+if [ -z "${SMTP_PASS:-}" ] && [ "$DRY_RUN" -eq 0 ]; then
     SMTP_PASS="$(git config --get sendemail.smtppass 2>/dev/null || true)"
     if [ -n "$SMTP_PASS" ]; then
         echo "🔑 Using stored Gmail App Password from git config (~/.gitconfig)."
@@ -46,7 +52,7 @@ if [ -z "${SMTP_PASS:-}" ]; then
 fi
 
 # Prompt once and persist if not found
-if [ -z "${SMTP_PASS:-}" ]; then
+if [ -z "${SMTP_PASS:-}" ] && [ "$DRY_RUN" -eq 0 ]; then
     read -r -s -p "Enter Gmail App Password (16 characters): " SMTP_PASS
     echo ""
     if [ -n "$SMTP_PASS" ]; then
@@ -59,41 +65,58 @@ if [ -z "${SMTP_PASS:-}" ]; then
     fi
 fi
 
-if [ -z "$SMTP_PASS" ]; then
+if [ -z "${SMTP_PASS:-}" ] && [ "$DRY_RUN" -eq 0 ]; then
     echo "❌ Error: App Password cannot be empty."
-    exit 1
+    exit 64
 fi
 
-echo ""
-echo "==> Sending patchset series via smtp.${GMAIL_DOMAIN}..."
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo ""
+    echo "==> [DRY RUN] Patchset series would be sent via smtp.${GMAIL_DOMAIN}..."
+    echo "  • Recipients:"
+    echo "      To: $LKML_TO"
+    echo "      Cc: $AXBOE_CC"
+    echo "      Cc: $LKML_CC"
+    echo "  • Patches:"
+    echo "      $OUT_DIR/0000-cover-letter.patch"
+    echo "      $OUT_DIR/0001-drivers-block-ramshared-add-hardware-VRAM-block-driver.patch"
+    echo "      $OUT_DIR/0002-drivers-block-integrate-ramshared-into-Kconfig-and-Makefile.patch"
+    echo ""
+    echo "============================================================"
+    echo "  ✅ [DRY RUN] LKML PATCHSET VERIFICATION COMPLETE"
+    echo "============================================================"
+else
+    echo ""
+    echo "==> Sending patchset series via smtp.${GMAIL_DOMAIN}..."
 
-# Dispatch via git send-email with secure in-memory password
-git send-email \
-    --smtp-server="smtp.${GMAIL_DOMAIN}" \
-    --smtp-server-port=587 \
-    --smtp-encryption=tls \
-    --smtp-user="$SENDER_EMAIL" \
-    --smtp-pass="$SMTP_PASS" \
-    --to="$LKML_TO" \
-    --cc="$AXBOE_CC" \
-    --cc="$LKML_CC" \
-    --confirm=never \
-    --quiet \
-    "$@" \
-    "$OUT_DIR/0000-cover-letter.patch" \
-    "$OUT_DIR/0001-drivers-block-ramshared-add-hardware-VRAM-block-driver.patch" \
-    "$OUT_DIR/0002-drivers-block-integrate-ramshared-into-Kconfig-and-Makefile.patch"
+    # Dispatch via git send-email with secure in-memory password
+    git send-email \
+        --smtp-server="smtp.${GMAIL_DOMAIN}" \
+        --smtp-server-port=587 \
+        --smtp-encryption=tls \
+        --smtp-user="$SENDER_EMAIL" \
+        --smtp-pass="$SMTP_PASS" \
+        --to="$LKML_TO" \
+        --cc="$AXBOE_CC" \
+        --cc="$LKML_CC" \
+        --confirm=never \
+        --quiet \
+        "$@" \
+        "$OUT_DIR/0000-cover-letter.patch" \
+        "$OUT_DIR/0001-drivers-block-ramshared-add-hardware-VRAM-block-driver.patch" \
+        "$OUT_DIR/0002-drivers-block-integrate-ramshared-into-Kconfig-and-Makefile.patch"
 
-# Scrub password from memory immediately
-unset SMTP_PASS
+    # Scrub password from memory immediately
+    unset SMTP_PASS
 
-echo ""
-echo "============================================================"
-echo "  ✅ LKML PATCHSET SENT SUCCESSFULLY!"
-echo "============================================================"
-echo "The patches have been delivered to:"
-echo "  • Jens Axboe <$AXBOE_CC>"
-echo "  • $LKML_TO"
-echo "  • $LKML_CC"
-echo ""
-echo "Check your inbox at $SENDER_EMAIL for the incoming delivery receipt."
+    echo ""
+    echo "============================================================"
+    echo "  ✅ LKML PATCHSET SENT SUCCESSFULLY!"
+    echo "============================================================"
+    echo "The patches have been delivered to:"
+    echo "  • Jens Axboe <$AXBOE_CC>"
+    echo "  • $LKML_TO"
+    echo "  • $LKML_CC"
+    echo ""
+    echo "Check your inbox at $SENDER_EMAIL for the incoming delivery receipt."
+fi


### PR DESCRIPTION
## Summary
Adds a `--dry-run` flag to `scripts/package/send-lkml-patchset.sh` to display recipients and patch summary without sending emails. This implements fail-fast verification and adheres to semantic error returns (exit 64) for missing credentials.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| f1731d22e4a577eacc16f94c4957b1f55b6c4d38 | Add --dry-run flag and semantic exit code | To allow safe pre-flight verification without triggering side effects | Implements parameter check for `--dry-run`, bypasses credential prompts and email dispatch if set, prints exact recipients and patches to be sent, updates missing password exit code to sysexits EX_USAGE (64) |

## Issue
OpsInfra100/2026-09-06/packaging/086

## Owner
jules

## Labels
type:packaging, area:scripts

## Validation
shellcheck scripts/package/send-lkml-patchset.sh

## Rollback trigger
Revert if patch application fails or shellcheck returns errors in CI/CD pipeline.

---
*PR created automatically by Jules for task [2493694344083352015](https://jules.google.com/task/2493694344083352015) started by @emersonbusson*