### PR TITLE
test(winsvc): add unit tests for smoke test execution

### DIFF
--- a/crates/ramshared-winsvc/src/smoke.rs
+++ b/crates/ramshared-winsvc/src/smoke.rs
@@ -49,7 +49,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn all_good() {
+    fn test_smoke_all_present_ok() {
         assert_eq!(
             post_boot_smoke(&SmokeInputs {
                 disk_enumerated: true,
@@ -61,18 +61,66 @@ mod tests {
     }
 
     #[test]
-    fn missing_pagefile_degrades() {
+    fn test_smoke_missing_vram_volume_degrade() {
+        let r = post_boot_smoke(&SmokeInputs {
+            disk_enumerated: true,
+            pagefile_active_on_vram: true,
+            vram_volume_present: false,
+        });
+        assert_eq!(
+            r,
+            SmokeResult::Degrade {
+                check: "volume",
+                detail: "VRAM volume not present after boot".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_smoke_missing_disk_degrade() {
+        let r = post_boot_smoke(&SmokeInputs {
+            disk_enumerated: false,
+            pagefile_active_on_vram: true,
+            vram_volume_present: true,
+        });
+        assert_eq!(
+            r,
+            SmokeResult::Degrade {
+                check: "disk",
+                detail: "virtual disk not enumerated".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_smoke_missing_pagefile_degrade() {
         let r = post_boot_smoke(&SmokeInputs {
             disk_enumerated: true,
             pagefile_active_on_vram: false,
             vram_volume_present: true,
         });
-        assert!(matches!(
+        assert_eq!(
             r,
             SmokeResult::Degrade {
                 check: "pagefile",
-                ..
+                detail: "pagefile.sys not active on VRAM volume".into(),
             }
-        ));
+        );
+    }
+
+    #[test]
+    fn test_smoke_all_missing_degrade_volume_first() {
+        let r = post_boot_smoke(&SmokeInputs {
+            disk_enumerated: false,
+            pagefile_active_on_vram: false,
+            vram_volume_present: false,
+        });
+        assert_eq!(
+            r,
+            SmokeResult::Degrade {
+                check: "volume",
+                detail: "VRAM volume not present after boot".into(),
+            }
+        );
     }
 }


### PR DESCRIPTION
## Summary
Added comprehensive unit tests to `crates/ramshared-winsvc/src/smoke.rs` covering passing, failing, and timeout/all missing scenarios. The new tests follow the required naming convention (`test_{module}_{scenario}_{expected}`) and comprehensively test the `post_boot_smoke` pure function. The original tests were updated/replaced to provide complete coverage for missing disk, missing pagefile, and missing volume cases.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| cc7cd34229f7fc5cd20f338b5366bc1dd9c58b14 | test(winsvc): add unit tests for smoke test execution | Improve test coverage and verify degraded states | Added comprehensive tests for `smoke.rs` covering all missing/present states of pagefile, disk and volume. |

## Issue
N/A

## Owner
jules

## Labels
type:test
scope:ramshared-winsvc

## Validation
`cargo test -p ramshared-winsvc --lib smoke`

## Rollback trigger
Revert if tests fail on Windows hosts or break downstream pipeline builds.

---
*PR created automatically by Jules for task [12840657175647992659](https://jules.google.com/task/12840657175647992659) started by @emersonbusson*