### PR TITLE
🧹 [code health] document safe channel error handling in cache_read_with_reply

### DIFF
--- a/crates/ramshared-block/src/isolated_origin.rs
+++ b/crates/ramshared-block/src/isolated_origin.rs
@@ -694,6 +694,7 @@ mod tests {
         drop(worker);
     }
 
+    /// Safely handles channel requests without panicking or unwrapping on channel errors.
     fn cache_read_with_reply(reply: Result<Option<Vec<u8>>, String>) -> (CacheRead, CacheState) {
         let (mut cache, worker) = isolated_cache_channel(1, Duration::from_millis(100));
         let worker = std::thread::spawn(move || {


### PR DESCRIPTION
Document safe non-panicking channel request handling in cache_read_with_reply in crates/ramshared-block/src/isolated_origin.rs.

---
*PR created automatically by Jules for task [5537671056123617633](https://jules.google.com/task/5537671056123617633) started by @emersonbusson*