### PR TITLE
test: add boundary condition unit tests to config numeric limits and harden CI scripts

### DIFF
--- a/crates/ramshared-winsvc/src/config.rs
+++ b/crates/ramshared-winsvc/src/config.rs
@@ -684,4 +684,43 @@ volume_mount_path = "C:\\Users\\Public\\lun""#,
         let c = WinDriveConfig::from_toml(GOOD).unwrap();
         assert_eq!(c.evidence_path(), c.evidence_path.as_path());
     }
+
+    #[test]
+    fn test_config_capacity_zero_fails() {
+        let bad = GOOD.replace("size_bytes = 536870912", "size_bytes = 0");
+        let e = WinDriveConfig::from_toml(&bad).unwrap_err();
+        assert!(matches!(
+            e,
+            ConfigError::Invalid {
+                field: "size_bytes",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_config_capacity_u64_max_fails() {
+        let bad = GOOD.replace("size_bytes = 536870912", &format!("size_bytes = {}", u64::MAX));
+        let e = WinDriveConfig::from_toml(&bad).unwrap_err();
+        assert!(matches!(
+            e,
+            ConfigError::Invalid {
+                field: "size_bytes",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_config_capacity_negative_fails() {
+        let bad = GOOD.replace("size_bytes = 536870912", "size_bytes = -1");
+        let e = WinDriveConfig::from_toml(&bad).unwrap_err();
+        assert!(matches!(e, ConfigError::Parse(_)));
+    }
+
+    #[test]
+    fn test_config_input_non_utf8_fails() {
+        let e = WinDriveConfig::from_reader(&[0xff, 0xff, 0xff]).unwrap_err();
+        assert!(matches!(e, ConfigError::Parse(_)));
+    }
 }

--- a/tools/ci/check-adr-index.mjs
+++ b/tools/ci/check-adr-index.mjs
@@ -209,4 +209,4 @@ export function main(argv = process.argv.slice(2)) {
   return 1
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) process.exitCode = main()
+if (process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url)) process.exitCode = main()

--- a/tools/ci/check-task-log.mjs
+++ b/tools/ci/check-task-log.mjs
@@ -233,4 +233,4 @@ function main(argv = process.argv.slice(2)) {
   return 1
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) process.exitCode = main()
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}` && !process.env.NODE_TEST_CONTEXT) process.exitCode = main()

--- a/tools/ci/check-validation-schema.mjs
+++ b/tools/ci/check-validation-schema.mjs
@@ -466,7 +466,7 @@ function main() {
   process.exit(1)
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}` && !process.env.NODE_TEST_CONTEXT) {
   main()
 }
 /* node:coverage enable */

--- a/tools/ci/merge-release-sboms.mjs
+++ b/tools/ci/merge-release-sboms.mjs
@@ -185,7 +185,7 @@ function main() {
   writeFileSync(options.out, `${JSON.stringify(merged, null, 2)}\n`, { flag: 'wx' })
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {
     main()
   } catch (error) {


### PR DESCRIPTION
## Summary
Add comprehensive unit tests for `config.rs` to cover boundary numeric limit test cases as required by the specification, and harden CI scripts against test-runner leakage.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| bb9c3d10cbeba500fcb2be56d8d08d4a359480fa | Add boundary tests to `config.rs` | To ensure robust numeric bounds validation on zero capacity, max capacity, negatives, and invalid UTF-8 | Ensures limits and memory invariants are properly verified before processing config buffers |
| 19c3e81ffd063484da6fbf9b1af80b8ebfa15e17 | Harden CI tooling scripts | To prevent node test-runner side-effects executing script logic unconditionally | Validates `process.argv[1]` boundaries on invocation endpoints |
| aac2436f04882a124fba925aec050658af48e84b | Refine CI tooling scripts fix | To further protect against tests running the main block directly | Use NODE_TEST_CONTEXT where applicable |

## Issue
None

## Owner
TestCov100

## Labels
type:test, type:ci, area:ramshared-winsvc

## Validation
cargo test --package ramshared-winsvc && node --test tools/ci/*.mjs

## Rollback trigger
Revert if tests fail to compile, fail to run in strict validation jobs, or if unexpected breakages affect configuration parsing.

---
*PR created automatically by Jules for task [8545885977541451804](https://jules.google.com/task/8545885977541451804) started by @emersonbusson*