### PR TITLE
feat(scripts): add guard checks to swap compare script

### DIFF
--- a/scripts/p0/measure-swap-compare.sh
+++ b/scripts/p0/measure-swap-compare.sh
@@ -8,12 +8,48 @@
 #   <alvo> = caminho de arquivo (NVMe) ou /dev/nbdX (VRAM-swap). Se for arquivo, é criado/apagado.
 set -euo pipefail
 
-TARGET="${1:?alvo (arquivo ou block device) requerido}"
+if [ "$#" -lt 1 ]; then
+    echo "Error: alvo (arquivo ou block device) requerido" >&2
+    exit 64
+fi
+
+TARGET="$1"
 LABEL="${2:-$TARGET}"
 SIZE="${3:-256M}"
 RT="${4:-12}"
 
-command -v fio >/dev/null || { echo "fio ausente" >&2; exit 2; }
+command -v fio >/dev/null || { echo "fio ausente" >&2; exit 69; }
+command -v swapon >/dev/null || { echo "swapon ausente" >&2; exit 69; }
+
+# Guard check that both baseline and comparison swap devices are configured and active.
+if [ "$(swapon --show --noheadings | wc -l)" -lt 2 ]; then
+    echo "Error: Both baseline and comparison swap devices must be configured and active." >&2
+    exit 78
+fi
+
+# Sanity Checks
+if [ ! -b "$TARGET" ]; then
+    target_dir="$(dirname "$TARGET")"
+    if [ ! -d "$target_dir" ]; then
+        echo "Error: Directory for target file does not exist: $target_dir" >&2
+        exit 74
+    fi
+fi
+
+if ! [[ "$RT" =~ ^[0-9]+$ ]]; then
+    echo "Error: Runtime must be numeric: $RT" >&2
+    exit 64
+fi
+
+if [ "$RT" -eq 0 ] || [ "$RT" -gt 86400 ]; then
+    echo "Error: Runtime out of physical bounds (1-86400): $RT" >&2
+    exit 64
+fi
+
+if ! [[ "$SIZE" =~ ^[0-9]+[KMGkmg]?$ ]]; then
+    echo "Error: Invalid size format: $SIZE" >&2
+    exit 64
+fi
 
 IS_FILE=0
 [ -b "$TARGET" ] || IS_FILE=1


### PR DESCRIPTION
## Summary
Added guard clauses and sanity checks to `scripts/p0/measure-swap-compare.sh` to validate that both baseline and comparison swap devices are configured and active before measurement, and to validate numeric/path inputs against physical system limits.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| b0283028550c2e0f767a3d9c058c553e2ee95790 | feat(scripts): add guard checks to swap compare script | To adhere to architectural principles for guard clauses and fast failure | Added `swapon --show --noheadings \| wc -l` check, validate numeric RT and SIZE bounds, and directory existence for files. Uses sysexits.h exit codes. |

## Issue
OpsInfra100/2026-09-06/p0-observability/093

## Owner
Jules

## Labels
type:scripts, area:p0-observability

## Validation
shellcheck scripts/p0/measure-swap-compare.sh

## Rollback trigger
Revert if fio executions are incorrectly blocked due to valid swap configurations or legitimate path inputs.

---
*PR created automatically by Jules for task [8349856775663770246](https://jules.google.com/task/8349856775663770246) started by @emersonbusson*