### PR TITLE
packaging: graceful teardown of active swap devices in debian prerm

### DIFF
--- a/packaging/debian/prerm
+++ b/packaging/debian/prerm
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+# Deactivate active ramshared swap devices safely before systemd service shutdown on package remove.
+# Strict guard clauses and validation.
+
+if [ "${1:-}" = "remove" ]; then
+    if command -v swapoff >/dev/null 2>&1; then
+        # Find active swaps and filter for ublkb or ramshared devices
+        while read -r swap_dev _rest; do
+            if [[ "$swap_dev" == /dev/ublkb* ]] || [[ "$swap_dev" == /dev/ramshared* ]]; then
+                echo "Deactivating ramshared swap device: $swap_dev"
+                swapoff "$swap_dev" || true
+            fi
+        done < <(grep -v "^Filename" /proc/swaps || true)
+    fi
+
+    if command -v systemctl >/dev/null 2>&1; then
+        if systemctl is-active --quiet ramshared-vram.service; then
+            echo "Stopping ramshared-vram.service"
+            systemctl stop ramshared-vram.service || true
+        fi
+    fi
+fi


### PR DESCRIPTION
## Resumo
Implemented graceful teardown of ramshared swap devices in Debian prerm script to prevent active swaps from persisting after package removal.
## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| pending | Added prerm script | To deactivate active ramshared swap devices before systemd service shutdown | Checks /proc/swaps and unswaps /dev/ublkb and /dev/ramshared devices |
## Labels
area:distro-packaging
type:packaging
## Validacao
shellcheck packaging/debian/prerm
## Rollback trigger
Revert if prerm script causes Debian package removal to fail due to swapoff or systemctl errors.

---
*PR created automatically by Jules for task [1791120759013113242](https://jules.google.com/task/1791120759013113242) started by @emersonbusson*