### PR TITLE
feat(scripts): add stress-ng check and clamp workers in measure-psi-load.sh

### DIFF
--- a/scripts/p0/measure-psi-load.sh
+++ b/scripts/p0/measure-psi-load.sh
@@ -17,10 +17,18 @@ CG=/sys/fs/cgroup/p0load
 LOG_PREFIX="[p0-load]"
 log() { echo "$LOG_PREFIX $*" >&2; }
 
-[ "$(id -u)" -eq 0 ]                                || { log "ERROR: root is required (cgroup write)"; exit 1; }
-[ "$(stat -fc %T /sys/fs/cgroup)" = cgroup2fs ]     || { log "ERROR: cgroup v2 missing"; exit 1; }
-grep -qw memory /sys/fs/cgroup/cgroup.subtree_control || { log "ERROR: memory controller not delegated"; exit 1; }
-command -v python3 >/dev/null                       || { log "ERROR: python3 missing"; exit 1; }
+[ "$(id -u)" -eq 0 ]                                || { log "ERROR: root is required (cgroup write)"; exit 69; }
+[ "$(stat -fc %T /sys/fs/cgroup)" = cgroup2fs ]     || { log "ERROR: cgroup v2 missing"; exit 69; }
+grep -qw memory /sys/fs/cgroup/cgroup.subtree_control || { log "ERROR: memory controller not delegated"; exit 78; }
+command -v python3 >/dev/null                       || { log "ERROR: python3 missing"; exit 69; }
+command -v stress-ng >/dev/null                     || { log "ERROR: stress-ng missing"; exit 69; }
+
+CORES=$(nproc 2>/dev/null || echo 1)
+WORKERS="${WORKERS:-$CORES}"
+if [ "$WORKERS" -gt "$CORES" ]; then
+	log "WARNING: requested workers ($WORKERS) exceeds available cores ($CORES). Clamping to $CORES."
+	WORKERS="$CORES"
+fi
 
 HOG=""
 cleanup() {


### PR DESCRIPTION
## Summary
Added guard clauses for stress-ng availability and clamped worker counts against physical cores using nproc.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 9bb6308b5f01679099b374b236ccf64ac4a907a2 | feat(scripts): add stress-ng check and clamp workers in measure-psi-load.sh | Validate physical limits and missing dependencies early. | Implemented guard checks using sysexits.h (69, 78) and enforced max workers using nproc. |

## Issue
None

## Owner
OpsInfra100/2026-09-06/p0-observability/098

## Labels
type:scripts, area:p0-observability

## Validation
shellcheck scripts/p0/measure-psi-load.sh

## Rollback trigger
Revert if PSI monitoring scripts fail on workload machines due to cgroup configuration or worker clamping issues.

---
*PR created automatically by Jules for task [3792770897198728378](https://jules.google.com/task/3792770897198728378) started by @emersonbusson*