### PR TITLE
test-winsvc: unit tests for IPC message serialization and deserialization

### DIFF
--- a/crates/ramshared-winsvc/src/ipc.rs
+++ b/crates/ramshared-winsvc/src/ipc.rs
@@ -223,6 +223,11 @@ impl BrokerStream for NamedPipeBrokerStream {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Instant;
+    use std::io::Cursor;
+    use ramshared_broker::protocol::{Msg, read_msg, write_msg};
+    use ramshared_broker::model::TransportKind;
+
     #[test]
     fn only_not_found_and_busy_retry() {
         assert!(retryable_pipe_error(2));
@@ -251,5 +256,48 @@ mod tests {
             result,
             Err(BrokerConnectError::Deadline) | Err(BrokerConnectError::NonTransient(_))
         ));
+    }
+
+    #[test]
+    fn test_ipc_serialization_roundtrips_all_message_types() {
+        let msgs = vec![
+            Msg::Register {
+                proto: 1,
+                tenant: "test_tenant".into(),
+                transport: TransportKind::WinDrive,
+            },
+            Msg::LeaseRequest { bytes: 4096 },
+            Msg::LeaseRelease { lease: 1 },
+            Msg::Status,
+            Msg::Ack,
+        ];
+        for original in msgs {
+            let mut buf = Vec::new();
+            write_msg(&mut buf, &original).unwrap();
+            let mut cursor = Cursor::new(buf);
+            let roundtrip = read_msg(&mut cursor).unwrap().unwrap();
+            assert_eq!(original, roundtrip);
+        }
+    }
+
+    #[test]
+    fn test_ipc_serialization_malformed_payload_error() {
+        let malformed = b"{ \"type\": \"unknown\" }\n";
+        let mut cursor = Cursor::new(malformed.to_vec());
+        let result = read_msg(&mut cursor);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ipc_serialization_truncated_message_eof() {
+        let msg = Msg::Ack;
+        let mut buf = Vec::new();
+        write_msg(&mut buf, &msg).unwrap();
+        // Truncate
+        buf.truncate(buf.len() / 2);
+
+        let mut cursor = Cursor::new(buf);
+        let result = read_msg(&mut cursor);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary
Adds comprehensive unit tests to `crates/ramshared-winsvc/src/ipc.rs` covering IPC message serialization, deserialization, malformed payloads, and truncated EOF messages, achieving orthogonal coverage goals.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| cfaa70cddedb80ef5cab6d822acd3bbaeed87554 | Added IPC serialization unit tests | Increase test coverage for critical IPC message handling paths | Implemented `test_ipc_serialization_roundtrips_all_message_types`, `test_ipc_serialization_malformed_payload_error`, and `test_ipc_serialization_truncated_message_eof` using `std::io::Cursor`. |

## Issue
test-winsvc

## Owner
TestCov100/2026-09-06/test-winsvc/005

## Labels
type:test, type:ci, area:ramshared-winsvc

## Validation
cargo test -p ramshared-winsvc --lib

## Rollback trigger
Any CI test failure or compilation issue targeting Windows components on either Windows or Linux environments.

---
*PR created automatically by Jules for task [8304716849962314229](https://jules.google.com/task/8304716849962314229) started by @emersonbusson*