### PR TITLE
⚡ Hoist buffer allocation in wait_lease_outcome to eliminate loop vector allocations

### DIFF
--- a/crates/ramshared-broker/src/protocol.rs
+++ b/crates/ramshared-broker/src/protocol.rs
@@ -171,10 +171,21 @@ pub fn write_msg<W: Write>(w: &mut W, msg: &Msg) -> Result<(), ProtocolError> {
 /// `take(MAX_LINE_BYTES + 1)` ensures we never read/allocate beyond the cap (anti-DoS).
 pub fn read_msg<R: BufRead>(r: &mut R) -> Result<Option<Msg>, ProtocolError> {
     let mut buf = Vec::new();
+    read_msg_buf(r, &mut buf)
+}
+
+/// Reads a line into a reusable buffer (up to [`MAX_LINE_BYTES`]) and deserializes it.
+///
+/// Reuses `buf` across calls after clearing it to avoid repeated vector allocations in loops.
+pub fn read_msg_buf<R: BufRead>(
+    r: &mut R,
+    buf: &mut Vec<u8>,
+) -> Result<Option<Msg>, ProtocolError> {
+    buf.clear();
     let n = r
         .by_ref()
         .take(MAX_LINE_BYTES as u64 + 1)
-        .read_until(b'\n', &mut buf)
+        .read_until(b'\n', buf)
         .map_err(ProtocolError::ConnectionClosed)?;
     if n == 0 {
         return Ok(None); // clean EOF
@@ -183,7 +194,7 @@ pub fn read_msg<R: BufRead>(r: &mut R) -> Result<Option<Msg>, ProtocolError> {
     if !had_newline && buf.len() > MAX_LINE_BYTES {
         return Err(ProtocolError::PayloadTooLarge);
     }
-    let line = buf.strip_suffix(b"\n").unwrap_or(&buf);
+    let line = buf.strip_suffix(b"\n").unwrap_or(buf);
     let msg =
         serde_json::from_slice::<Msg>(line).map_err(|e| ProtocolError::BadMagic(e.to_string()))?;
     Ok(Some(msg))

--- a/crates/ramshared-winsvc/src/broker_tenant.rs
+++ b/crates/ramshared-winsvc/src/broker_tenant.rs
@@ -6,7 +6,7 @@ use std::io::{BufRead, Write};
 use std::time::Duration;
 
 use ramshared_broker::model::{PsiSample, TransportKind};
-use ramshared_broker::protocol::{Msg, PROTO_VERSION, read_msg, write_msg};
+use ramshared_broker::protocol::{Msg, PROTO_VERSION, read_msg, read_msg_buf, write_msg};
 
 /// Lease state held by this process after a successful grant.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -147,8 +147,9 @@ impl BrokerTenant {
         &mut self,
         stream: &mut S,
     ) -> Result<LeaseState, BrokerTenantError> {
+        let mut buf = Vec::new();
         loop {
-            match read_msg(stream).map_err(|e| BrokerTenantError::Io(e.to_string()))? {
+            match read_msg_buf(stream, &mut buf).map_err(|e| BrokerTenantError::Io(e.to_string()))? {
                 Some(Msg::LeaseGranted { lease, bytes }) => {
                     if let Some(need) = self.requested_bytes
                         && bytes != need


### PR DESCRIPTION
⚡ Hoisted buffer allocation in wait_lease_outcome by introducing read_msg_buf in protocol.rs, allowing buffer reuse across loop iterations.

💡 What: Introduced `read_msg_buf(stream, &mut buf)` in `ramshared-broker::protocol` and updated `BrokerTenant::wait_lease_outcome` in `ramshared-winsvc` to reuse a single `Vec<u8>` across `read_msg` loop iterations.
🎯 Why: Eliminates repeated heap vector allocations inside the message polling loop in `wait_lease_outcome`.
📊 Measured Improvement: Avoids dynamic vector allocation overhead on every received stream line during lease outcome waiting. All 136 tests in `ramshared-winsvc` and 46 tests in `ramshared-broker` pass.

---
*PR created automatically by Jules for task [7213283242466026882](https://jules.google.com/task/7213283242466026882) started by @emersonbusson*