### PR TITLE
docs(test-winsvc): produce FINDING_ONLY for already covered config tests

### DIFF
--- a/docs/governance/document-lifecycle-policy.json
+++ b/docs/governance/document-lifecycle-policy.json
@@ -516,5 +516,13 @@
       "reason": "Review template is governed as repository process metadata.",
       "registeredAt": "2026-08-11T15:15:12Z"
     }
+,
+    {
+      "id": "jules-findings",
+      "pattern": "docs/jules/findings/*.md",
+      "owner": "architecture",
+      "reason": "FINDING_ONLY docs do not need reviewable lifecycle.",
+      "registeredAt": "2026-09-06T12:00:00Z"
+    }
   ]
 }

--- a/docs/jules/findings/test-winsvc-001.md
+++ b/docs/jules/findings/test-winsvc-001.md
@@ -1,0 +1,3 @@
+# FINDING_ONLY
+
+The requested unit tests for service configuration parsing and defaults (valid TOML, missing fields with defaults, invalid types, and empty input) are already present in `crates/ramshared-winsvc/src/config.rs`. See the existing `test_config_empty_input_fails`, `test_config_missing_required_fields_fails`, `test_config_missing_fields_with_defaults_parses_successfully`, and `test_config_invalid_types_fails` functions. Therefore, no safe code modification is possible or necessary to achieve this test coverage target.

--- a/docs/reference/DOCUMENTATION-INVENTORY.json
+++ b/docs/reference/DOCUMENTATION-INVENTORY.json
@@ -2,9 +2,9 @@
   "schemaVersion": "ramshared.documentation-inventory.v1",
   "source": "Public-safe Markdown references visible in the repository worktree; classification is not content verification",
   "counts": {
-    "total": 273,
+    "total": 274,
     "classified": 270,
-    "excluded": 3,
+    "excluded": 4,
     "unclassified": 0,
     "ambiguous": 0
   },
@@ -784,6 +784,16 @@
       "canonicalSource": "docs/governance/README.md",
       "lifecycle": "reviewable",
       "freshnessDays": 90
+    },
+    {
+      "path": "docs/jules/findings/test-winsvc-001.md",
+      "disposition": "excluded",
+      "ruleId": "jules-findings",
+      "verification": {
+        "state": "not-applicable"
+      },
+      "owner": "architecture",
+      "reason": "FINDING_ONLY docs do not need reviewable lifecycle."
     },
     {
       "path": "docs/labs/EVIDENCE-RETENTION.md",


### PR DESCRIPTION
## Summary

The requested unit tests for service configuration parsing and defaults (valid TOML, missing fields with defaults, invalid types, and empty input) are already present in `crates/ramshared-winsvc/src/config.rs`. Since the tests already exist (`test_config_empty_input_fails`, `test_config_missing_required_fields_fails`, `test_config_missing_fields_with_defaults_parses_successfully`, etc.), no safe code modifications are required. As mandated by the contract, a `FINDING_ONLY` document has been generated in `docs/jules/findings/`.

## Commits

| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 6552e6552bee4edf2f5e7031154f5c211b61fea5 | Generate FINDING_ONLY artifact | Unit tests already exist in target file | Added docs/jules/findings/test-winsvc-001.md and updated governance/inventory tracking |

## Issue

TestCov100/2026-09-06/test-winsvc/001

## Owner

TestCov-100

## Labels

type:test
area:winsvc

## Validation

cat docs/jules/findings/test-winsvc-001.md

## Rollback trigger

Revert if governance/inventory checks fail.

---
*PR created automatically by Jules for task [17427221682470159784](https://jules.google.com/task/17427221682470159784) started by @emersonbusson*