### PR TITLE
🧹 [code health] assert msg deserialization in with_reply test helper

### DIFF
--- a/crates/ramshared-winsvc/src/broker_tenant.rs
+++ b/crates/ramshared-winsvc/src/broker_tenant.rs
@@ -399,7 +399,13 @@ mod tests {
     // silence unused helper
     #[test]
     fn dual_with_reply_helper_compiles() {
-        let _ = with_reply(Msg::Ack, Msg::Registered { tenant_id: 1 });
+        let (mut cur, in_buf) = with_reply(Msg::Ack, Msg::Registered { tenant_id: 1 })
+            .expect("with_reply should successfully serialize test messages");
+        assert!(in_buf.is_empty());
+        let msg = read_msg(&mut cur)
+            .expect("read_msg should succeed")
+            .expect("expected registered message");
+        assert_eq!(msg, Msg::Registered { tenant_id: 1 });
     }
 
     #[test]


### PR DESCRIPTION
Refactor dual_with_reply_helper_compiles test in crates/ramshared-winsvc/src/broker_tenant.rs to validate the deserialized Msg output from with_reply rather than ignoring it.

---
*PR created automatically by Jules for task [12660660496174918387](https://jules.google.com/task/12660660496174918387) started by @emersonbusson*