### PR TITLE
feat(packaging): add machine-readable debian copyright file in Format 1.0

### DIFF
--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -1,0 +1,28 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: RamShared
+Upstream-Contact: Emerson Busson
+Source: https://github.com/emersonbusson/ramshared
+
+Files: *
+Copyright: 2026 RamShared Contributors
+           2026 Emerson Busson
+License: MIT
+
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.

--- a/scripts/package/build-deb-package.sh
+++ b/scripts/package/build-deb-package.sh
@@ -89,7 +89,11 @@ fi
 
 # Install documentation & licenses
 install -m 0644 "$ROOT/README.md" "$STAGE_DIR/usr/share/doc/ramshared/README.md"
-install -m 0644 "$ROOT/LICENSE" "$STAGE_DIR/usr/share/doc/ramshared/copyright" 2>/dev/null || true
+if [[ -f "$ROOT/packaging/debian/copyright" ]]; then
+  install -m 0644 "$ROOT/packaging/debian/copyright" "$STAGE_DIR/usr/share/doc/ramshared/copyright"
+else
+  install -m 0644 "$ROOT/LICENSE" "$STAGE_DIR/usr/share/doc/ramshared/copyright" 2>/dev/null || true
+fi
 
 # Generate DEBIAN/control file
 printf "Package: ramshared\n" > "$STAGE_DIR/DEBIAN/control"


### PR DESCRIPTION
## Resumo
Add machine-readable debian copyright file in Format 1.0

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| PENDING | Added machine-readable debian copyright file | To conform with Debian Policy Format 1.0 specification | |

## Labels
area:distro-packaging, type:packaging

## Validacao
bash scripts/package/build-deb-package.sh
dpkg-deb --contents artifacts/packages/ramshared_0.9.0-beta2_amd64.deb | grep copyright
cargo test

## Rollback trigger
If the debian package fails to build or the copyright file is missing.

RULES:
1. Read README.md, AGENTS.md, CLAUDE.md, trovaldo.md, and all pertinent .claude/rules/.
2. Baseline git SHA is 156355c4427b6e00321ebc68c7de9288dbf72e09 on origin/main.
3. Implement only the smallest safe orthogonal slice. Use TDD, run cargo test, shellcheck, or checkpatch where applicable, and open 1 PR strictly against jules/inbox.
4. If safe code modification is not possible, produce FINDING_ONLY with evidence in docs/jules/findings/.
5. Do not read, write, print, or persist credentials/secrets.
6. PRs remain unmerged on jules/inbox; human consolidation will merge verified gains into main.
7. English only for all source code, comments, identifiers, commits, and PR descriptions.
8. Follow Conventional Commits format (<=72 chars title, body explaining rationale and rollback trigger).
9. Format PR body with: Resumo, Commits table, Labels, Validacao, Rollback trigger.
10. All 10 contractual blocks MUST be generated in the plan before modifying any file.

---
*PR created automatically by Jules for task [14500825132479407442](https://jules.google.com/task/14500825132479407442) started by @emersonbusson*