### PR TITLE
build(deb): enforce deterministic timestamps for reproducible builds

### DIFF
--- a/scripts/package/build-deb-package.sh
+++ b/scripts/package/build-deb-package.sh
@@ -144,9 +144,17 @@ exit 0
 PRERM_EOF
 chmod 0755 "$STAGE_DIR/DEBIAN/prerm"
 
+# Enable deterministic timestamps for reproducible builds
+export SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log -1 --format=%ct 2>/dev/null || date +%s)}"
+
+# Clamp timestamps of files inside the staging directory
+find "$STAGE_DIR" -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} +
+
 # Build the .deb archive
 mkdir -p "$OUT_DIR"
 dpkg-deb --build --root-owner-group "$STAGE_DIR" "$DEB_FILE"
+
+
 rm -rf "$STAGE_DIR"
 
 # Compute SHA-256


### PR DESCRIPTION
Implemented deterministic timestamps and reproducible build flags in debian builder. Exported SOURCE_DATE_EPOCH based on the latest git commit or current date. Applied clamped timestamps to files in the staging directory. Reverted the unnecessary and unsafe ar repacking which was found to be detrimental to archive ownership reproducibility natively handled by dpkg-deb.

---
*PR created automatically by Jules for task [7893398078967793259](https://jules.google.com/task/7893398078967793259) started by @emersonbusson*