### PR TITLE
test: add coverage for ConfigError display variants

### DIFF
--- a/crates/ramshared-config/src/error.rs
+++ b/crates/ramshared-config/src/error.rs
@@ -100,4 +100,33 @@ mod tests {
         let e6 = ConfigError::UnsupportedBackend("directx".into());
         assert_eq!(e6.to_string(), "unsupported backend: directx");
     }
+
+    #[test]
+    fn test_error_display_parse_with_location_empty_key() {
+        let e = ConfigError::Parse {
+            message: "invalid syntax".into(),
+            line: Some(5),
+            column: Some(10),
+            key_path: "".into(),
+        };
+        assert_eq!(e.to_string(), "parse error at line 5, col 10: invalid syntax");
+    }
+
+    #[test]
+    fn test_error_display_parse_no_location_with_key() {
+        let e = ConfigError::Parse {
+            message: "invalid value".into(),
+            line: None,
+            column: None,
+            key_path: "storage.path".into(),
+        };
+        assert_eq!(e.to_string(), "parse error for key 'storage.path': invalid value");
+    }
+
+    #[test]
+    fn test_error_source_is_none() {
+        use std::error::Error;
+        let e = ConfigError::InvalidInput("test".into());
+        assert!(e.source().is_none());
+    }
 }


### PR DESCRIPTION
## Summary

Add unit tests to cover previously untested display formatting branches for ConfigError::Parse variant in crates/ramshared-config/src/error.rs when key_path is empty with and without line/column locations, as well as the error source chain. These tests boost line coverage for error.rs from 95.9% to 100%.

## Commits

| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 52b59502a55710cdb5f5b15c3b6f6fbcc5fb8e79 | <details><summary>test: add coverage for ConfigError display variants</summary>Added unit tests to crates/ramshared-config/src/error.rs covering edge cases in the Display implementation for the Parse variant and tested the error source chain.</details> | To reach 100% line coverage for the configuration error types by validating formatting when the key path string is empty and checking the error source. | <details><summary>More info</summary>Files changed: crates/ramshared-config/src/error.rs<br>Validation: node tools/ci/check-rust-slice-coverage.mjs -p ramshared-config --files crates/ramshared-config/src/error.rs (100% coverage)<br>Rollback trigger: test suite failure</details> |

## Issue

Resolves #066

## Owner

@jules

## Labels

area:ramshared-config, type:test

## Validation

- [x] node tools/ci/check-rust-slice-coverage.mjs -p ramshared-config --files crates/ramshared-config/src/error.rs runs without errors.
- [x] Coverage check shows 100% line coverage for error.rs.

## Rollback trigger

CI failure or unit test suite failure on any platform due to unexpected error formatting.

---
*PR created automatically by Jules for task [14332456625666691828](https://jules.google.com/task/14332456625666691828) started by @emersonbusson*