### PR TITLE
test(winsvc): add unit tests for package manifest parsing

### DIFF
--- a/crates/ramshared-winsvc/src/package.rs
+++ b/crates/ramshared-winsvc/src/package.rs
@@ -322,6 +322,64 @@ mod tests {
         }
     }
 
+
+    #[test]
+    fn test_package_valid_manifest_parses_successfully() {
+        let candidate = manifest();
+        let bytes = serde_json::to_vec(&candidate).unwrap();
+        assert_eq!(parse_manifest(&bytes).unwrap(), candidate);
+    }
+
+    #[test]
+    fn test_package_missing_required_fields_rejects() {
+        let mut value = serde_json::to_value(manifest()).unwrap();
+        value.as_object_mut().unwrap().remove("version");
+        let bytes = serde_json::to_vec(&value).unwrap();
+        assert!(parse_manifest(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_package_invalid_schema_rejects() {
+        let mut candidate = manifest();
+        candidate.schema = 2;
+        let bytes = serde_json::to_vec(&candidate).unwrap();
+        assert!(parse_manifest(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_package_invalid_architecture_rejects() {
+        let mut candidate = manifest();
+        candidate.architecture = "x86_64-unknown-linux-gnu".into();
+        let bytes = serde_json::to_vec(&candidate).unwrap();
+        assert!(parse_manifest(&bytes).is_err());
+    }
+
+
+    #[test]
+    fn test_package_invalid_version_rejects() {
+        let mut candidate = manifest();
+        candidate.version = "".into();
+        let bytes = serde_json::to_vec(&candidate).unwrap();
+        assert!(parse_manifest(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_package_duplicate_artifact_role_rejects() {
+        let mut candidate = manifest();
+        let dup_artifact = candidate.artifacts[0].clone();
+        candidate.artifacts.push(dup_artifact);
+        let bytes = serde_json::to_vec(&candidate).unwrap();
+        assert!(parse_manifest(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_package_missing_artifact_role_rejects() {
+        let mut candidate = manifest();
+        candidate.artifacts.pop();
+        let bytes = serde_json::to_vec(&candidate).unwrap();
+        assert!(parse_manifest(&bytes).is_err());
+    }
+
     #[test]
     fn manifest_rejects_unknown_and_over_64k() {
         let mut value = serde_json::to_value(manifest()).unwrap();


### PR DESCRIPTION
## Summary
Added comprehensive unit tests to `crates/ramshared-winsvc/src/package.rs` to verify package manifest parsing. The tests cover scenarios including valid parsing, missing required fields, invalid schemas, invalid architecture values, duplicate artifact roles, missing artifact roles, and invalid version formatting to ensure the parser correctly enforces rules. The test names follow the standard conventions.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 8ee5c9de094e2ca8926b2be9adb1538624fd6a30 | Add unit tests for manifest parsing | Increase test coverage and harden package parsing validations | Adds tests for missing fields, architecture, duplicates, invalid versions, and uses proper names. |

## Issue
None

## Owner
jules

## Labels
type:test, scope:ramshared-winsvc

## Validation
cargo test --package ramshared-winsvc

## Rollback trigger
Revert if tests fail in CI or cause build issues on non-Windows platforms.

---
*PR created automatically by Jules for task [10425464948129741084](https://jules.google.com/task/10425464948129741084) started by @emersonbusson*