### PR TITLE
🧪 test(winsvc): add unit test assertion for flush_and_dismount error formatting

### DIFF
--- a/crates/ramshared-winsvc/src/windows_host.rs
+++ b/crates/ramshared-winsvc/src/windows_host.rs
@@ -1283,6 +1283,7 @@ mod tests {
         let err = WindowsHostState::flush_and_dismount(&vol).unwrap_err();
         assert!(matches!(err, HostError::Volume(_)));
         assert!(err.to_string().contains("FlushFileBuffers"));
+        assert!(err.to_string().contains("volume:"));
     }
 
     #[test]


### PR DESCRIPTION
🎯 **What:** Adds unit test assertions for `WindowsHostState::flush_and_dismount` in `crates/ramshared-winsvc/src/windows_host.rs`.
📊 **Coverage:** Verifies `HostError::Volume` error variant and message formatting under invalid volume handle condition.
✨ **Result:** Improved test reliability and explicit error message validation for volume dismount error paths.

---
*PR created automatically by Jules for task [11640385205650921808](https://jules.google.com/task/11640385205650921808) started by @emersonbusson*