### PR TITLE
chore: add conffiles for debian packaging

### DIFF
--- a/packaging/debian/conffiles
+++ b/packaging/debian/conffiles
@@ -1,0 +1,1 @@
+/etc/ramshared/config.toml


### PR DESCRIPTION
Added conffiles declaration for /etc/ramshared/config.toml to preserve user customizations across upgrades.

---
*PR created automatically by Jules for task [12033570288869452152](https://jules.google.com/task/12033570288869452152) started by @emersonbusson*