### PR TITLE
feat(packaging): add wsl-kernel.sh build guard clauses

### DIFF
--- a/scripts/kernel/wsl-kernel.sh
+++ b/scripts/kernel/wsl-kernel.sh
@@ -86,6 +86,23 @@ validate_environment_contract() {
 	if [[ -n "${KERNEL_PAIR_MANIFEST:-}" ]]; then
 		assert_canonical_path "$KERNEL_PAIR_MANIFEST" KERNEL_PAIR_MANIFEST || return 1
 	fi
+	if [[ -n "${KSRC:-}" ]]; then
+		assert_canonical_path "$KSRC" KSRC || return 64
+		test -d "$KSRC" || {
+			echo 'wsl-kernel: KSRC kernel source checkout is missing' >&2
+			return 69
+		}
+		test -f "$KSRC/.config" || {
+			echo 'wsl-kernel: KSRC kernel .config is missing' >&2
+			return 78
+		}
+	fi
+	if [[ -n "${CC:-}" ]]; then
+		command -v "$CC" >/dev/null 2>&1 || {
+			echo 'wsl-kernel: cross-compilation toolchain is unavailable' >&2
+			return 69
+		}
+	fi
 }
 
 require_no_arguments() {


### PR DESCRIPTION
## Summary
Implemented clean orthogonal code to validate the WSL kernel source checkout, .config presence, and cross-compilation toolchain inside scripts/kernel/wsl-kernel.sh using robust exit codes.

## Commits table
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| ef2c2680406c4ecafc6c23d2ca1afd58df9c037a | feat(packaging): add wsl-kernel.sh build guard clauses | Added build toolchain validation to the runtime control script safely within `validate_environment_contract`. | Added checks for `$KSRC`, `$KSRC/.config`, and `$CC` with safe sysexits codes. |

## Labels
type:packaging, area:scripts

## Validation
bash scripts/kernel/test-wsl-kernel-static.sh

## Rollback trigger
Revert if validation causes false positives during apply.

---
*PR created automatically by Jules for task [275931787099428857](https://jules.google.com/task/275931787099428857) started by @emersonbusson*