### PR TITLE
test(winsvc): add error path tests for service start failure scenarios

### DIFF
--- a/crates/ramshared-winsvc/src/service.rs
+++ b/crates/ramshared-winsvc/src/service.rs
@@ -398,9 +398,14 @@ mod tests {
         registered: bool,
         destroy_calls: u32,
         unreg_calls: u32,
+        create_fail: bool,
+        register_fail: bool,
     }
     impl DiskControl for MemDisk {
         fn create_disk(&mut self, _: u64, _: u32) -> Result<(), String> {
+            if self.create_fail {
+                return Err("mock create error".into());
+            }
             self.created = true;
             Ok(())
         }
@@ -410,6 +415,9 @@ mod tests {
             Ok(())
         }
         fn register_queue(&mut self) -> Result<(), String> {
+            if self.register_fail {
+                return Err("mock register error".into());
+            }
             self.registered = true;
             Ok(())
         }
@@ -1009,5 +1017,67 @@ mod tests {
                 .verify_unique(&[matching.clone(), matching])
                 .is_err()
         );
+    }
+
+    #[test]
+    fn test_service_create_disk_error_fails() {
+        let c = cfg();
+        let mut state = ServiceState::default();
+        let mut disk = MemDisk {
+            create_fail: true,
+            ..Default::default()
+        };
+        let mut tenant = BrokerTenant::new("wd", Duration::from_secs(5));
+
+        let e = provision_after_lease(
+            &c,
+            &mut state,
+            LeaseState {
+                lease: 2,
+                bytes: c.size_bytes,
+            },
+            &FixedFree(2 << 30),
+            &mut disk,
+            &mut tenant,
+        )
+        .unwrap_err();
+
+        assert!(matches!(e, ProvisionError::Disk(_)));
+        assert!(!disk.created);
+        assert!(!disk.registered);
+        assert!(!state.disk_created);
+        assert!(!state.registered_queue);
+        assert!(!state.online);
+    }
+
+    #[test]
+    fn test_service_register_queue_error_fails() {
+        let c = cfg();
+        let mut state = ServiceState::default();
+        let mut disk = MemDisk {
+            register_fail: true,
+            ..Default::default()
+        };
+        let mut tenant = BrokerTenant::new("wd", Duration::from_secs(5));
+
+        let e = provision_after_lease(
+            &c,
+            &mut state,
+            LeaseState {
+                lease: 2,
+                bytes: c.size_bytes,
+            },
+            &FixedFree(2 << 30),
+            &mut disk,
+            &mut tenant,
+        )
+        .unwrap_err();
+
+        assert!(matches!(e, ProvisionError::Disk(_)));
+        assert!(disk.created);
+        assert!(!disk.registered);
+        assert!(state.disk_created);
+        assert!(!state.registered_queue);
+        assert!(!state.online);
     }
 }


### PR DESCRIPTION
## Summary
Added error path tests for service start failure scenarios.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 33cf1916361a8f90760f38b2580c8dc82f6e91f1 | test(winsvc): add error path tests for service start failure scenarios | To test service start failures | Added unit tests to mock disk creation and queue registration errors |

## Issue
TASK-004

## Owner
TestCov100

## Labels
type:test
area:ramshared-winsvc

## Validation
cargo test -p ramshared-winsvc

## Rollback trigger
Test failures on CI

---
*PR created automatically by Jules for task [5376160911856366979](https://jules.google.com/task/5376160911856366979) started by @emersonbusson*