### PR TITLE
feat(p0-observability): validate external GPU adapter presence and WDDM driver version

### DIFF
--- a/scripts/p0/Invoke-ExternalGpuWddmPressureAudit.ps1
+++ b/scripts/p0/Invoke-ExternalGpuWddmPressureAudit.ps1
@@ -21,10 +21,26 @@ param(
     [string]$OutDir = "ramshared-external-gpu-wddm-pressure-audit-$(Get-Date -Format yyyyMMdd-HHmmss)"
 )
 
+
 $ErrorActionPreference = "Stop"
 
+if ($PSVersionTable.Platform -eq "Win32NT") {
+    $gpu = Get-CimInstance -ClassName Win32_VideoController -ErrorAction Stop | Where-Object { $_.PNPDeviceID -match "PCI\\VEN_10DE|PCI\\VEN_1002" }
+
+    if (-not $gpu) {
+        throw [System.Management.Automation.ItemNotFoundException]::new("No external GPU adapter found via PnP device query.")
+    }
+
+    $wddmVersion = [string]($gpu | Select-Object -First 1).DriverVersion
+    $driverMajor = ([version]$wddmVersion).Major
+    if ($driverMajor -lt 27) {
+        throw [System.NotSupportedException]::new("WDDM driver version is less than 2.7. Found: $wddmVersion")
+    }
+}
+
+
 function L([string]$Message) {
-    Write-Host "[external-gpu-wddm-pressure-audit] $Message"
+    Write-Output "[external-gpu-wddm-pressure-audit] $Message"
 }
 
 function Resolve-RamsharedExe {


### PR DESCRIPTION
## Summary
Added guard check for external GPU adapter presence via PnP device query and validated WDDM driver version >= 2.7 as pre-flight checks in `Invoke-ExternalGpuWddmPressureAudit.ps1`. Replaced `Write-Host` with `Write-Output` to satisfy `PSScriptAnalyzer`.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| a0017bdc0166c71867ea6d428a3700da1d4c490d | Added guard check for GPU/WDDM and fixed Write-Host | To satisfy architecture principles and PSScriptAnalyzer | Checks for PCI\VEN_10DE or PCI\VEN_1002 and WDDM major >= 27 |

## Issue
validate external GPU adapter presence and WDDM driver version

## Owner
OpsInfra100/2026-09-06/p0-observability/097

## Labels
type:scripts, area:p0-observability

## Validation
pwsh -c 'Invoke-ScriptAnalyzer -Path scripts/p0/Invoke-ExternalGpuWddmPressureAudit.ps1'

## Rollback trigger
If the script fails to run correctly on valid GPU/WDDM configurations, triggering false positive guards.

---
*PR created automatically by Jules for task [18301582853343737856](https://jules.google.com/task/18301582853343737856) started by @emersonbusson*