### PR TITLE
test(ramshared-vram): add comprehensive unit tests for VRAM capacity

### DIFF
--- a/crates/ramshared-vram/src/lib.rs
+++ b/crates/ramshared-vram/src/lib.rs
@@ -63,6 +63,29 @@ pub trait VramMemory {
     fn write_at(&mut self, off: u64, src: &[u8]) -> Result<(), VramError>;
 }
 
+/// Represents VRAM capacity reporting and free space.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VramCapacity {
+    pub free: u64,
+    pub total: u64,
+}
+
+impl VramCapacity {
+    /// Creates a new VRAM capacity instance.
+    pub fn new(free: u64, total: u64) -> Result<Self, VramError> {
+        if free > total {
+            return Err(VramError::Provider("free capacity cannot exceed total".to_string()));
+        }
+        Ok(Self { free, total })
+    }
+}
+
+impl fmt::Display for VramCapacity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "VRAM: {}/{} bytes free", self.free, self.total)
+    }
+}
+
 /// VRAM Provider (representing an initialized thread-affinity context): Allocates regions and reports capacity metrics.
 ///
 /// The driver lifecycle (driver load, device selection, and context creation) is the responsibility
@@ -106,5 +129,110 @@ mod tests {
             "vram invalid alignment"
         );
         assert_eq!(VramError::Busy.to_string(), "vram busy");
+    }
+
+    #[test]
+    fn test_vram_capacity_new_valid() {
+        let cap = VramCapacity::new(100, 200).unwrap();
+        assert_eq!(cap.free, 100);
+        assert_eq!(cap.total, 200);
+    }
+
+    #[test]
+    fn test_vram_capacity_zero_bounds_valid() {
+        let cap = VramCapacity::new(0, 0).unwrap();
+        assert_eq!(cap.free, 0);
+        assert_eq!(cap.total, 0);
+    }
+
+    #[test]
+    fn test_vram_capacity_max_bounds_valid() {
+        let cap = VramCapacity::new(u64::MAX, u64::MAX).unwrap();
+        assert_eq!(cap.free, u64::MAX);
+        assert_eq!(cap.total, u64::MAX);
+    }
+
+    #[test]
+    fn test_vram_capacity_invalid_state_error() {
+        let err = VramCapacity::new(200, 100).unwrap_err();
+        assert!(matches!(err, VramError::Provider(_)));
+    }
+
+    #[test]
+    fn test_vram_capacity_formatting_valid() {
+        let cap = VramCapacity::new(1024, 2048).unwrap();
+        assert_eq!(cap.to_string(), "VRAM: 1024/2048 bytes free");
+    }
+
+    #[derive(Debug)]
+    struct MockVramMemory {
+        size: usize,
+    }
+
+    impl VramMemory for MockVramMemory {
+        fn len(&self) -> usize {
+            self.size
+        }
+        fn zero(&mut self) -> Result<(), VramError> {
+            Ok(())
+        }
+        fn read_at(&self, _off: u64, _dst: &mut [u8]) -> Result<(), VramError> {
+            Ok(())
+        }
+        fn write_at(&mut self, _off: u64, _src: &[u8]) -> Result<(), VramError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_mock_vram_memory_methods() {
+        let mut mem = MockVramMemory { size: 10 };
+        assert_eq!(mem.len(), 10);
+        assert!(mem.zero().is_ok());
+        let mut dst = [0u8; 10];
+        assert!(mem.read_at(0, &mut dst).is_ok());
+        assert!(mem.write_at(0, &[0u8; 10]).is_ok());
+    }
+
+    struct MockVramProvider {
+        free: u64,
+        total: u64,
+    }
+
+    impl VramProvider for MockVramProvider {
+        type Mem<'p> = MockVramMemory where Self: 'p;
+
+        fn alloc(&self, bytes: usize) -> Result<Self::Mem<'_>, VramError> {
+            if bytes as u64 > self.free {
+                return Err(VramError::OutOfMemory);
+            }
+            Ok(MockVramMemory { size: bytes })
+        }
+
+        fn mem_info(&self) -> Result<(u64, u64), VramError> {
+            Ok((self.free, self.total))
+        }
+    }
+
+    #[test]
+    fn test_vram_provider_alloc_valid() {
+        let provider = MockVramProvider { free: 100, total: 200 };
+        let (f, t) = provider.mem_info().unwrap();
+        assert_eq!(f, 100);
+        assert_eq!(t, 200);
+
+        let mem = provider.alloc(50).unwrap();
+        assert_eq!(mem.len(), 50);
+        assert!(!mem.is_empty());
+
+        let empty_mem = provider.alloc(0).unwrap();
+        assert!(empty_mem.is_empty());
+    }
+
+    #[test]
+    fn test_vram_provider_alloc_outofmemory_error() {
+        let provider = MockVramProvider { free: 50, total: 100 };
+        let err = provider.alloc(100).unwrap_err();
+        assert!(matches!(err, VramError::OutOfMemory));
     }
 }


### PR DESCRIPTION
## Summary

Add comprehensive unit tests and capacity structs for `crates/ramshared-vram/src/lib.rs`.

## Issue

N/A

## Owner

agent-governance

## Commits

| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 1e429a3 | test(ramshared-vram): add comprehensive unit tests for VRAM capacity | To ensure coverage over struct definitions and logic for free/total memory size | Created `VramCapacity` struct, formatting trait, zero bounds tests, and tested out-of-memory error paths |

## Labels

area:ramshared-vram

## Validation

`node tools/ci/check-rust-slice-coverage.mjs -p ramshared-vram --files crates/ramshared-vram/src/lib.rs --min 100` and `cargo test --package ramshared-vram` pass locally.

## Rollback trigger

Revert if VRAM capacity causes CI coverage errors or if out-of-memory logic conflicts with CUDA abstraction.

---
*PR created automatically by Jules for task [12246815111608231360](https://jules.google.com/task/12246815111608231360) started by @emersonbusson*