### PR TITLE
fix(packaging): harden ramshared.install scriptlet with guard clauses

### DIFF
--- a/packaging/arch/ramshared.install
+++ b/packaging/arch/ramshared.install
@@ -1,6 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 post_install() {
-    systemctl daemon-reload
-    udevadm control --reload-rules && udevadm trigger || true
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl daemon-reload
+    fi
+    if command -v udevadm >/dev/null 2>&1; then
+        udevadm control --reload-rules || true
+        udevadm trigger || true
+    fi
     echo "==> RamShared installed. The VRAM memory tier activates automatically upon GPU detection."
 }
 
@@ -9,6 +17,8 @@ post_upgrade() {
 }
 
 pre_remove() {
-    systemctl stop ramshared-vram.service 2>/dev/null || true
-    systemctl disable ramshared-vram.service 2>/dev/null || true
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl stop ramshared-vram.service 2>/dev/null || true
+        systemctl disable ramshared-vram.service 2>/dev/null || true
+    fi
 }


### PR DESCRIPTION
## Resumo
Hardened the Arch Linux pacman scriptlet (ramshared.install) to comply with architectural principles. Added a shebang, set -euo pipefail for fail-fast error handling, and command -v guard clauses before invoking systemctl and udevadm.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|

## Labels
area:packaging, type:packaging, type:security

## Validacao
rm -f patch.diff
shellcheck packaging/arch/ramshared.install

## Rollback trigger
If the hardened pacman scriptlet causes installation failures in clean chroots or environments lacking udevadm/systemctl, the change should be reverted.

1. Read README.md, AGENTS.md, CLAUDE.md, trovaldo.md, and all pertinent .claude/rules/.
2. Baseline git SHA is 156355c4427b6e00321ebc68c7de9288dbf72e09 on origin/main.
3. Implement only the smallest safe orthogonal slice. Use TDD, run cargo test, shellcheck, or checkpatch where applicable, and open 1 PR strictly against jules/inbox.
4. If safe code modification is not possible, produce FINDING_ONLY with evidence in docs/jules/findings/.
5. Do not read, write, print, or persist credentials/secrets.
6. PRs remain unmerged on jules/inbox; human consolidation will merge verified gains into main.
7. English only for all source code, comments, identifiers, commits, and PR descriptions.
8. Follow Conventional Commits format (<=72 chars title, body explaining rationale and rollback trigger).
9. Format PR body with: Resumo, Commits, Labels, Validacao, Rollback trigger.
10. All 10 contractual blocks MUST be generated in the plan before modifying any file.

---
*PR created automatically by Jules for task [18003274600716679953](https://jules.google.com/task/18003274600716679953) started by @emersonbusson*