### PR TITLE
test(ci): harden generate-documentation-inventory.mjs with io validation

### DIFF
--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,7 @@
+test(ci): harden generate-documentation-inventory.mjs with io validation
+
+- Validates that the 'docs' directory exists before attempting any operation.
+- Validates that the output directory for the inventory is writable.
+- Adds test cases checking empty docs directory handling and unclassified common fields.
+
+Rollback trigger: Revert if the script crashes on valid environments or test pipeline blocks execution.

--- a/tools/ci/generate-documentation-inventory.mjs
+++ b/tools/ci/generate-documentation-inventory.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { createHash } from 'node:crypto'
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, accessSync, constants } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
@@ -56,6 +56,20 @@ function main(argv = process.argv.slice(2)) {
     console.error('usage: generate-documentation-inventory.mjs --write|--check')
     return 2
   }
+
+  if (!existsSync(path.join(ROOT, 'docs'))) {
+    console.error('ERROR: docs directory does not exist')
+    return 1
+  }
+
+  const outputDir = path.dirname(path.join(ROOT, OUTPUT_PATH))
+  try {
+    accessSync(outputDir, constants.W_OK)
+  } catch (error) {
+    console.error(`ERROR: output directory ${outputDir} is not writable`)
+    return 1
+  }
+
   if (argv[0] === '--write') {
     writeFileSync(path.join(ROOT, OUTPUT_PATH), renderInventory(buildInventory({ root: ROOT })))
     console.log(`DOCUMENTATION_INVENTORY=written ${OUTPUT_PATH}`)

--- a/tools/ci/generate-documentation-inventory.test.mjs
+++ b/tools/ci/generate-documentation-inventory.test.mjs
@@ -22,3 +22,24 @@ test('checked inventory matches its deterministic generator output', () => {
   const result = checkInventory({ root: process.cwd(), current: output })
   assert.equal(result.ok, true, result.reason)
 })
+
+test('test_buildInventory_empty_docs_returns_empty_inventory', () => {
+  const inventory = buildInventory({
+    root: process.cwd(),
+    paths: [],
+    policy: { schemaVersion: 'ramshared.document-lifecycle-policy.v1', owner: 'governance', routes: [], exclusions: [] }
+  })
+  assert.equal(inventory.counts.total, 0)
+  assert.equal(inventory.entries.length, 0)
+})
+
+test('test_buildInventory_unclassified_document_handles_common_fields', () => {
+  const paths = ['docs/some/unknown/file.md']
+  const policy = { schemaVersion: 'ramshared.document-lifecycle-policy.v1', owner: 'governance', routes: [], exclusions: [] }
+  const inventory = buildInventory({ root: process.cwd(), paths, policy })
+  assert.equal(inventory.counts.total, 1)
+  assert.equal(inventory.counts.unclassified, 1)
+  assert.equal(inventory.entries[0].disposition, 'unclassified')
+  assert.equal(inventory.entries[0].ruleId, null)
+  assert.equal(inventory.entries[0].verification.state, 'unverified')
+})


### PR DESCRIPTION
## Resumo
Validates docs directory exists and output path parent dir is writable in generate-documentation-inventory.mjs.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| test(ci): harden generate-documentation-inventory.mjs with io validation | Add guard clauses and IO validation | Prevent crash on missing docs directory | Checks docs exists and output dir writable |

## Issue
N/A

## Owner
N/A

## Labels
type:ci, scope:tools

## Validacao
node --test

## Rollback trigger
Revert if the script crashes on valid environments or test pipeline blocks execution.

---
*PR created automatically by Jules for task [2396740436455805493](https://jules.google.com/task/2396740436455805493) started by @emersonbusson*