### PR TITLE
🧪 test(winsvc): add unit test for lock_product_volume

### DIFF
--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1199,6 +1199,19 @@ mod tests {
     }
 
     #[test]
+    fn lock_product_volume_validates_range_and_case() {
+        for bad in ['a', 'b', 'c', '@', '1', '['] {
+            let err = WindowsHostState::lock_product_volume(bad, None).unwrap_err();
+            assert!(matches!(err, HostError::Volume(msg) if msg.contains("letter must be D..=Z")));
+        }
+
+        for valid in ['d', 'D', 'z', 'Z'] {
+            let err = WindowsHostState::lock_product_volume(valid, Some(1)).unwrap_err();
+            assert!(matches!(err, HostError::Volume(_)));
+        }
+    }
+
+    #[test]
     fn read_owned_config_rejects_relative_path() {
         let err = WindowsHostState::read_owned_config(Path::new("relative/path/winsvc.toml"))
             .unwrap_err();


### PR DESCRIPTION
## Summary
Adds a unit test `lock_product_volume_validates_range_and_case` to `crates/ramshared-winsvc/src/windows_host.rs` covering drive letter validation and handling in `WindowsHostState::lock_product_volume`.

## Commits

| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| `e25d21f0e5d236532bcb9712cc47214d8fd851e4` | Add unit test for `lock_product_volume` | Cover volume letter validation for `lock_product_volume` in `windows_host.rs` | <details><summary>details</summary>**Files:** `crates/ramshared-winsvc/src/windows_host.rs`<br>**Validation:** `cargo test -p ramshared-winsvc`<br>**Risk/rollback:** Revert commit if regression occurs</details> |

## Issue

Closes #410

## Owner

@jules

## Labels

type:test, area:winsvc

## Validation

cargo test -p ramshared-winsvc

## Rollback trigger

Revert commit if unit tests in `ramshared-winsvc` fail.

---
*PR created automatically by Jules for task [2400611809675672106](https://jules.google.com/task/2400611809675672106) started by @emersonbusson*