### PR TITLE
🧪 test(winsvc): add test coverage for connect_status_pipe and retry_until

### DIFF
--- a/crates/ramshared-winsvc/src/ipc.rs
+++ b/crates/ramshared-winsvc/src/ipc.rs
@@ -245,11 +245,45 @@ mod tests {
     }
     #[cfg(windows)]
     #[test]
+    fn connect_status_pipe_with_future_deadline_times_out() {
+        let deadline = Instant::now() + Duration::from_millis(10);
+        let result = NamedPipeBrokerStream::connect_status_pipe(deadline);
+        assert!(matches!(
+            result,
+            Err(BrokerConnectError::Deadline) | Err(BrokerConnectError::NonTransient(_))
+        ));
+    }
+    #[cfg(windows)]
+    #[test]
     fn connect_status_pipe_deadline_stops_retry() {
         let result = NamedPipeBrokerStream::connect_status_pipe(Instant::now());
         assert!(matches!(
             result,
             Err(BrokerConnectError::Deadline) | Err(BrokerConnectError::NonTransient(_))
         ));
+    }
+    #[test]
+    fn retry_until_non_transient_error() {
+        let result = retry_until(Instant::now(), || Err(5));
+        assert_eq!(result, Err(BrokerConnectError::NonTransient(5)));
+    }
+    #[test]
+    fn retry_until_success_first_try() {
+        let result = retry_until(Instant::now(), || Ok(()));
+        assert_eq!(result, Ok(()));
+    }
+    #[test]
+    fn retry_until_transient_then_success() {
+        let mut attempts = 0;
+        let result = retry_until(Instant::now() + Duration::from_secs(1), || {
+            attempts += 1;
+            if attempts == 1 {
+                Err(2)
+            } else {
+                Ok(())
+            }
+        });
+        assert_eq!(result, Ok(()));
+        assert_eq!(attempts, 2);
     }
 }


### PR DESCRIPTION
🎯 **What:** Improved unit test coverage for `connect_status_pipe` and underlying `retry_until` IPC helper logic in `crates/ramshared-winsvc/src/ipc.rs`.

📊 **Coverage:**
- `connect_status_pipe` connection with future deadline timeout and error handling.
- `retry_until` handling for non-transient error codes (returns `Err(BrokerConnectError::NonTransient)` immediately).
- `retry_until` handling for immediate success on first try.
- `retry_until` recovery on transient error retries.

✨ **Result:** Increased test coverage and verification of IPC broker pipe connection behavior in `ramshared-winsvc`.

---
*PR created automatically by Jules for task [13317142467132089498](https://jules.google.com/task/13317142467132089498) started by @emersonbusson*