### PR TITLE
⚡ perf(cli): optimize reservation creation by eliminating redundant string clones

### DIFF
--- a/crates/ramshared-cli/src/workload.rs
+++ b/crates/ramshared-cli/src/workload.rs
@@ -1081,12 +1081,13 @@ fn acquire_reservation_at(
         .next_ordinal
         .checked_add(1)
         .ok_or("reservation ordinal sequence exhausted")?;
+    let unit = format!("ramshared-{}-{}.scope", class.as_str(), id);
     let reservation = Reservation {
-        id: id.clone(),
+        id,
         owner,
         class,
         memory_bytes,
-        unit: format!("ramshared-{}-{}.scope", class.as_str(), id),
+        unit,
         invocation_id: None,
         issued_ordinal,
     };
@@ -1138,12 +1139,13 @@ fn admit_reservation_at(
         .next_ordinal
         .checked_add(1)
         .ok_or("reservation ordinal sequence exhausted")?;
+    let unit = format!("ramshared-{}-{}.scope", class.as_str(), id);
     let reservation = Reservation {
-        id: id.clone(),
+        id,
         owner,
         class,
         memory_bytes,
-        unit: format!("ramshared-{}-{}.scope", class.as_str(), id),
+        unit,
         invocation_id: None,
         issued_ordinal,
     };
@@ -1942,9 +1944,11 @@ mod tests {
             _command: &[String],
         ) -> Result<Box<dyn ScopeExecution>, String> {
             *self.calls.borrow_mut() += 1;
+            let ledger_root = Arc::clone(&self.ledger_root);
+            let supervisor = Arc::clone(&self.supervisor);
             Ok(Box::new(TransitionBlockingExecution {
-                ledger_root: Arc::clone(&self.ledger_root),
-                supervisor: Arc::clone(&self.supervisor),
+                ledger_root,
+                supervisor,
             }))
         }
     }


### PR DESCRIPTION
## Summary
Optimized reservation creation in `crates/ramshared-cli/src/workload.rs` by formatting the unit string prior to `Reservation` construction, eliminating redundant `id.clone()` allocations during workload admission.

## Issue
Unnecessary clone in workload reservation path.

## Owner
`cli-performance`

## Labels
`type:performance`, `area:cli`

## Validation
umask 0022 && cargo test -p ramshared-cli

## Rollback trigger
Any regression in workload reservation handling or test failures.

---
*PR created automatically by Jules for task [14093069863589816531](https://jules.google.com/task/14093069863589816531) started by @emersonbusson*