### PR TITLE
🧪 test(winsvc): add unit test coverage for lock_product_volume_path

### DIFF
--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1293,13 +1293,40 @@ mod tests {
         let err = WindowsHostState::lock_product_volume_path(r"\\.\E:", 'D', None).unwrap_err();
         assert!(err.to_string().contains("invalid volume device path"));
 
+        let err = WindowsHostState::lock_product_volume_path(
+            r"Volume{00000000-0000-0000-0000-000000000000}",
+            'D',
+            None,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("invalid volume device path"));
+
+        let err = WindowsHostState::lock_product_volume_path(
+            r"\\?\Volume{00000000-0000-0000-0000-000000000000",
+            'D',
+            None,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("invalid volume device path"));
+
         let err = WindowsHostState::lock_product_volume_path(r"\\.\D:", 'd', None).unwrap_err();
+        assert!(err.to_string().contains("volume"));
+
+        let err = WindowsHostState::lock_product_volume_path(r"\\.\D:", 'D', Some(1)).unwrap_err();
         assert!(err.to_string().contains("volume"));
 
         let err = WindowsHostState::lock_product_volume_path(
             r"\\?\Volume{00000000-0000-0000-0000-000000000000}",
             'D',
             None,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("volume"));
+
+        let err = WindowsHostState::lock_product_volume_path(
+            r"\\?\Volume{00000000-0000-0000-0000-000000000000}",
+            'E',
+            Some(2),
         )
         .unwrap_err();
         assert!(err.to_string().contains("volume"));


### PR DESCRIPTION
🎯 **What:** Extended unit test coverage for `lock_product_volume_path` in `crates/ramshared-winsvc/src/windows_host.rs`.
📊 **Coverage:** Added test assertions for volume GUID validation (missing `\\?\` prefix or missing trailing `}`) and disk number parameter matching.
✨ **Result:** Increased reliability and full coverage of path validation edge cases for `lock_product_volume_path`.

---
*PR created automatically by Jules for task [2324665885656368803](https://jules.google.com/task/2324665885656368803) started by @emersonbusson*