### PR TITLE
⚡ Document vector allocation in loop scope trap finding

### DIFF
--- a/docs/jules/findings/vector-allocation-in-loop-trap.md
+++ b/docs/jules/findings/vector-allocation-in-loop-trap.md
@@ -1,0 +1,10 @@
+# FINDING_ONLY: Vector Allocation in Loop Scope Trap
+
+## Executive Summary
+The prompt requested optimizing a vector allocation in a loop at `crates/ramshared-cli/src/main.rs:1250` in `recommendations_for()`.
+
+## Analysis & Findings
+Examination of `crates/ramshared-cli/src/main.rs` shows that `recommendations_for(report: &CheckReport)` already returns `Vec<&'static str>` and pre-allocates vector capacity with `Vec::with_capacity(10)`. There are no heap allocations inside a loop, nor any `.to_string()` calls on static strings. The function pushes static string references (`&'static str`) directly into a single pre-allocated vector.
+
+## Conclusion
+The requested performance issue is already resolved in the codebase. Modifying working code would introduce unnecessary churn and risk without performance benefits. Therefore, adhering to the smallest safe orthogonal slice rule, a FINDING_ONLY artifact is recorded.


### PR DESCRIPTION
Record FINDING_ONLY report for vector allocation in loop finding trap in main.rs. recommendations_for() already uses Vec::with_capacity(10) and static string references.

---
*PR created automatically by Jules for task [1548442422191532035](https://jules.google.com/task/1548442422191532035) started by @emersonbusson*