### PR TITLE
test: validate locale code format and translation file pairing

### DIFF
--- a/tools/ci/check-documentation-localization.mjs
+++ b/tools/ci/check-documentation-localization.mjs
@@ -156,6 +156,28 @@ export function validateManifest(manifest, root = ROOT) {
     if (!safeRelative(entry.canonical_source) || !safeRelative(entry.localized_path)) {
       findings.push(finding(MANIFEST_PATH, line, 'UNSAFE_PATH', 'manifest-path-must-be-relative'))
     }
+    let locale = null
+    if (safeRelative(entry.canonical_source) && safeRelative(entry.localized_path)) {
+      const canonical = entry.canonical_source
+      const localizedPath = entry.localized_path
+      if (localizedPath.startsWith('docs/') && localizedPath.endsWith(`/${canonical}`)) {
+        locale = localizedPath.slice(5, -canonical.length - 1)
+      } else if (canonical.endsWith('.md') && localizedPath.startsWith(canonical.slice(0, -3) + '.') && localizedPath.endsWith('.md')) {
+        locale = localizedPath.slice(canonical.length - 2, -3)
+      }
+      if (!locale || locale.includes('/')) {
+        findings.push(finding(MANIFEST_PATH, line, 'LOCALIZATION_PAIRING', 'invalid-translation-file-pairing'))
+      } else {
+        try {
+          const canonicalLocales = Intl.getCanonicalLocales(locale)
+          if (!canonicalLocales || canonicalLocales.length === 0 || canonicalLocales[0] !== locale) {
+            findings.push(finding(MANIFEST_PATH, line, 'LOCALE_CODE', 'invalid-bcp47-locale-code'))
+          }
+        } catch {
+          findings.push(finding(MANIFEST_PATH, line, 'LOCALE_CODE', 'invalid-bcp47-locale-code'))
+        }
+      }
+    }
     if (localized.has(entry.localized_path)) findings.push(finding(MANIFEST_PATH, line, 'DUPLICATE_LOCALIZED_PATH', 'localized-path-is-duplicated'))
     localized.add(entry.localized_path)
     if (!REQUIRED_LOCALIZED.has(entry.localized_path)) findings.push(finding(MANIFEST_PATH, line, 'UNEXPECTED_LOCALIZATION', 'path-is-not-required'))

--- a/tools/ci/check-documentation-localization.test.mjs
+++ b/tools/ci/check-documentation-localization.test.mjs
@@ -227,6 +227,12 @@ test('manifest_schema_and_path_guards_fail', () => {
   const unsafeEntry = { ...manifest.entries[0], canonical_source: '../README.md', localized_path: '/tmp/translated.md', source_sha256: 'bad', translation_sha256: 'bad', state: 'unknown', policy: 'normative' }
   const unsafeFindings = JSON.stringify(validateManifest({ ...manifest, entries: [unsafeEntry, manifest.entries[1]] }, root))
   assert.match(unsafeFindings, /UNSAFE_PATH|SOURCE_HASH|STATE|POLICY|UNEXPECTED_LOCALIZATION/)
+  const badLocaleEntry1 = { ...manifest.entries[0], canonical_source: 'README.md', localized_path: 'README.pt_BR.md' }
+  const badLocaleFindings1 = JSON.stringify(validateManifest({ ...manifest, entries: [badLocaleEntry1, manifest.entries[1]] }, root))
+  assert.match(badLocaleFindings1, /invalid-bcp47-locale-code/)
+  const badLocaleEntry2 = { ...manifest.entries[0], canonical_source: 'README.md', localized_path: 'README.md' }
+  const badLocaleFindings2 = JSON.stringify(validateManifest({ ...manifest, entries: [badLocaleEntry2, manifest.entries[1]] }, root))
+  assert.match(badLocaleFindings2, /invalid-translation-file-pairing/)
   assert.equal(loadManifest(path.join(root, 'missing')), null)
 })
 


### PR DESCRIPTION
## Resumo
Added BCP-47 locale code format validation to `check-documentation-localization.mjs` and ensured translation files correctly pair with their canonical sources based on paths. Modified tests to check invalid BCP-47 locales (e.g. `pt_BR`) and incorrect pairs.

## Issue
TestCov-100

## Owner
agent-governance

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|

## Labels
type:ci, type:test, scope:localization

## Validacao
`node --test tools/ci/check-documentation-localization.test.mjs`

## Rollback trigger
Rollback if tests break or correct locale/pairing definitions are incorrectly marked as failing (e.g. false positives in regex/path validation).

---
*PR created automatically by Jules for task [17638617760485642702](https://jules.google.com/task/17638617760485642702) started by @emersonbusson*