### PR TITLE
test: unit tests for io_uring ring initialization and parameter validation

### DIFF
--- a/crates/ramshared-uring/src/lib.rs
+++ b/crates/ramshared-uring/src/lib.rs
@@ -821,6 +821,36 @@ mod tests {
         fs::remove_file(path).expect("remove fixture");
     }
     #[test]
+    fn test_ublkserver_new_validates_queue_depth() {
+        let page = page_size();
+        let (path, file) = regular_file_fixture("ublk-new-queue-depth", page);
+
+        // valid
+        let server = UblkServer::new(file.as_raw_fd(), 2, page);
+        assert!(server.is_ok());
+
+        // queue depth 0 fails because it attempts to mmap a size of 0
+        let server_zero = UblkServer::new(file.as_raw_fd(), 0, page);
+        assert!(server_zero.is_err());
+        assert_eq!(server_zero.err().unwrap().kind(), io::ErrorKind::InvalidInput);
+
+        drop(file);
+        std::fs::remove_file(path).expect("remove fixture");
+    }
+
+    #[test]
+    fn test_ublk_get_features_handles_kernel_version_and_flags() {
+        let (path, file) = regular_file_fixture("ublk-get-features", 4096);
+        let fd = file.as_raw_fd();
+
+        let err = ublk_get_features(fd).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+
+        drop(file);
+        std::fs::remove_file(path).expect("remove fixture");
+    }
+
+    #[test]
     fn ublk_server_push_guard_clause_rejects_full_ring() {
         let page = page_size();
         let (path, file) = regular_file_fixture("ublk-full-ring", page);


### PR DESCRIPTION
## Summary
Added unit test test_ublkserver_new_validates_queue_depth to crates/ramshared-uring/src/lib.rs to cover UblkServer::new initialization behavior with zero queue depth, and added test_ublk_get_features_handles_kernel_version_and_flags to cover unsupported flags.

## Commits
| Commit | What was done | Why it was done | Details |
|---|---|---|---|

## Issue
Test coverage for ramshared-uring

## Owner
@jules

## Labels
area:ramshared-uring, type:test

## Validation
cargo test -p ramshared-uring
node tools/ci/check-rust-slice-coverage.mjs -p ramshared-uring --files crates/ramshared-uring/src/lib.rs --min 80

## Rollback trigger
test suite fails

---
*PR created automatically by Jules for task [13706363028765526620](https://jules.google.com/task/13706363028765526620) started by @emersonbusson*