### PR TITLE
docs(wsl2d): document dxgkrnl anti-bug reference as safety finding report

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -384,6 +384,16 @@
       "registeredAt": "2026-08-11T15:25:34Z"
     },
     {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "reliability",
+      "canonicalSource": "docs/reliability/GAP-REGISTER.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-08T08:35:00Z"
+    },
+    {
       "id": "reliability-evidence",
       "pattern": "docs/reliability/evidence/**/*.md",
       "owner": "reliability",

--- a/docs/jules/findings/dxgkrnl-anti-bug-reference.md
+++ b/docs/jules/findings/dxgkrnl-anti-bug-reference.md
@@ -1,0 +1,28 @@
+# Finding Report: dxgkrnl ANTI-BUG Reference Analysis
+
+## Summary
+Analysis of the item referencing `dxgkrnl ANTI-BUG` in `crates/ramshared-wsl2d/src/main.rs`.
+
+## Context & Analysis
+In `crates/ramshared-wsl2d/src/main.rs` (lines 4615 and 4789–4792):
+```rust
+    // MCL_CURRENT only: MCL_FUTURE races dxgkrnl mapping and can hang the host.
+    runtime.lock_memory(force, false)?;
+...
+// NOTE: `arm_future_lock` (arm future lock post-init) was REMOVED — had a race with the
+// asynchronous CUDA init of the worker (spawn_server_dt3_vram_with_residency), which would have
+// re-triggered the dxgkrnl kernel BUG. The ublk+vram path remains in MCL_CURRENT only.
+// See the "dxgkrnl ANTI-BUG" comment in run_ublk.
+```
+
+An automated task harvester flagged the phrase "dxgkrnl ANTI-BUG" as an uncompleted item or task. However, code analysis confirms this comment is a critical architectural safety marker that documents an intentional anti-bug fix.
+
+## Technical Details
+1. **Host Memory Locking (`mlockall`) Race**: When `mlockall` is called with `MCL_FUTURE` or when future page locks are enabled post-initialization in WSL2, the Linux kernel memory subsystem attempts to lock all present and future virtual memory mappings into physical RAM.
+2. **dxgkrnl Driver Conflict**: In WSL2 environments utilizing `dxgkrnl` (DirectX Graphics Kernel for GPU-PV), GPU memory allocations and VMBus page mappings occur asynchronously. `MCL_FUTURE` races against these driver mappings, triggering a kernel BUG panic at `drivers/hv/dxgkrnl/dxgvmbus.c` and causing the host VM to freeze.
+3. **Safety Invariant**: To prevent kernel BUG crashes, the `ublk+vram` daemon path strictly uses `MCL_CURRENT` memory locking only. The deferred `arm_future_lock` mechanism was deliberately removed to guarantee host stability.
+
+## Conclusion & Recommendation
+No code modifications should be made. The comment is an anti-bug safety reference protecting against kernel crashes, not an uncompleted feature. Modifying this logic or attempting to re-enable `MCL_FUTURE` would violate system invariants and reintroduce host freezes.
+
+This finding artifact (`FINDING_ONLY`) satisfies the smallest safe orthogonal slice rule.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 274,
+    "classified": 271,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,18 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/dxgkrnl-anti-bug-reference.md",
+      "disposition": "classified",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "reliability",
+      "canonicalSource": "docs/reliability/GAP-REGISTER.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Summary
Documents the dxgkrnl anti-bug reference in `crates/ramshared-wsl2d/src/main.rs` as a safety finding report (`FINDING_ONLY`) rather than an uncompleted task.

## Commits
| Commit | What was done | Why it was done | Details |
| 156355c4427b6e00321ebc68c7de9288dbf72e09 | Document dxgkrnl anti-bug reference | Prevent unsafe code modifications to mlockall safety invariant | <details><summary>Details</summary>Recorded finding in docs/jules/findings/dxgkrnl-anti-bug-reference.md</details> |

## Issue
Resolves #1207

## Owner
@emersonbusson

## Labels
type:docs, area:documentation

## Validation
cat docs/jules/findings/dxgkrnl-anti-bug-reference.md

## Rollback trigger
N/A (FINDING_ONLY documentation artifact)

---
*PR created automatically by Jules for task [10413730772236288609](https://jules.google.com/task/10413730772236288609) started by @emersonbusson*