### PR TITLE
test(ramshared-cuda): add tests for CUDA library loading with missing dll

### DIFF
--- a/crates/ramshared-cuda/src/loader_win.rs
+++ b/crates/ramshared-cuda/src/loader_win.rs
@@ -85,4 +85,31 @@ mod tests {
         unsafe { SetLastError(0) };
         assert_eq!(error(), "Windows error code: 0x00000000");
     }
+
+    #[test]
+    fn test_loader_win_open_missing_dll() {
+        let ptr = unsafe { open(c"nonexistent_gpu_lib.dll".as_ptr()) };
+        assert!(ptr.is_null());
+        let err = error();
+        assert!(err.starts_with("Windows error code: "));
+    }
+
+    #[test]
+    fn test_loader_win_open_invalid_utf8() {
+        let bad_str: &[u8] = b"bad\\xFFstr\\0";
+        let ptr = unsafe { open(bad_str.as_ptr() as *const c_char) };
+        assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn test_loader_win_sym_null_handle() {
+        let ptr = unsafe { sym(core::ptr::null_mut(), c"some_symbol".as_ptr()) };
+        assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn test_loader_win_close_null_handle() {
+        let res = unsafe { close(core::ptr::null_mut()) };
+        assert_eq!(res, 0);
+    }
 }


### PR DESCRIPTION
## Summary
Add comprehensive unit testing to crates/ramshared-cuda/src/loader_win.rs for dynamic library loading with missing nvcuda.dll, validating UTF-8 error cases, and testing null handles for both opening and closing according to testing guidelines.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 803fd82 | Added unit tests to loader_win.rs | To validate CUDA library loading failure cases on Windows | Includes missing DLL, invalid UTF-8, and null handle checks |

## Issue
Fixes #053

## Owner
jules

## Labels
type:test
area:ramshared-cuda

## Validation
CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER=wine cargo test --target x86_64-pc-windows-gnu -p ramshared-cuda

## Rollback trigger
If PR causes CI test failures or regressions in other crates.

RULES:
1. Read README.md, AGENTS.md, CLAUDE.md, and all pertinent .claude/rules/.
2. Baseline git SHA is 24531803029a7ecbc8b884ac9d5c77178e58036e on origin/main.
3. Implement only the smallest safe orthogonal slice. Run cargo test (or node --test for .mjs) and open 1 PR strictly against jules/inbox.
4. If safe code modification is not possible, produce FINDING_ONLY with evidence in docs/jules/findings/.
5. Do not read, write, print, or persist credentials/secrets.
6. PRs remain unmerged on jules/inbox; human consolidation will merge verified gains into main.
7. English only for all source code, comments, identifiers, commits, and PR descriptions.
8. Follow Conventional Commits format (<=72 chars title, body explaining rationale and rollback trigger).
9. Format PR body with: ## Summary, ## Commits, ## Labels, ## Validation, ## Rollback trigger.
10. All 10 contractual blocks MUST be generated in the plan before modifying any file.

---
*PR created automatically by Jules for task [16220362629909575781](https://jules.google.com/task/16220362629909575781) started by @emersonbusson*