### PR TITLE
test(ci-tooling): harden CLI arguments and add comprehensive tests

### DIFF
--- a/tools/ci/check-task-log.mjs
+++ b/tools/ci/check-task-log.mjs
@@ -214,23 +214,29 @@ export function run({ root = ROOT, baseRef = null, all = false } = {}) {
   return { ok: violations.length === 0, violations }
 }
 
-function main(argv = process.argv.slice(2)) {
+export function main(argv = process.argv.slice(2), { stdout = process.stdout, stderr = process.stderr, root = undefined } = {}) {
   const all = argv.includes('--all')
   const diffIndex = argv.indexOf('--diff')
   const baseRef = diffIndex === -1 ? null : argv[diffIndex + 1]
-  if (!all && !baseRef) {
-    process.stderr.write('usage: check-task-log.mjs (--all | --diff <baseRef>)\n')
+  if ((!all && diffIndex === -1) || (diffIndex !== -1 && (!baseRef || baseRef.startsWith('--')))) {
+    stderr.write('usage: check-task-log.mjs (--all | --diff <baseRef>)\n')
     return 2
   }
-  const result = run({ all, baseRef })
+  const result = run({ all, baseRef, root: root ?? ROOT })
   if (result.ok) {
-    process.stdout.write(`✓ ${TARGET} schema OK (${all ? 'all records' : `diff vs ${baseRef}`})\n`)
+    stdout.write(`✓ ${TARGET} schema OK (${all ? 'all records' : `diff vs ${baseRef}`})\n`)
     return 0
   }
   for (const violation of result.violations) {
-    process.stdout.write(`${TARGET}:${violation.line} — ${violation.rule}: ${violation.message}\n`)
+    stdout.write(`${TARGET}:${violation.line} — ${violation.rule}: ${violation.message}\n`)
   }
   return 1
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) process.exitCode = main()
+if (
+  import.meta.url === `file://${process.argv[1]}` &&
+  typeof process.env.NODE_TEST_CONTEXT === 'undefined' &&
+  !process.argv.includes('--test')
+) {
+  process.exitCode = main()
+}

--- a/tools/ci/check-task-log.test.mjs
+++ b/tools/ci/check-task-log.test.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
 
-import { run, validateTaskLog } from './check-task-log.mjs'
+import { run, validateTaskLog, main } from './check-task-log.mjs'
 
 const RECORD = `## TASK-0001 — Fixture task
 **Schema:** \`ramshared.task.v1\`.
@@ -121,4 +121,103 @@ test('accepts an existing task update with a newer updated time', () => {
     )
   )
   assert.deepEqual(run({ root, baseRef: 'HEAD' }), { ok: true, violations: [] })
+})
+
+test('test_cli_missing_args_fails', () => {
+  let errOutput = ''
+  const stderr = { write: (msg) => { errOutput += msg } }
+
+  assert.equal(main([], { stderr }), 2)
+  assert.match(errOutput, /usage/)
+})
+
+test('test_cli_diff_missing_base_ref_fails', () => {
+  let errOutput = ''
+  const stderr = { write: (msg) => { errOutput += msg } }
+
+  assert.equal(main(['--diff'], { stderr }), 2)
+  assert.match(errOutput, /usage/)
+})
+
+test('test_cli_diff_invalid_base_ref_fails', () => {
+  let errOutput = ''
+  const stderr = { write: (msg) => { errOutput += msg } }
+
+  assert.equal(main(['--diff', '--all'], { stderr }), 2)
+  assert.match(errOutput, /usage/)
+})
+
+test('test_cli_all_success', () => {
+  let outOutput = ''
+  const stdout = { write: (msg) => { outOutput += msg } }
+
+  const root = gitFixture()
+  assert.equal(main(['--all'], { stdout, root }), 0)
+  assert.match(outOutput, /schema OK/)
+})
+
+test('test_cli_diff_violations_returns_1', () => {
+  let outOutput = ''
+  const stdout = { write: (msg) => { outOutput += msg } }
+
+  const root = gitFixture()
+  writeFileSync(path.join(root, 'TASK.md'), taskLog(RECORD.replace('**Updated time:** `12:00:00`.', '')))
+
+  assert.equal(main(['--diff', 'HEAD'], { stdout, root }), 1)
+  assert.match(outOutput, /missing or invalid \`\*\*Updated time:\*\*\`/)
+})
+
+test('test_cli_diff_error_returns_1', () => {
+  let outOutput = ''
+  const stdout = { write: (msg) => { outOutput += msg } }
+
+  const root = gitFixture()
+
+  assert.equal(main(['--diff', 'invalid-ref'], { stdout, root }), 1)
+  assert.match(outOutput, /unable to read the requested Git base revision/)
+})
+
+test('test_validate_task_log_no_marker', () => {
+  assert.equal(validateTaskLog('missing marker').length, 1)
+})
+
+test('test_validate_task_log_no_records', () => {
+  assert.equal(validateTaskLog('<!-- task-schema-v1 -->\n').length, 1)
+})
+
+test('test_run_missing_task_md', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ramshared-task-log-missing-'))
+  const result = run({ root })
+  assert.equal(result.ok, false)
+  assert.match(result.violations[0].message, /TASK.md does not exist/)
+})
+
+test('test_run_diff_missing_git_ref', () => {
+  const root = gitFixture()
+  const result = run({ root, baseRef: 'invalid-ref' })
+  assert.equal(result.ok, false)
+  assert.match(result.violations[0].message, /unable to read the requested Git base revision/)
+})
+
+test('test_run_diff_task_removed', () => {
+  const root = gitFixture()
+  writeFileSync(path.join(root, 'TASK.md'), taskLog(''))
+  const result = run({ root, baseRef: 'HEAD' })
+  assert.equal(result.ok, false)
+  assert.match(JSON.stringify(result.violations), /was removed/)
+})
+
+test('test_validateRecord_missing_schema', () => {
+  const violations = validateTaskLog(taskLog(RECORD.replace('**Schema:** `ramshared.task.v1`.', '')))
+  assert.match(JSON.stringify(violations), /missing \`\*\*Schema:\*\* \`ramshared.task.v1\`\`/)
+})
+
+test('test_validateRecord_invalid_updated_precedes_registered', () => {
+  const violations = validateTaskLog(taskLog(RECORD.replace('**Updated time:** `12:00:00`.', '**Updated time:** `11:00:00`.')))
+  assert.match(JSON.stringify(violations), /must not precede/)
+})
+
+test('test_validateRecord_invalid_source_revision', () => {
+  const violations = validateTaskLog(taskLog(RECORD.replace('**Source revision:** `fd5cbf2d39a026bcf737a3082ef2497d3861b257`.', '**Source revision:** `xyz`.')))
+  assert.match(JSON.stringify(violations), /missing or invalid \`\*\*Source revision:\*\*\` Git revision/)
 })


### PR DESCRIPTION
## Resumo

Hardened tools/ci/check-task-log.mjs with input validation on CLI arguments, improved error handling (ensuring correct stdout/stderr usage in the main function) and added comprehensive test coverage for boundaries, error paths, and missing dependencies in tools/ci/check-task-log.test.mjs.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 053c608 | Harden CLI arguments and add tests | Prevent CI script errors on bad arguments and achieve 100% test coverage | Added checks for missing and malformed CLI args (`--diff` missing `baseRef`) and covered missing `TASK.md`, invalid refs, missing schemas, etc. |

## Issue

Fixes #1

## Owner

governance

## Labels

type:ci, scope:tools

## Validacao

node --test

## Rollback trigger

Revert if check-task-log.mjs crashes on valid inputs during CI tasks or fails to properly validate TASK.md schemas.

---
*PR created automatically by Jules for task [9202924372675893436](https://jules.google.com/task/9202924372675893436) started by @emersonbusson*