### PR TITLE
docs: record FINDING_ONLY report for historical broker cross-host CIVM note

### DIFF
--- a/docs/jules/findings/broker-cross-host-civm-historical-note.md
+++ b/docs/jules/findings/broker-cross-host-civm-historical-note.md
@@ -1,0 +1,22 @@
+# Finding: Broker Cross-Host CIVM Historical Note Verification
+
+## Overview
+- **File:** `crates/ramshared-wsl2d/src/broker_srv.rs`
+- **Line:** 986
+- **Classification:** `FINDING_ONLY`
+
+## Context
+The task references a comment in `crates/ramshared-wsl2d/src/broker_srv.rs`:
+```rust
+    // message rate. (Bug caught in e2e cross-host civm; the QEMU drill passed by luck of timing.)
+```
+
+## Analysis
+1. The comment in `broker_srv.rs` describes a historical race condition during cross-host testing where arbiter ticks were starved by message loops when `recv_timeout(tick)` was used without wall-clock deadline tracking.
+2. The core loop logic in `broker_srv.rs` already calculates `let wait = next_tick.saturating_duration_since(Instant::now());` and enforces wall-clock deadline expiration regardless of message volume.
+3. This behavior is fully verified and covered by the regression test `e2e_psi_flood_does_not_starve_arbiter_tick` in `crates/ramshared-wsl2d/tests/broker_e2e.rs`.
+4. As noted in the task rationale, this comment is an informative historical note rather than an outstanding bug or actionable code defect.
+5. Making code modifications to code that is already working and fully tested would introduce unnecessary risk and violate the principle of smallest safe orthogonal slice.
+
+## Conclusion
+No code changes are required. This finding serves as architectural verification of the existing tick-deadline implementation in `broker_srv.rs`.


### PR DESCRIPTION
Produces a FINDING_ONLY documentation report verifying that the historical broker cross-host CIVM comment in broker_srv.rs is an informative note and that existing code already handles wall-clock deadlines correctly.

---
*PR created automatically by Jules for task [3206735792037157276](https://jules.google.com/task/3206735792037157276) started by @emersonbusson*