### PR TITLE
test: fuzz-style tests for malformed protocol frames in ramshared-winsvc

### DIFF
--- a/crates/ramshared-winsvc/src/proto.rs
+++ b/crates/ramshared-winsvc/src/proto.rs
@@ -34,6 +34,60 @@ pub struct Sqe {
     pub buf_slot: u32,
 }
 
+impl Sqe {
+    /// Safe parser for SQE from an untrusted byte slice (e.g. fuzzing / driver inputs).
+    pub fn parse(b: &[u8]) -> Result<Self, i32> {
+        if b.len() < core::mem::size_of::<Self>() {
+            return Err(ST_EINVAL);
+        }
+
+        let mut len_bytes = [0u8; 4];
+        len_bytes.copy_from_slice(&b[24..28]);
+        let len = u32::from_le_bytes(len_bytes);
+
+        if len > MAX_IO {
+            return Err(ST_EINVAL);
+        }
+
+        // This validates the structure bounds. Real implementations would deserialize all fields safely.
+        // We do a simple copy for now to fulfill the struct layout.
+
+        let mut sqe = Self {
+            tag: 0,
+            op: 0,
+            flags: 0,
+            offset: 0,
+            len: 0,
+            buf_slot: 0,
+        };
+
+        // Since we forbid unsafe_code, we deserialize safely.
+        let mut tag_bytes = [0u8; 8];
+        tag_bytes.copy_from_slice(&b[0..8]);
+        sqe.tag = u64::from_le_bytes(tag_bytes);
+
+        let mut op_bytes = [0u8; 4];
+        op_bytes.copy_from_slice(&b[8..12]);
+        sqe.op = u32::from_le_bytes(op_bytes);
+
+        let mut flags_bytes = [0u8; 4];
+        flags_bytes.copy_from_slice(&b[12..16]);
+        sqe.flags = u32::from_le_bytes(flags_bytes);
+
+        let mut offset_bytes = [0u8; 8];
+        offset_bytes.copy_from_slice(&b[16..24]);
+        sqe.offset = u64::from_le_bytes(offset_bytes);
+
+        sqe.len = len;
+
+        let mut slot_bytes = [0u8; 4];
+        slot_bytes.copy_from_slice(&b[28..32]);
+        sqe.buf_slot = u32::from_le_bytes(slot_bytes);
+
+        Ok(sqe)
+    }
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Cqe {
@@ -49,6 +103,40 @@ pub struct RingHdr {
     pub entries: u32,
     pub head: u32,
     pub tail: u32,
+}
+
+impl RingHdr {
+    /// Safe parser for RingHdr from an untrusted byte slice.
+    pub fn parse(b: &[u8]) -> Result<Self, i32> {
+        if b.len() < core::mem::size_of::<Self>() {
+            return Err(ST_EINVAL);
+        }
+
+        let mut magic_bytes = [0u8; 4];
+        magic_bytes.copy_from_slice(&b[0..4]);
+        let magic = u32::from_le_bytes(magic_bytes);
+
+        if magic != RING_MAGIC {
+            return Err(ST_EINVAL);
+        }
+
+        let mut hdr = Self { magic: 0, entries: 0, head: 0, tail: 0 };
+        hdr.magic = magic;
+
+        let mut entries_bytes = [0u8; 4];
+        entries_bytes.copy_from_slice(&b[4..8]);
+        hdr.entries = u32::from_le_bytes(entries_bytes);
+
+        let mut head_bytes = [0u8; 4];
+        head_bytes.copy_from_slice(&b[8..12]);
+        hdr.head = u32::from_le_bytes(head_bytes);
+
+        let mut tail_bytes = [0u8; 4];
+        tail_bytes.copy_from_slice(&b[12..16]);
+        hdr.tail = u32::from_le_bytes(tail_bytes);
+
+        Ok(hdr)
+    }
 }
 
 #[repr(C)]
@@ -123,6 +211,57 @@ mod tests {
         assert_eq!(&bytes[24..28], &512u32.to_le_bytes());
         // buf_slot = 3
         assert_eq!(&bytes[28..32], &3u32.to_le_bytes());
+    }
+
+    #[test]
+    fn test_proto_truncated_header_fails_parse() {
+        let bytes = [0u8; 8]; // Truncated, RingHdr is 16 bytes
+        assert_eq!(RingHdr::parse(&bytes).unwrap_err(), ST_EINVAL);
+    }
+
+    #[test]
+    fn test_proto_wrong_magic_bytes_fails() {
+        let mut bytes = [0u8; 16];
+        let wrong_magic = 0x0000_0000u32;
+        bytes[0..4].copy_from_slice(&wrong_magic.to_le_bytes());
+        assert_eq!(RingHdr::parse(&bytes).unwrap_err(), ST_EINVAL);
+    }
+
+    #[test]
+    fn test_proto_valid_header_parses() {
+        let mut bytes = [0u8; 16];
+        bytes[0..4].copy_from_slice(&RING_MAGIC.to_le_bytes());
+        bytes[4..8].copy_from_slice(&256u32.to_le_bytes()); // entries
+        bytes[8..12].copy_from_slice(&0u32.to_le_bytes()); // head
+        bytes[12..16].copy_from_slice(&0u32.to_le_bytes()); // tail
+
+        let hdr = RingHdr::parse(&bytes).unwrap();
+        assert_eq!(hdr.magic, RING_MAGIC);
+        assert_eq!(hdr.entries, 256);
+    }
+
+    #[test]
+    fn test_proto_oversized_length_field_rejected() {
+        let mut bytes = [0u8; 32];
+        let oversized_len = MAX_IO + 1;
+        bytes[24..28].copy_from_slice(&oversized_len.to_le_bytes());
+        assert_eq!(Sqe::parse(&bytes).unwrap_err(), ST_EINVAL);
+    }
+
+    #[test]
+    fn test_proto_truncated_sqe_fails_parse() {
+        let bytes = [0u8; 16]; // Truncated, Sqe is 32 bytes
+        assert_eq!(Sqe::parse(&bytes).unwrap_err(), ST_EINVAL);
+    }
+
+    #[test]
+    fn test_proto_valid_sqe_parses() {
+        let mut bytes = [0u8; 32];
+        let len = 512u32;
+        bytes[24..28].copy_from_slice(&len.to_le_bytes());
+
+        let sqe = Sqe::parse(&bytes).unwrap();
+        assert_eq!(sqe.len, len);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Added safe parsing methods and fuzz-style tests for malformed protocol frames in `crates/ramshared-winsvc/src/proto.rs`. The new methods safely extract fields from slices, and tests validate truncation, wrong magic bytes, and oversized length fields against the expected constants.

## Commits

| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| a31b0568407f8307c2782a4a0d66afb75716eae1 | Added `parse` methods and fuzz-style tests for protocol frames. | Improve robustness and test coverage for the proto module parser. | <details>Added `parse` method to `RingHdr` and `Sqe` structs. Added tests `test_proto_truncated_header_fails_parse`, `test_proto_wrong_magic_bytes_fails`, `test_proto_valid_header_parses`, `test_proto_oversized_length_field_rejected`, `test_proto_truncated_sqe_fails_parse`, `test_proto_valid_sqe_parses` to `crates/ramshared-winsvc/src/proto.rs`.</details> |

## Issue

Resolves #008

## Owner

@jules

## Labels

type:test, area:winsvc

## Validation

cargo test -p ramshared-winsvc

## Rollback trigger

If the added logic introduces parsing regressions during automated CI.

---
*PR created automatically by Jules for task [13977506836018993024](https://jules.google.com/task/13977506836018993024) started by @emersonbusson*