### PR TITLE
test: add unit tests for block request bounds and validation

### DIFF
--- a/crates/ramshared-block/src/request.rs
+++ b/crates/ramshared-block/src/request.rs
@@ -436,7 +436,7 @@ mod tests {
             bs: 4096,
         };
         // The length of the payload needs to match req.len, otherwise it fails earlier.
-        let r = serve(&req, &vec![0u8; 100], &mut b);
+        let r = serve(&req, &[0u8; 100], &mut b);
         assert_eq!(
             u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
             NBD_EINVAL

--- a/crates/ramshared-block/src/request.rs
+++ b/crates/ramshared-block/src/request.rs
@@ -369,4 +369,84 @@ mod tests {
             NBD_ERANGE
         );
     }
+
+    #[test]
+    fn test_request_validate_command_flags_write_unknown_flags_einval() {
+        let mut req = req(Command::Write, 0, 4096);
+        req.flags = NBD_CMD_FLAG_FUA | 0x0002;
+        let mut b = MemBackend { data: vec![0u8; 8192], bs: 4096 };
+        let r = serve(&req, &vec![0u8; 4096], &mut b);
+        assert_eq!(
+            u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
+            NBD_EINVAL
+        );
+    }
+
+    #[test]
+    fn test_request_validate_command_flags_read_any_flags_einval() {
+        let mut req = req(Command::Read, 0, 4096);
+        req.flags = NBD_CMD_FLAG_FUA;
+        let mut b = MemBackend { data: vec![0u8; 8192], bs: 4096 };
+        let r = serve(&req, &[], &mut b);
+        assert_eq!(
+            u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
+            NBD_EINVAL
+        );
+    }
+
+    #[test]
+    fn test_request_validate_command_flags_read_no_flags_ok() {
+        let req = req(Command::Read, 0, 4096);
+        let mut b = MemBackend { data: vec![0u8; 8192], bs: 4096 };
+        let r = serve(&req, &[], &mut b);
+        assert_eq!(
+            u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
+            NBD_OK
+        );
+    }
+
+    #[test]
+    fn test_request_validate_alignment_read_unaligned_offset_einval() {
+        let req = req(Command::Read, 100, 4096);
+        let mut b = MemBackend { data: vec![0u8; 8192], bs: 4096 };
+        let r = serve(&req, &[], &mut b);
+        assert_eq!(
+            u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
+            NBD_EINVAL
+        );
+    }
+
+    #[test]
+    fn test_request_validate_alignment_write_unaligned_length_einval() {
+        let req = req(Command::Write, 0, 100);
+        let mut b = MemBackend { data: vec![0u8; 8192], bs: 4096 };
+        // The length of the payload needs to match req.len, otherwise it fails earlier.
+        let r = serve(&req, &vec![0u8; 100], &mut b);
+        assert_eq!(
+            u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
+            NBD_EINVAL
+        );
+    }
+
+    #[test]
+    fn test_request_validate_bounds_read_out_of_bounds_erange() {
+        let req = req(Command::Read, 4096, 8192); // end = 12288
+        let mut b = MemBackend { data: vec![0u8; 8192], bs: 4096 }; // max = 8192
+        let r = serve(&req, &[], &mut b);
+        assert_eq!(
+            u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
+            NBD_ERANGE
+        );
+    }
+
+    #[test]
+    fn test_request_validate_bounds_write_overflow_erange() {
+        let req = req(Command::Write, u64::MAX - 4095, 8192);
+        let mut b = MemBackend { data: vec![0u8; 8192], bs: 4096 };
+        let r = serve(&req, &vec![0u8; 8192], &mut b);
+        assert_eq!(
+            u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
+            NBD_ERANGE
+        );
+    }
 }

--- a/crates/ramshared-block/src/request.rs
+++ b/crates/ramshared-block/src/request.rs
@@ -374,7 +374,10 @@ mod tests {
     fn test_request_validate_command_flags_write_unknown_flags_einval() {
         let mut req = req(Command::Write, 0, 4096);
         req.flags = NBD_CMD_FLAG_FUA | 0x0002;
-        let mut b = MemBackend { data: vec![0u8; 8192], bs: 4096 };
+        let mut b = MemBackend {
+            data: vec![0u8; 8192],
+            bs: 4096,
+        };
         let r = serve(&req, &vec![0u8; 4096], &mut b);
         assert_eq!(
             u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
@@ -386,7 +389,10 @@ mod tests {
     fn test_request_validate_command_flags_read_any_flags_einval() {
         let mut req = req(Command::Read, 0, 4096);
         req.flags = NBD_CMD_FLAG_FUA;
-        let mut b = MemBackend { data: vec![0u8; 8192], bs: 4096 };
+        let mut b = MemBackend {
+            data: vec![0u8; 8192],
+            bs: 4096,
+        };
         let r = serve(&req, &[], &mut b);
         assert_eq!(
             u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
@@ -397,7 +403,10 @@ mod tests {
     #[test]
     fn test_request_validate_command_flags_read_no_flags_ok() {
         let req = req(Command::Read, 0, 4096);
-        let mut b = MemBackend { data: vec![0u8; 8192], bs: 4096 };
+        let mut b = MemBackend {
+            data: vec![0u8; 8192],
+            bs: 4096,
+        };
         let r = serve(&req, &[], &mut b);
         assert_eq!(
             u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
@@ -408,7 +417,10 @@ mod tests {
     #[test]
     fn test_request_validate_alignment_read_unaligned_offset_einval() {
         let req = req(Command::Read, 100, 4096);
-        let mut b = MemBackend { data: vec![0u8; 8192], bs: 4096 };
+        let mut b = MemBackend {
+            data: vec![0u8; 8192],
+            bs: 4096,
+        };
         let r = serve(&req, &[], &mut b);
         assert_eq!(
             u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
@@ -419,7 +431,10 @@ mod tests {
     #[test]
     fn test_request_validate_alignment_write_unaligned_length_einval() {
         let req = req(Command::Write, 0, 100);
-        let mut b = MemBackend { data: vec![0u8; 8192], bs: 4096 };
+        let mut b = MemBackend {
+            data: vec![0u8; 8192],
+            bs: 4096,
+        };
         // The length of the payload needs to match req.len, otherwise it fails earlier.
         let r = serve(&req, &vec![0u8; 100], &mut b);
         assert_eq!(
@@ -431,7 +446,10 @@ mod tests {
     #[test]
     fn test_request_validate_bounds_read_out_of_bounds_erange() {
         let req = req(Command::Read, 4096, 8192); // end = 12288
-        let mut b = MemBackend { data: vec![0u8; 8192], bs: 4096 }; // max = 8192
+        let mut b = MemBackend {
+            data: vec![0u8; 8192],
+            bs: 4096,
+        }; // max = 8192
         let r = serve(&req, &[], &mut b);
         assert_eq!(
             u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
@@ -442,7 +460,10 @@ mod tests {
     #[test]
     fn test_request_validate_bounds_write_overflow_erange() {
         let req = req(Command::Write, u64::MAX - 4095, 8192);
-        let mut b = MemBackend { data: vec![0u8; 8192], bs: 4096 };
+        let mut b = MemBackend {
+            data: vec![0u8; 8192],
+            bs: 4096,
+        };
         let r = serve(&req, &vec![0u8; 8192], &mut b);
         assert_eq!(
             u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),


### PR DESCRIPTION
## Summary
Added unit tests to `crates/ramshared-block/src/request.rs` to test valid/invalid sector ranges, alignment checks, size bounds, and command flags. This fulfills the objective of verifying request construction and testing error boundary conditions.

## Issue
TestCov100/2026-09-06/test-block/027

## Owner
Jules

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 39ef65a747fc1f13721d606266ace0fc35ddf389 | Add unit tests for block request bounds and validation | To cover alignment checks, size bounds, and sector ranges logic. | Added boundary tests for unaligned read/write offset/lengths and out-of-bounds errors, plus valid/invalid command flags validation. Followed required function naming conventions. |

## Labels
type:test, area:ramshared-block

## Validation
cargo test -p ramshared-block

## Rollback trigger
Revert if tests fail dynamically in CI or block other tests from passing.

---
*PR created automatically by Jules for task [236322107777327848](https://jules.google.com/task/236322107777327848) started by @emersonbusson*