### PR TITLE
🧹 Replace unwrap() calls with expect() in origin_cache test helper

### DIFF
--- a/crates/ramshared-block/src/origin_cache.rs
+++ b/crates/ramshared-block/src/origin_cache.rs
@@ -920,11 +920,15 @@ mod tests {
         events.borrow_mut().clear();
 
         let payload = *b"cache-origin-round-trip-proof-32";
-        backend.write_at(0, &payload).unwrap();
+        backend
+            .write_at(0, &payload)
+            .expect("write_at should succeed");
         assert_eq!(backend.release_cache(), 8);
 
         let mut read_back = [0; 32];
-        backend.read_at(0, &mut read_back).unwrap();
+        backend
+            .read_at(0, &mut read_back)
+            .expect("read_at should succeed");
         assert_eq!(read_back, payload);
         assert_eq!(backend.telemetry().fallback_reads, 1);
         assert_eq!(


### PR DESCRIPTION
🎯 **What:** Replaced bare `unwrap()` calls in `assert_write_release_vram_read_origin_hash_matches` with descriptive `.expect()` failure messages in `crates/ramshared-block/src/origin_cache.rs`.
💡 **Why:** Replaces bare panics with context-rich error messages, improving test maintainability and debugging clarity.
✅ **Verification:** Verified via `cargo test -p ramshared-block`, all 82 tests passed cleanly.
✨ **Result:** Improved code health and diagnostic messages in tests without changing runtime behavior.

---
*PR created automatically by Jules for task [14897471910863865548](https://jules.google.com/task/14897471910863865548) started by @emersonbusson*