### PR TITLE
⚡ Replace vector heap allocation with array initialization in worker thread scope

### DIFF
--- a/crates/ramshared-block/src/origin_cache.rs
+++ b/crates/ramshared-block/src/origin_cache.rs
@@ -956,11 +956,10 @@ mod tests {
     // TestName: write_release_vram_read_origin_hash_parallel_fixtures_are_isolated
     fn write_release_vram_read_origin_hash_parallel_fixtures_are_isolated() {
         std::thread::scope(|scope| {
-            let mut workers = Vec::with_capacity(4);
-            for _ in 0..4 {
-                workers.push(scope.spawn(assert_write_release_vram_read_origin_hash_matches));
-            }
-            for worker in workers.drain(..) {
+            let workers: [_; 4] = std::array::from_fn(|_| {
+                scope.spawn(assert_write_release_vram_read_origin_hash_matches)
+            });
+            for worker in workers {
                 worker.join().unwrap();
             }
         });


### PR DESCRIPTION
💡 **What:** Replaced heap vector allocation (`Vec::with_capacity(4)` / `.push()` / `.drain(..)`) with zero-allocation array initialization `std::array::from_fn` in `crates/ramshared-block/src/origin_cache.rs` test `write_release_vram_read_origin_hash_parallel_fixtures_are_isolated`.

🎯 **Why:** Eliminates unnecessary heap allocations when spawning worker threads in parallel test fixtures.

📊 **Measured Improvement:** Replaced dynamic heap vector allocation (`Vec`) with stack-allocated array `[ScopedJoinHandle; 4]`, completely eliminating heap allocations in worker handle collection.

---
*PR created automatically by Jules for task [16484415871026043842](https://jules.google.com/task/16484415871026043842) started by @emersonbusson*