### PR TITLE
test(block): add boundary tests for request sector range limits

### DIFF
--- a/crates/ramshared-block/src/request.rs
+++ b/crates/ramshared-block/src/request.rs
@@ -369,4 +369,56 @@ mod tests {
             NBD_ERANGE
         );
     }
+
+    #[test]
+    fn test_request_sector_0_ok() {
+        let mut b = MemBackend {
+            data: vec![0u8; 8192],
+            bs: 4096,
+        };
+        let r = serve(&req(Command::Read, 0, 4096), &[], &mut b);
+        assert_eq!(
+            u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
+            NBD_OK
+        );
+    }
+
+    #[test]
+    fn test_request_max_sector_ok() {
+        let mut b = MemBackend {
+            data: vec![0u8; 8192],
+            bs: 4096,
+        };
+        let r = serve(&req(Command::Read, 4096, 4096), &[], &mut b);
+        assert_eq!(
+            u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
+            NBD_OK
+        );
+    }
+
+    #[test]
+    fn test_request_cross_boundary_erange() {
+        let mut b = MemBackend {
+            data: vec![0u8; 8192],
+            bs: 4096,
+        };
+        let r = serve(&req(Command::Read, 4096, 8192), &[], &mut b);
+        assert_eq!(
+            u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
+            NBD_ERANGE
+        );
+    }
+
+    #[test]
+    fn test_request_zero_length_ok() {
+        let mut b = MemBackend {
+            data: vec![0u8; 8192],
+            bs: 4096,
+        };
+        let r = serve(&req(Command::Read, 4096, 0), &[], &mut b);
+        assert_eq!(
+            u32::from_be_bytes([r.reply[4], r.reply[5], r.reply[6], r.reply[7]]),
+            NBD_OK
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Added unit tests in `crates/ramshared-block/src/request.rs` for NBD request boundary conditions including sector 0, max sector, cross-boundary spans, and zero-length requests.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 392e13428d10bb00dcf1bf6e6b02d9e12b362578 | test(block): add boundary tests for request sector range limits | To ensure request limits are respected according to SPEC 8. | Implemented `test_request_sector_0_ok`, `test_request_max_sector_ok`, `test_request_cross_boundary_erange`, and `test_request_zero_length_ok`. |

## Issue
N/A

## Owner
jules

## Labels
type:test, scope:ramshared-block

## Validation
`cargo test --package ramshared-block`

## Rollback trigger
Revert if any tests fail on edge case scenarios.

---
*PR created automatically by Jules for task [10391610986479406040](https://jules.google.com/task/10391610986479406040) started by @emersonbusson*