### PR TITLE
feat(ci): add PKGBUILD namcap lint check harness

### DIFF
--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -41,6 +41,11 @@ run_gate gap-register node tools/ci/check-gap-register.mjs
 run_gate public-hygiene node tools/ci/check-public-hygiene.mjs --candidate
 run_gate public-hygiene-tests node --test --test-reporter=dot tools/ci/check-public-hygiene.test.mjs
 run_gate legacy-preallocation-removal node tools/ci/check-legacy-preallocation-removal.mjs --candidate
+run_gate pkgbuild-namcap node tools/ci/check-pkgbuild-namcap.mjs
+run_gate pkgbuild-namcap-tests node --experimental-test-coverage \
+  --test-coverage-include=tools/ci/check-pkgbuild-namcap.mjs \
+  --test-coverage-lines=80 --test-coverage-branches=80 --test-coverage-functions=80 \
+  --test-reporter=dot tools/ci/check-pkgbuild-namcap.test.mjs
 run_gate legacy-preallocation-removal-tests node --experimental-test-coverage \
   --test-coverage-include=tools/ci/check-legacy-preallocation-removal.mjs \
   --test-coverage-lines=80 --test-coverage-branches=80 --test-coverage-functions=80 \

--- a/tools/ci/check-pkgbuild-namcap.mjs
+++ b/tools/ci/check-pkgbuild-namcap.mjs
@@ -1,0 +1,63 @@
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const root = join(__dirname, '../..');
+const defaultTarget = join(root, 'packaging/arch/PKGBUILD');
+const target = process.env.PKGBUILD_TARGET || defaultTarget;
+
+/* node:coverage disable */
+if (typeof process.env.NODE_TEST_CONTEXT !== 'undefined' || process.argv.includes('--test')) {
+    // Prevent main execution during unit tests
+}
+/* node:coverage enable */
+
+export function runChecks(targetPath) {
+    if (!existsSync(targetPath)) {
+        console.error(`ERROR: ${targetPath} not found.`);
+        return false;
+    }
+
+    console.log(`==> Verifying ${targetPath}...`);
+    // Allow overriding command for tests
+    const namcapCmd = process.env.MOCK_NAMCAP_CMD || 'namcap';
+    const bashCmd = process.env.MOCK_BASH_CMD || 'bash';
+
+    // Simple check to see if we should try namcap
+    const hasNamcap = process.env.MOCK_HAS_NAMCAP === '1' ||
+                     (process.env.MOCK_HAS_NAMCAP !== '0' && spawnSync('command', ['-v', namcapCmd], { shell: true }).status === 0);
+
+    if (hasNamcap) {
+        console.log(`==> Running namcap lint...`);
+        const namcap = spawnSync(namcapCmd, [targetPath], { stdio: 'inherit', shell: true });
+        if (namcap.status !== 0) {
+            console.error(`ERROR: namcap failed on ${targetPath}`);
+            return false;
+        } else {
+            console.log(`✓ namcap found zero fatal errors.`);
+            return true;
+        }
+    } else {
+        console.log(`==> namcap unavailable, performing baseline syntax check (bash -n)...`);
+        const bash = spawnSync(bashCmd, ['-n', targetPath], { stdio: 'inherit', shell: true });
+        if (bash.status !== 0) {
+            console.error(`ERROR: Baseline syntax check failed on ${targetPath}`);
+            return false;
+        } else {
+            console.log(`✓ Baseline syntax check passed.`);
+            return true;
+        }
+    }
+}
+
+// Ensure the CLI execution matches the new logic
+/* node:coverage disable */
+if (import.meta.url === `file://${process.argv[1]}` && !process.argv.includes('--test') && typeof process.env.NODE_TEST_CONTEXT === 'undefined') {
+    if (!runChecks(target)) {
+        process.exitCode = 1;
+    }
+}
+/* node:coverage enable */

--- a/tools/ci/check-pkgbuild-namcap.test.mjs
+++ b/tools/ci/check-pkgbuild-namcap.test.mjs
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { runChecks } from './check-pkgbuild-namcap.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const root = join(__dirname, '../..');
+
+test('check-pkgbuild-namcap.mjs: success on syntax check when namcap is absent', () => {
+    const validTarget = join(root, 'packaging/arch/PKGBUILD');
+    const originalEnv = { ...process.env };
+    process.env.MOCK_HAS_NAMCAP = '0';
+    process.env.MOCK_BASH_CMD = 'bash';
+
+    try {
+        const result = runChecks(validTarget);
+        assert.strictEqual(result, true);
+    } finally {
+        process.env = originalEnv;
+    }
+});
+
+test('check-pkgbuild-namcap.mjs: error on syntax check failure when namcap is absent', () => {
+    const tmpTarget = join(root, 'PKGBUILD.tmp.test');
+    writeFileSync(tmpTarget, 'pkgname=ramshared\nif [ $pkgname == "ramshared" ]; then\n  echo "missing fi"\n', 'utf8');
+
+    const originalEnv = { ...process.env };
+    process.env.MOCK_HAS_NAMCAP = '0';
+    process.env.MOCK_BASH_CMD = 'bash';
+
+    try {
+        const result = runChecks(tmpTarget);
+        assert.strictEqual(result, false);
+    } finally {
+        process.env = originalEnv;
+        try { unlinkSync(tmpTarget); } catch (e) {}
+    }
+});
+
+test('check-pkgbuild-namcap.mjs: error when target does not exist', () => {
+    const tmpTarget = join(root, 'nonexistent-PKGBUILD');
+
+    const originalEnv = { ...process.env };
+    process.env.MOCK_HAS_NAMCAP = '0';
+
+    try {
+        const result = runChecks(tmpTarget);
+        assert.strictEqual(result, false);
+    } finally {
+        process.env = originalEnv;
+    }
+});
+
+test('check-pkgbuild-namcap.mjs: success when namcap is present and passes', () => {
+    const validTarget = join(root, 'packaging/arch/PKGBUILD');
+
+    const originalEnv = { ...process.env };
+    process.env.MOCK_HAS_NAMCAP = '1';
+    process.env.MOCK_NAMCAP_CMD = 'true';
+
+    try {
+        const result = runChecks(validTarget);
+        assert.strictEqual(result, true);
+    } finally {
+        process.env = originalEnv;
+    }
+});
+
+test('check-pkgbuild-namcap.mjs: failure when namcap is present and fails', () => {
+    const tmpTarget = join(root, 'PKGBUILD.tmp.fail');
+    writeFileSync(tmpTarget, 'bad stuff', 'utf8');
+
+    const originalEnv = { ...process.env };
+    process.env.MOCK_HAS_NAMCAP = '1';
+    process.env.MOCK_NAMCAP_CMD = 'false';
+
+    try {
+        const result = runChecks(tmpTarget);
+        assert.strictEqual(result, false);
+    } finally {
+        process.env = originalEnv;
+        try { unlinkSync(tmpTarget); } catch (e) {}
+    }
+});


### PR DESCRIPTION
## Resumo
Added PKGBUILD namcap lint check verification harness.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| d27de11 | Added check-pkgbuild-namcap.mjs | Added namcap linting harness | Uses bash -n fallback if namcap is not available |
## Labels
area:ci-tooling
type:packaging
## Validacao
```bash
node tools/ci/check-pkgbuild-namcap.mjs
node --test --experimental-test-coverage tools/ci/check-pkgbuild-namcap.test.mjs
./scripts/docs-check.sh
```
## Rollback trigger
If the CI pipeline fails because of missing tools or syntax errors on valid files.

---
*PR created automatically by Jules for task [5813246498816376930](https://jules.google.com/task/5813246498816376930) started by @emersonbusson*