### PR TITLE
🧹 replace unwrap with expect in origin_cache test helper

### DIFF
--- a/crates/ramshared-block/src/origin_cache.rs
+++ b/crates/ramshared-block/src/origin_cache.rs
@@ -920,11 +920,15 @@ mod tests {
         events.borrow_mut().clear();
 
         let payload = *b"cache-origin-round-trip-proof-32";
-        backend.write_at(0, &payload).unwrap();
+        backend
+            .write_at(0, &payload)
+            .expect("write_at payload should succeed");
         assert_eq!(backend.release_cache(), 8);
 
         let mut read_back = [0; 32];
-        backend.read_at(0, &mut read_back).unwrap();
+        backend
+            .read_at(0, &mut read_back)
+            .expect("read_at payload should succeed");
         assert_eq!(read_back, payload);
         assert_eq!(backend.telemetry().fallback_reads, 1);
         assert_eq!(


### PR DESCRIPTION
🎯 **What:** Replaced unsafe unwrap() calls in `assert_write_release_vram_read_origin_hash_matches` in `crates/ramshared-block/src/origin_cache.rs` with `.expect()` calls providing clear failure context.
💡 **Why:** Provides clear error diagnostics if a test fails during backend read or write operations, improving codebase test health and maintainability.
✅ **Verification:** Verified by running `cargo test -p ramshared-block`. All 82 tests pass.
✨ **Result:** Improved test code quality and maintainability without changing runtime behavior.

---
*PR created automatically by Jules for task [1340420621752868227](https://jules.google.com/task/1340420621752868227) started by @emersonbusson*