### PR TITLE
feat(packaging): add portable release tarball creator

### DIFF
--- a/scripts/package/build-tarball.sh
+++ b/scripts/package/build-tarball.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <output-tarball> <source-dir>" >&2
+  exit 1
+fi
+
+OUTPUT_TARBALL="$1"
+SOURCE_DIR="$2"
+
+# Validate prerequisites
+if ! command -v tar >/dev/null 2>&1; then
+  echo "Error: tar command not found." >&2
+  exit 1
+fi
+
+if ! command -v find >/dev/null 2>&1; then
+  echo "Error: find command not found." >&2
+  exit 1
+fi
+
+if [ ! -d "$SOURCE_DIR" ]; then
+  echo "Error: Source directory '$SOURCE_DIR' does not exist or is not a directory." >&2
+  exit 1
+fi
+
+# Secure temporary directory
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+# Stage files
+STAGE_DIR="$TEMP_DIR/ramshared"
+mkdir -p "$STAGE_DIR"
+cp -a "$SOURCE_DIR/." "$STAGE_DIR/"
+
+# Normalize permissions
+find "$STAGE_DIR" -type f -exec chmod 0644 {} +
+find "$STAGE_DIR" -type d -exec chmod 0755 {} +
+# Ensure executables have execute permission
+find "$STAGE_DIR" -type f \( -name "*.sh" -o -name "*.pl" -o -name "*.py" -o -name "ramshared*" \) -exec chmod 0755 {} +
+
+# Create portable tarball with uid 0, gid 0
+tar --owner=0 --group=0 -czf "$OUTPUT_TARBALL" -C "$TEMP_DIR" "ramshared"
+
+echo "Tarball created successfully: $OUTPUT_TARBALL"


### PR DESCRIPTION
## Resumo
Creates a portable build tarball script (`scripts/package/build-tarball.sh`) that correctly normalizes output tarballs to uid/gid 0 and 0644/0755 file modes.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| (pending) | Implemented `build-tarball.sh` | Required to provide a strictly standardized distro-packaging pipeline. | Added execution bit and normalized permissions logic. |

## Labels
area:distro-packaging, type:packaging, type:upstream, type:security

## Validacao
Executed via standard bash tests validating file attributes:
```
mkdir -p test_dir
touch test_dir/test1.txt
mkdir -p test_dir/test_sub
touch test_dir/test_sub/test2.txt
./scripts/package/build-tarball.sh out.tar.gz test_dir
tar -tvf out.tar.gz
rm -rf test_dir out.tar.gz
node --test tools/ci/check-pr-metrics-table.test.mjs
node --test tools/ci/check-ci-contract.test.mjs
```

## Rollback trigger
If the script fails to execute on default bash due to missing dependencies or incorrect argument parsing.

---
*PR created automatically by Jules for task [12590153419920666348](https://jules.google.com/task/12590153419920666348) started by @emersonbusson*