### PR TITLE
docs: add FINDING_ONLY report for bug C1 transient eviction comment

### DIFF
--- a/docs/jules/findings/transient-eviction-bug-comment.md
+++ b/docs/jules/findings/transient-eviction-bug-comment.md
@@ -1,0 +1,13 @@
+# Finding Report: Bug C1 Transient Eviction Comment
+
+## Overview
+- **File**: `crates/ramshared-wsl2d/src/broker_srv.rs:811`
+- **Context**: `// a transient eviction (1-2 DEMOTEs) and the eviction signal would never appear (bug C1).`
+
+## Analysis
+The comment in `crates/ramshared-wsl2d/src/broker_srv.rs` at line 811 refers to historical bug C1, where hysteresis logic in the reconciliation engine previously swallowed transient eviction events (1-2 `DEMOTE` signals). The code surrounding this comment implements the fix for bug C1, ensuring that `ReconcileFlag::Eviction` bypasses hysteresis and receives immediate confirmation.
+
+As noted in the task rationale, this comment documents historical architectural context for why eviction events bypass hysteresis, rather than indicating an unresolved bug or actionable code deficiency.
+
+## Decision
+Pursuant to repository rules regarding FINDING_ONLY reports for historical bug references and non-actionable comment items, no code modification is required in `broker_srv.rs`. This finding report documents the contextual analysis and verifies that the bug C1 mitigation is functioning as designed in the codebase.


### PR DESCRIPTION
This PR produces a FINDING_ONLY report for a comment in `crates/ramshared-wsl2d/src/broker_srv.rs:811` referencing historical bug C1. The comment documents why transient eviction bypasses hysteresis in the broker core reconciliation engine and is non-actionable context rather than a bug.

---
*PR created automatically by Jules for task [6730376614460328117](https://jules.google.com/task/6730376614460328117) started by @emersonbusson*