### PR TITLE
Added sparse VRAM boundary tests

### DIFF
--- a/crates/ramshared-block/src/sparse_vram.rs
+++ b/crates/ramshared-block/src/sparse_vram.rs
@@ -817,4 +817,51 @@ mod tests {
             assert!(commit_cap_bytes_from_env() > 1 << 30);
         }
     }
+
+    #[test]
+    fn test_sparse_vram_allocation_exactly_capacity_passes() {
+        let p = FakeProvider::new();
+        let chunk = 256 * 1024;
+        let capacity = 4 * chunk;
+        let mut be = SparseVramBackend::new(&p, capacity, chunk, 4096).unwrap();
+
+        let payload = vec![0xABu8; 4096];
+        be.write_at(capacity - 4096, &payload).unwrap();
+        assert_eq!(p.allocs.get(), 1);
+
+        let mut buf = vec![0u8; 4096];
+        be.read_at(capacity - 4096, &mut buf).unwrap();
+        assert_eq!(buf, payload);
+    }
+
+    #[test]
+    fn test_sparse_vram_allocation_capacity_plus_one_rejection() {
+        let p = FakeProvider::new();
+        let chunk = 256 * 1024;
+        let capacity = 4 * chunk;
+        let mut be = SparseVramBackend::new(&p, capacity, chunk, 4096).unwrap();
+
+        let payload = vec![0xABu8; 4096];
+        let err = be.write_at(capacity, &payload).unwrap_err();
+        assert!(err.0.contains("oob") || err.0.contains("capacity"));
+    }
+
+    #[test]
+    fn test_sparse_vram_double_free_returns_zero() {
+        let p = FakeProvider::new();
+        let chunk = 256 * 1024;
+        let capacity = 4 * chunk;
+        let mut be = SparseVramBackend::new(&p, capacity, chunk, 4096).unwrap();
+
+        let payload = vec![0xABu8; 4096];
+        be.write_at(0, &payload).unwrap();
+        assert_eq!(be.chunks_live(), 1);
+
+        let freed1 = be.free_all_live();
+        assert_eq!(freed1, chunk);
+        assert_eq!(be.chunks_live(), 0);
+
+        let freed2 = be.free_all_live();
+        assert_eq!(freed2, 0);
+    }
 }


### PR DESCRIPTION
## Summary
Add boundary tests for sparse VRAM at capacity limits.

## Commits
| Commit | What was done | Why it was done | Details |
| --- | --- | --- | --- |

## Issue
TestCov-100

## Owner
jules

## Labels
type:test
area:ramshared-block

## Validation
cargo test --package ramshared-block

## Rollback trigger
Sparse VRAM boundary test failure or pipeline regression.

---
*PR created automatically by Jules for task [9303883610630993508](https://jules.google.com/task/9303883610630993508) started by @emersonbusson*