### PR TITLE
build(pkg): enforce fail-fast for rpmbuild requirements

### DIFF
--- a/scripts/package/build-rpm-package.sh
+++ b/scripts/package/build-rpm-package.sh
@@ -79,11 +79,21 @@ fi
 - Official v0.9.0-beta.2 Linux RPM release with hardware DMA & ublk support.
 SPEC_EOF
 
-if command -v rpmbuild >/dev/null 2>&1; then
-  echo "==> Executing rpmbuild..."
-  rpmbuild --define "_topdir $RPM_ROOT" -bb "$SPEC_FILE"
-  cp "$RPM_ROOT"/RPMS/*/*.rpm "$OUT_DIR/" 2>/dev/null || true
-  echo "✓ RPM package built under $OUT_DIR/"
-else
-  echo "==> rpmbuild not installed on host. Spec generated at $SPEC_FILE (PASS)."
+for cmd in rpmbuild spectool createrepo; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: Required command '$cmd' is not installed." >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$OUT_DIR"
+AVAILABLE_SPACE=$(df -kP "$OUT_DIR" | awk 'NR==2 {print $4}')
+if [ -n "$AVAILABLE_SPACE" ] && [ "$AVAILABLE_SPACE" -lt 512000 ]; then
+  echo "ERROR: Insufficient disk space in $OUT_DIR (less than 500MB)." >&2
+  exit 1
 fi
+
+echo "==> Executing rpmbuild..."
+rpmbuild --define "_topdir $RPM_ROOT" -bb "$SPEC_FILE"
+cp "$RPM_ROOT"/RPMS/*/*.rpm "$OUT_DIR/" 2>/dev/null || true
+echo "✓ RPM package built under $OUT_DIR/"


### PR DESCRIPTION
## Resumo
Validates rpmbuild prerequisites and available disk space to enforce fail-fast isolation.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 7f793d4 | build(pkg): enforce fail-fast for rpmbuild requirements | To enforce fail-fast isolation during package build | Validated space checks and command existence |

## Labels
area:ci-tooling
type:packaging

## Validacao
mkdir -p target/release
touch target/release/ramshared target/release/ramsharedd
chmod +x target/release/ramshared target/release/ramsharedd
export PATH=$PATH:$PWD/mock_bin
mkdir -p mock_bin
cat << 'EOF' > mock_bin/rpmbuild
#!/bin/bash
echo "mock rpmbuild"
EOF
cat << 'EOF' > mock_bin/spectool
#!/bin/bash
echo "mock spectool"
EOF
cat << 'EOF' > mock_bin/createrepo
#!/bin/bash
echo "mock createrepo"
EOF
chmod +x mock_bin/rpmbuild mock_bin/spectool mock_bin/createrepo
./scripts/package/build-rpm-package.sh
rm -rf mock_bin
rm -rf artifacts
rm -rf target
cargo test

## Rollback trigger
Revert if RPM package builds start failing unexpectedly due to strict space requirements or missing dependencies in clean environments.

---
*PR created automatically by Jules for task [12033119581048859051](https://jules.google.com/task/12033119581048859051) started by @emersonbusson*