### PR TITLE
feat(ci-tooling): guard clauses for semantic version tag and changelog entry

### DIFF
--- a/tools/ci/check-release-publication.mjs
+++ b/tools/ci/check-release-publication.mjs
@@ -59,11 +59,30 @@ export function validateReleasePromotionPolicy(policy) {
   return { ok: errors.length === 0, errors }
 }
 
-export function validatePublicationInput(input, policy) {
+const SEMVER_TAG_RE = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+
+function checkChangelogEntry(tag, root) {
+  try {
+    const changelogPath = path.resolve(root || process.cwd(), 'CHANGELOG.md')
+    if (!existsSync(changelogPath)) return false
+    const content = readFileSync(changelogPath, 'utf8')
+    const version = tag.replace(/^v/, '')
+    const headerPrefix = `## [${version}]`
+    return content.includes(headerPrefix)
+  } catch {
+    return false
+  }
+}
+
+export function validatePublicationInput(input, policy, { root } = {}) {
   const errors = [...validateReleasePromotionPolicy(policy).errors]
   if (!isObject(input) || input.tag !== policy?.target_tag || !SOURCE_SHA_RE.test(input.source_sha) ||
       typeof input.integrity_run_id !== 'string' || !/^[1-9][0-9]{0,18}$/.test(input.integrity_run_id)) {
     add(errors, 'publication-input-invalid')
+  } else if (!SEMVER_TAG_RE.test(input.tag)) {
+    add(errors, 'publication-tag-not-semver')
+  } else if (!checkChangelogEntry(input.tag, root)) {
+    add(errors, 'publication-changelog-missing')
   }
   return { ok: errors.length === 0, errors: errors.sort() }
 }
@@ -81,9 +100,9 @@ export function validatePublicationCandidate(policy, candidate) {
   return { ok: errors.length === 0, errors: errors.sort() }
 }
 
-export function validatePublicationBinding(input, candidate, policy) {
+export function validatePublicationBinding(input, candidate, policy, { root } = {}) {
   const errors = [
-    ...validatePublicationInput(input, policy).errors,
+    ...validatePublicationInput(input, policy, { root }).errors,
     ...validatePublicationCandidate(policy, candidate).errors,
   ]
   if (candidate?.source?.tag !== input?.tag || candidate?.source?.sha !== input?.source_sha) {
@@ -260,7 +279,7 @@ export function main(argv = process.argv.slice(2), { cwd = process.cwd(), print 
         tag: args.values.get('--tag'),
         source_sha: args.values.get('--source-sha'),
         integrity_run_id: args.values.get('--integrity-run-id'),
-      }, policy)
+      }, policy, { root: cwd })
       if (!inputResult.ok) throw new Error(inputResult.errors.join(','))
       print('RELEASE_PUBLICATION_INPUT=PASS')
       return 0
@@ -271,13 +290,13 @@ export function main(argv = process.argv.slice(2), { cwd = process.cwd(), print 
         source_sha: args.values.get('--source-sha'),
         integrity_run_id: args.values.get('--integrity-run-id'),
       }
-      const inputResult = validatePublicationInput(input, policy)
-      if (!inputResult.ok) throw new Error(inputResult.errors.join(','))
       const root = resolveRelative(cwd, args.values.get('--root'), { allowRoot: true })
+      const inputResult = validatePublicationInput(input, policy, { root })
+      if (!inputResult.ok) throw new Error(inputResult.errors.join(','))
       const manifestPath = resolveRelative(cwd, args.values.get('--manifest'))
       if (!root || !manifestPath) throw new Error('publication-candidate-path-invalid')
       const candidate = candidateFromReleaseManifest(readJson(manifestPath), { root })
-      const binding = validatePublicationBinding(input, candidate, policy)
+      const binding = validatePublicationBinding(input, candidate, policy, { root })
       if (!binding.ok) {
         throw new Error(binding.errors.join(','))
       }

--- a/tools/ci/check-release-publication.test.mjs
+++ b/tools/ci/check-release-publication.test.mjs
@@ -94,19 +94,44 @@ function candidate() {
 
 test('publication_input_rejects_historical_or_non_exact_identity', () => {
   assert.deepEqual(validateReleasePromotionPolicy(POLICY), { ok: true, errors: [] })
+  const fixture = releaseCandidateFixture()
+  writeFileSync(path.join(fixture.root, 'CHANGELOG.md'), '## [0.9.0-beta.1]\n')
   assert.deepEqual(validatePublicationInput({
     tag: TARGET_TAG,
     source_sha: SOURCE_SHA,
     integrity_run_id: '123456',
-  }, POLICY), { ok: true, errors: [] })
+  }, POLICY, { root: fixture.root }), { ok: true, errors: [] })
   for (const input of [
     { tag: 'v0.8.0', source_sha: SOURCE_SHA, integrity_run_id: '123456' },
     { tag: TARGET_TAG, source_sha: 'main', integrity_run_id: '123456' },
     { tag: TARGET_TAG, source_sha: SOURCE_SHA, integrity_run_id: '0' },
   ]) {
-    const result = validatePublicationInput(input, POLICY)
+    const result = validatePublicationInput(input, POLICY, { root: fixture.root })
     assert.equal(result.ok, false)
   }
+})
+
+test('publication_input_rejects_non_semver_tag', () => {
+  const fixture = releaseCandidateFixture()
+  writeFileSync(path.join(fixture.root, 'CHANGELOG.md'), '## [0.9.0-beta.1]\n')
+  const result = validatePublicationInput({
+    tag: 'invalid-tag',
+    source_sha: SOURCE_SHA,
+    integrity_run_id: '123456',
+  }, { ...POLICY, target_tag: 'invalid-tag' }, { root: fixture.root })
+  assert.equal(result.ok, false)
+  assert.equal(result.errors.includes('publication-tag-not-semver'), true)
+})
+
+test('publication_input_rejects_missing_changelog', () => {
+  const fixture = releaseCandidateFixture()
+  const result = validatePublicationInput({
+    tag: TARGET_TAG,
+    source_sha: SOURCE_SHA,
+    integrity_run_id: '123456',
+  }, POLICY, { root: fixture.root })
+  assert.equal(result.ok, false)
+  assert.equal(result.errors.includes('publication-changelog-missing'), true)
 })
 
 test('publication_policy_and_candidate_refuse_malformed_records', () => {
@@ -294,6 +319,7 @@ test('publication_candidate_and_plan_cli_bind_files_and_fail_closed_on_paths', (
   assert.deepEqual(direct.public_assets.map((record) => record.name), PUBLIC_ASSETS)
 
   const output = []
+  writeFileSync(path.join(fixture.root, 'CHANGELOG.md'), '## [0.9.0-beta.1]\n')
   assert.equal(main([
     '--policy', 'policy.json',
     '--manifest', 'artifacts/release/release-manifest.json',
@@ -305,7 +331,7 @@ test('publication_candidate_and_plan_cli_bind_files_and_fail_closed_on_paths', (
   ], {
     cwd: fixture.root,
     print: (line) => output.push(line),
-    error: () => assert.fail('verified candidate must not emit an error'),
+    error: (msg) => assert.fail(`verified candidate must not emit an error: ${msg}`),
   }), 0)
   assert.deepEqual(output, ['RELEASE_PUBLICATION_CANDIDATE=PASS'])
   const candidateJson = JSON.parse(readFileSync(path.join(fixture.root, 'candidate.json'), 'utf8'))


### PR DESCRIPTION
## Resumo

Adicionada validacao obrigatoria de versionamento semantico para tags de release e checagem da existencia de uma entrada correspondente no arquivo CHANGELOG.md para garantir o cumprimento dos contratos de CI de publicacao.

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 226cbbde2325906812133d23ebfdbd129b5be798 | Implementou SEMVER_TAG_RE e checkChangelogEntry | Para bloquear publicacoes com tags malformadas ou sem documentacao no changelog | Atualizou validatePublicationInput para realizar parsing estrito da tag e validar o CHANGELOG.md na raiz do repositorio, alem de injetar o root dinamicamente para os mocks de teste |

## Owner

agent-ci-tooling

## Issue

TestCov100-085

## Labels

type:ci, scope:ci-tooling

## Validacao

node --test

## Rollback trigger

Se ocorrer bloqueio indevido de tags semanticas validas (ex: v1.0.0-rc.1) ou falsos negativos no parsing do CHANGELOG.md que impessam publicacoes legtimas em producao.

---
*PR created automatically by Jules for task [7931715061548603665](https://jules.google.com/task/7931715061548603665) started by @emersonbusson*