### PR TITLE
🧪 test(winsvc): expand test coverage for observe_volume_identity

### DIFF
--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1361,11 +1361,24 @@ mod tests {
 
     #[test]
     fn observe_volume_identity_invalid_letter_rejected() {
-        let err = WindowsHostState::observe_volume_identity('C').unwrap_err();
-        assert!(matches!(err, HostError::Volume(msg) if msg.contains("letter must be D..=Z")));
+        for bad_letter in ['A', 'a', 'B', 'b', 'C', 'c', '@', '[', '1', ' ', '{'] {
+            let err = WindowsHostState::observe_volume_identity(bad_letter).unwrap_err();
+            assert!(
+                matches!(err, HostError::Volume(msg) if msg.contains("letter must be D..=Z")),
+                "expected rejection for letter {bad_letter}"
+            );
+        }
+    }
 
-        let err = WindowsHostState::observe_volume_identity('A').unwrap_err();
-        assert!(matches!(err, HostError::Volume(msg) if msg.contains("letter must be D..=Z")));
+    #[test]
+    fn observe_volume_identity_valid_letter_proceeds_to_execution() {
+        for valid_letter in ['D', 'd', 'M', 'm', 'Z', 'z'] {
+            let res = WindowsHostState::observe_volume_identity(valid_letter);
+            assert!(
+                matches!(res, Err(HostError::Identity(_))) || res.is_ok(),
+                "expected valid letter {valid_letter} to pass volume letter validation"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
🎯 **What:** Expanded unit test coverage for `WindowsHostState::observe_volume_identity` in `crates/ramshared-winsvc/src/windows_host.rs`.
📊 **Coverage:** Covered parameter validation boundaries for drive letters (`A..=Z`), testing invalid drive letters across uppercase, lowercase, numbers, and symbols, and verifying valid drive letters pass drive letter validation and proceed to execution.
✨ **Result:** Increased test coverage and validation confidence for Windows volume identity observation.

---
*PR created automatically by Jules for task [15345475272032290870](https://jules.google.com/task/15345475272032290870) started by @emersonbusson*