### PR TITLE
🧹 [code health] document FINDING_ONLY report for IdentityFailGates panic audit

### DIFF
--- a/docs/jules/findings/finding-identity-fail-gates-panic-audit.md
+++ b/docs/jules/findings/finding-identity-fail-gates-panic-audit.md
@@ -1,0 +1,14 @@
+# FINDING_ONLY: Audit of IdentityFailGates Panic Safety in service.rs
+
+## Executive Summary
+An audit was performed on `crates/ramshared-winsvc/src/service.rs` regarding reported `panic!()` calls in `IdentityFailGates` (`lock_volume` and `flush_and_dismount`).
+
+## Audit Findings
+1. Inspection of `crates/ramshared-winsvc/src/service.rs` confirms that `IdentityFailGates` implementation of `PagefileGates` handles all failure cases by returning `Result::Err(String)`:
+   - `lock_volume`: returns `Err("volume lock must not run after identity refusal".into())`
+   - `flush_and_dismount`: returns `Err("dismount must not run after identity refusal".into())`
+2. No active `panic!()` calls exist in production paths or in `IdentityFailGates` within `crates/ramshared-winsvc/src/service.rs`.
+3. The codebase already adheres to panic safety and error propagation standards for `PagefileGates`.
+
+## Conclusion
+No code changes are required as the issue is already resolved in the current codebase.


### PR DESCRIPTION
This PR produces a FINDING_ONLY report confirming that `crates/ramshared-winsvc/src/service.rs` already properly returns `Err` instead of calling `panic!()` in `IdentityFailGates`.

---
*PR created automatically by Jules for task [18234329508240786441](https://jules.google.com/task/18234329508240786441) started by @emersonbusson*