### PR TITLE
feat(packaging): add systemd-sysusers configuration for ramshared daemon

### DIFF
--- a/packaging/systemd-sysusers.d/ramshared.conf
+++ b/packaging/systemd-sysusers.d/ramshared.conf
@@ -1,0 +1,2 @@
+# Type Name ID GECOS Home directory Shell
+u ramshared - "RamShared Daemon" /var/lib/ramshared /usr/sbin/nologin


### PR DESCRIPTION
## Resumo
Adds a systemd-sysusers configuration to create the ramshared unprivileged system user for the daemon.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|

## Labels
area:distro-packaging, type:packaging, type:security

## Validacao
mkdir -p packaging/systemd-sysusers.d/
cat << 'EOF' > packaging/systemd-sysusers.d/ramshared.conf
# Type Name ID GECOS Home directory Shell
u ramshared - "RamShared Daemon" /var/lib/ramshared /usr/sbin/nologin
EOF
chmod 644 packaging/systemd-sysusers.d/ramshared.conf
cat packaging/systemd-sysusers.d/ramshared.conf
systemd-sysusers --cat-config packaging/systemd-sysusers.d/ramshared.conf

## Rollback trigger
If systemd-sysusers fails to parse this configuration file or if creating the user causes a conflict during package installation, revert this commit.

RULES:
1. Read README.md, AGENTS.md, CLAUDE.md, trovaldo.md, and all pertinent .claude/rules/.
2. Baseline git SHA is 156355c4427b6e00321ebc68c7de9288dbf72e09 on origin/main.
3. Implement only the smallest safe orthogonal slice. Use TDD, run cargo test, shellcheck, or checkpatch where applicable, and open 1 PR strictly against jules/inbox.
4. If safe code modification is not possible, produce FINDING_ONLY with evidence in docs/jules/findings/.
5. Do not read, write, print, or persist credentials/secrets.
6. PRs remain unmerged on jules/inbox; human consolidation will merge verified gains into main.
7. English only for all source code, comments, identifiers, commits, and PR descriptions.
8. Follow Conventional Commits format (<=72 chars title, body explaining rationale and rollback trigger).
9. Format PR body with: Resumo, Commits, Labels, Validacao, Rollback trigger.
10. All 10 contractual blocks MUST be generated in the plan before modifying any file.

---
*PR created automatically by Jules for task [14205983872529636025](https://jules.google.com/task/14205983872529636025) started by @emersonbusson*