### PR TITLE
test(ci-tooling): fix json parsing unhandled exception & add guard tests

### DIFF
--- a/tools/ci/check-documentation-governance.mjs
+++ b/tools/ci/check-documentation-governance.mjs
@@ -320,33 +320,91 @@ function structuralFiles(root) {
     if (!(rel === 'README.md' || rel === 'README.pt-BR.md' || rel === 'ARCHITECTURE.md' || rel === 'CLAUDE.md' || rel === 'AGENTS.md' || rel === 'validation.md' || rel.startsWith('.claude/rules/') || rel.startsWith('docs/') || rel === 'scripts/docs-check.sh')) continue
     const stat = statSync(full)
     if (stat.size > MAX_FILE_BYTES) { files.push({ path: rel, text: '', oversize: true }); continue }
-    files.push({ path: rel, text: readFileSync(full, 'utf8') })
+    try {
+      files.push({ path: rel, text: readFileSync(full, 'utf8') })
+    } catch (err) {
+      if (err.code !== 'ENOENT' && err.code !== 'EACCES') throw err
+      files.push({ path: rel, text: '', unreadable: true })
+    }
     if (files.length > MAX_FILES) break
   }
   return files
 }
 
 function readJson(root, rel) {
-  return JSON.parse(readFileSync(path.join(root, rel), 'utf8'))
+  try {
+    return JSON.parse(readFileSync(path.join(root, rel), 'utf8'))
+  } catch (err) {
+    if (err.code === 'ENOENT' || err.code === 'EACCES') return null
+    return { _parseError: true }
+  }
+}
+
+function tryReadFileSync(root, rel) {
+  try {
+    return readFileSync(path.join(root, rel), 'utf8')
+  } catch {
+    return null
+  }
 }
 
 export function run({ root = ROOT } = {}) {
   const findings = []
-  const parity = readFileSync(path.join(root, 'docs/DOCUMENTATION-PARITY.md'), 'utf8')
-  const reference = readFileSync(path.join(root, 'docs/reference/REFERENCE-INDEX.md'), 'utf8')
-  const governance = readFileSync(path.join(root, 'docs/governance/README.md'), 'utf8')
-  findings.push(...validateParityDocument(parity, root), ...validateReferenceIndex(reference, root))
-  findings.push(...validateRouterConsistency(parity, reference, governance))
+  const parity = tryReadFileSync(root, 'docs/DOCUMENTATION-PARITY.md')
+  const reference = tryReadFileSync(root, 'docs/reference/REFERENCE-INDEX.md')
+  const governance = tryReadFileSync(root, 'docs/governance/README.md')
+
+  if (parity === null) findings.push(finding('docs/DOCUMENTATION-PARITY.md', 1, 'MISSING_GOVERNANCE_FILE', 'missing docs/DOCUMENTATION-PARITY.md'))
+  if (reference === null) findings.push(finding('docs/reference/REFERENCE-INDEX.md', 1, 'MISSING_GOVERNANCE_FILE', 'missing docs/reference/REFERENCE-INDEX.md'))
+  if (governance === null) findings.push(finding('docs/governance/README.md', 1, 'MISSING_GOVERNANCE_FILE', 'missing docs/governance/README.md'))
+
+  if (parity !== null) findings.push(...validateParityDocument(parity, root))
+  if (reference !== null) findings.push(...validateReferenceIndex(reference, root))
+  if (parity !== null && reference !== null && governance !== null) findings.push(...validateRouterConsistency(parity, reference, governance))
+
   const claims = readJson(root, 'docs/governance/claims.json')
-  findings.push(...validateClaims(claims, root))
-  const closureResult = evaluateClaimClosures(claims, loadClaimClosures(root), { root })
-  for (const reason of closureResult.findings) findings.push(finding('docs/governance/claim-closures.json', 1, 'CLAIM_CLOSURE', reason))
+  if (claims === null) {
+    findings.push(finding('docs/governance/claims.json', 1, 'MISSING_GOVERNANCE_FILE', 'missing docs/governance/claims.json'))
+  } else if (claims?._parseError) {
+    findings.push(finding('docs/governance/claims.json', 1, 'INVALID_JSON', 'docs/governance/claims.json is not valid JSON'))
+  } else {
+    findings.push(...validateClaims(claims, root))
+
+    const closureRegistry = loadClaimClosures(root)
+    if (closureRegistry === null) {
+        findings.push(finding('docs/governance/claim-closures.json', 1, 'MISSING_GOVERNANCE_FILE', 'missing docs/governance/claim-closures.json'))
+    } else if (closureRegistry?._parseError) {
+        findings.push(finding('docs/governance/claim-closures.json', 1, 'INVALID_JSON', 'docs/governance/claim-closures.json is not valid JSON'))
+    } else {
+        const closureResult = evaluateClaimClosures(claims, closureRegistry, { root })
+        for (const reason of closureResult.findings) findings.push(finding('docs/governance/claim-closures.json', 1, 'CLAIM_CLOSURE', reason))
+    }
+  }
   const files = structuralFiles(root)
   for (const file of files.filter((item) => item.oversize)) findings.push(finding(file.path, 1, 'FILE_LIMIT', 'file-size-limit'))
-  findings.push(...scanProvenance(files, readJson(root, 'docs/governance/provenance-allowlist.json'), readJson(root, 'docs/governance/provenance-baseline.json')))
+
+  const allowlist = readJson(root, 'docs/governance/provenance-allowlist.json')
+  const baseline = readJson(root, 'docs/governance/provenance-baseline.json')
+
+  if (allowlist === null) findings.push(finding('docs/governance/provenance-allowlist.json', 1, 'MISSING_GOVERNANCE_FILE', 'missing docs/governance/provenance-allowlist.json'))
+  else if (allowlist?._parseError) findings.push(finding('docs/governance/provenance-allowlist.json', 1, 'INVALID_JSON', 'docs/governance/provenance-allowlist.json is not valid JSON'))
+
+  if (baseline === null) findings.push(finding('docs/governance/provenance-baseline.json', 1, 'MISSING_GOVERNANCE_FILE', 'missing docs/governance/provenance-baseline.json'))
+  else if (baseline?._parseError) findings.push(finding('docs/governance/provenance-baseline.json', 1, 'INVALID_JSON', 'docs/governance/provenance-baseline.json is not valid JSON'))
+
+  if (allowlist !== null && !allowlist?._parseError && baseline !== null && !baseline?._parseError) {
+    findings.push(...scanProvenance(files, allowlist, baseline))
+  }
+
   findings.push(...validateReadmeHygiene(files))
   const journey = readJson(root, 'docs/governance/journeys/documentation-governance-smoke.json')
-  for (const reason of validateJourneyManifest(journey, root)) findings.push(finding('docs/governance/journeys/documentation-governance-smoke.json', 1, 'JOURNEY', reason))
+  if (journey === null) {
+    findings.push(finding('docs/governance/journeys/documentation-governance-smoke.json', 1, 'MISSING_GOVERNANCE_FILE', 'missing docs/governance/journeys/documentation-governance-smoke.json'))
+  } else if (journey?._parseError) {
+    findings.push(finding('docs/governance/journeys/documentation-governance-smoke.json', 1, 'INVALID_JSON', 'docs/governance/journeys/documentation-governance-smoke.json is not valid JSON'))
+  } else {
+    for (const reason of validateJourneyManifest(journey, root)) findings.push(finding('docs/governance/journeys/documentation-governance-smoke.json', 1, 'JOURNEY', reason))
+  }
   for (const file of files.filter((item) => item.path.startsWith('docs/postmortems/') && item.path.endsWith('.md'))) for (const reason of validatePostmortemEffectiveness(file.text, file.path)) findings.push(finding(file.path, 1, 'POSTMORTEM', reason))
   return { ok: findings.length === 0, findings: sorted(findings), counts: { files: files.length, findings: findings.length } }
 }

--- a/tools/ci/check-documentation-governance.test.mjs
+++ b/tools/ci/check-documentation-governance.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
@@ -199,6 +199,46 @@ test('governance_cli_check_aliases_all_and_unknown_options_refuse', () => {
   const all = spawnSync(process.execPath, [cli, '--all'], { encoding: 'utf8' })
   const check = spawnSync(process.execPath, [cli, '--check'], { encoding: 'utf8' })
   assert.equal(check.status, all.status)
+})
+
+test('governance_handles_missing_rule_files', () => {
+  const root = rootFixture()
+  const result = runGovernance({ root })
+  assert.equal(result.ok, false)
+  const findings = result.findings.map((f) => f.rule)
+  assert.ok(findings.includes('MISSING_GOVERNANCE_FILE'))
+})
+
+test('governance_handles_invalid_json', () => {
+  const root = rootFixture()
+  mkdirSync(path.join(root, 'docs/governance'), { recursive: true })
+  writeFileSync(path.join(root, 'docs/governance/claims.json'), '{invalid')
+  const result = runGovernance({ root })
+  assert.equal(result.ok, false)
+  const findings = result.findings.map((f) => f.rule)
+  assert.ok(findings.includes('INVALID_JSON'))
+})
+
+test('governance_handles_permission_denied', () => {
+  const root = rootFixture()
+  mkdirSync(path.join(root, 'docs/governance'), { recursive: true })
+  const claimsPath = path.join(root, 'docs/governance/claims.json')
+  writeFileSync(claimsPath, '{}')
+  try {
+    chmodSync(claimsPath, 0o000)
+    const result = runGovernance({ root })
+    assert.equal(result.ok, false)
+    const findings = result.findings.map((f) => f.rule)
+    assert.ok(findings.includes('MISSING_GOVERNANCE_FILE'))
+  } finally {
+    chmodSync(claimsPath, 0o644)
+  }
+})
+
+test('governance_cli_check_aliases_all_and_unknown_options_refuse_extended', () => {
+  const cli = fileURLToPath(new URL('./check-documentation-governance.mjs', import.meta.url))
+  const all = spawnSync(process.execPath, [cli, '--all'], { encoding: 'utf8' })
+  const check = spawnSync(process.execPath, [cli, '--check'], { encoding: 'utf8' })
   assert.equal(check.stdout, all.stdout)
   assert.equal(check.stderr, all.stderr)
   assert.equal(spawnSync(process.execPath, [cli, '--not-a-mode'], { encoding: 'utf8' }).status, 2)

--- a/tools/ci/documentation-claim-closure.mjs
+++ b/tools/ci/documentation-claim-closure.mjs
@@ -127,11 +127,11 @@ export function computeClosureDigest(closure) {
 
 export function loadClaimClosures(root) {
   const absolute = path.join(root, CLAIM_CLOSURE_PATH)
-  if (!existsSync(absolute)) return null
   try {
     return JSON.parse(readFileSync(absolute, 'utf8'))
-  } catch {
-    return null
+  } catch (err) {
+    if (err.code === 'ENOENT' || err.code === 'EACCES') return null
+    return { _parseError: true }
   }
 }
 


### PR DESCRIPTION
## Resumo
Added guard clauses and `try-catch` blocks in `tools/ci/check-documentation-governance.mjs` to safely handle missing files and JSON parsing errors, preventing ungraceful script crashes (like `ENOENT`, `EACCES`, and `SyntaxError`). Added corresponding tests to verify graceful error handling paths.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 266e72c | Added graceful error handling and guard tests for missing or malformed rule files | To prevent pipeline crashes and provide structured validation errors | Wrapped `readFileSync` and `JSON.parse` in try-catch and introduced tests covering missing file, missing permission, and invalid JSON scenarios. |

## Issue
N/A

## Owner
agent-governance

## Labels
type:ci, scope:ci-tooling

## Validacao
`node --test` executed successfully, passing all 485 tests.

## Rollback trigger
Revert if `check-documentation-governance.mjs` fails inappropriately on valid governance structures or introduces false positive validation results on rule checks.

---
*PR created automatically by Jules for task [13802297023771722190](https://jules.google.com/task/13802297023771722190) started by @emersonbusson*