### PR TITLE
docs: document past swap dropping under load bug in residency sampler

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -492,6 +492,16 @@
       "freshnessDays": 90,
       "verification": { "state": "unverified" },
       "registeredAt": "2026-09-06T12:00:00Z"
+    },
+    {
+      "id": "agent-findings-documents",
+      "pattern": "docs/jules/findings/**/*.md",
+      "owner": "documentation-governance",
+      "canonicalSource": "docs/DOCUMENTATION-PARITY.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null,
+      "verification": { "state": "unverified" },
+      "registeredAt": "2026-09-08T08:45:00Z"
     }
   ],
   "exclusions": [

--- a/docs/jules/findings/swap-dropping-under-load.md
+++ b/docs/jules/findings/swap-dropping-under-load.md
@@ -1,0 +1,13 @@
+# Finding: Swap dropping under load (e2e civm bug)
+
+## Context & Analysis
+The comment in `crates/ramshared-wsl2d/src/residency.rs` at line 171 refers to a historical bug and calibration context:
+```rust
+// With 8× this triggered and dropped the swap under load (e2e civm bug); with 64×, it remains Ok.
+```
+
+## Finding Summary
+1. **Historical Context**: In earlier tuning (DT-31), a 8× baseline multiplier for canary latency detection caused false positive triggers when serving latency reached ~17× baseline under heavy end-to-end civm load. This caused the residency canary to incorrectly signal `DemoteReason::Latency` and drop swap under load.
+2. **Current Implementation**: The parameter `latency_mult` in `ResidencyConfig` default was updated to 64× (well above 17× load latency spikes and well below 330× WDDM eviction spikes).
+3. **Verification**: The unit test `load_spike_below_threshold_stays_ok` in `crates/ramshared-wsl2d/src/residency.rs` explicitly tests and validates this behavior, ensuring that 17× load spikes remain `Verdict::Ok` and do not drop swap.
+4. **Action**: The issue describes historical context rather than an active bug requiring code changes. Aborting unsafe modifications per orthogonal slice rules, generating this finding artifact.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,8 +2,8 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
-    "classified": 270,
+    "total": 274,
+    "classified": 271,
     "excluded": 3,
     "unclassified": 0,
     "ambiguous": 0
@@ -784,6 +784,18 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/swap-dropping-under-load.md",
+      "disposition": "classified",
+      "ruleId": "agent-findings-documents",
+      "verification": {
+        "state": "unverified"
+      },
+      "owner": "documentation-governance",
+      "canonicalSource": "docs/DOCUMENTATION-PARITY.md",
+      "lifecycle": "immutable",
+      "freshnessDays": null
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
Document finding regarding historical e2e civm swap dropping under load bug in residency.rs.

---
*PR created automatically by Jules for task [16158099857841477003](https://jules.google.com/task/16158099857841477003) started by @emersonbusson*