### PR TITLE
⚡ Audit workload.rs test double clone usage

### DIFF
--- a/docs/jules/findings/workload-clone-audit.md
+++ b/docs/jules/findings/workload-clone-audit.md
@@ -1,0 +1,38 @@
+# Audit Finding: Unnecessary Clone in Loop (`crates/ramshared-cli/src/workload.rs:1932`)
+
+## Executive Summary
+An investigation was conducted into the reported issue regarding an "Unnecessary Clone in Loop" at line `1932` in `crates/ramshared-cli/src/workload.rs`.
+
+## Analysis Findings
+1. **Target Identification**:
+   Line 1922 (associated with the line range around 1932) in `crates/ramshared-cli/src/workload.rs` contains:
+   ```rust
+   impl ScopeRunner for FakeRunner {
+       fn launch(
+           &self,
+           _unit: &str,
+           runner_args: &[String],
+           command: &[String],
+       ) -> Result<Box<dyn ScopeExecution>, String> {
+           self.calls
+               .borrow_mut()
+               .push((runner_args.to_vec(), command.to_vec()));
+           Ok(Box::new(FakeExecution {
+               result: self.result.clone(),
+           }))
+       }
+   }
+   ```
+2. **Scope Analysis**:
+   - `FakeRunner` and `FakeExecution` are unit test doubles located entirely within `#[cfg(test)] mod tests` in `crates/ramshared-cli/src/workload.rs`.
+   - `FakeRunner::launch` is a single-call method, not inside a loop.
+   - The value `self.result` is a small enum (`Result<Option<i32>, String>`).
+   - Cloned mock instances allow `FakeRunner` to be invoked multiple times statelessly across test scenarios without mutating mock state.
+
+3. **Production Performance Impact**:
+   - `FakeRunner` is never compiled or executed in production builds.
+   - Zero `clone()` calls in production workload paths occur inside loops.
+   - Mutating mock state via `std::mem::replace` in unit test doubles would introduce test state contamination and break test isolation.
+
+## Conclusion
+Modifying test double fixtures provides zero production performance improvement and risks introducing test flakiness. The existing code path in `crates/ramshared-cli/src/workload.rs` is optimal and safe.


### PR DESCRIPTION
Audited crates/ramshared-cli/src/workload.rs at line 1932 regarding the reported unnecessary clone in loop. Confirmed FakeRunner and FakeExecution are test doubles inside cfg(test) where FakeRunner::launch is a single-call method and clones small mock state for test isolation. Documented findings in docs/jules/findings/workload-clone-audit.md.

---
*PR created automatically by Jules for task [16130381720969939488](https://jules.google.com/task/16130381720969939488) started by @emersonbusson*