### PR TITLE
build(dkms): automated kernel module signing script

### DIFF
--- a/scripts/dkms/sign-kernel-module.sh
+++ b/scripts/dkms/sign-kernel-module.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <module.ko> <private_key.priv> <certificate.der>"
+    echo "Signs a kernel module using kmodsign or scripts/sign-file."
+    exit 1
+}
+
+if [ "$#" -ne 3 ]; then
+    usage
+fi
+
+MODULE_PATH="$1"
+PRIV_KEY="$2"
+CERT="$3"
+
+if [ ! -f "$MODULE_PATH" ]; then
+    echo "Error: Module not found at $MODULE_PATH" >&2
+    exit 1
+fi
+
+if [ ! -f "$PRIV_KEY" ]; then
+    echo "Error: Private key not found at $PRIV_KEY" >&2
+    exit 1
+fi
+
+if [ ! -f "$CERT" ]; then
+    echo "Error: Certificate not found at $CERT" >&2
+    exit 1
+fi
+
+# Check key permissions
+PERMS=$(stat -c "%a" "$PRIV_KEY")
+if [ "$PERMS" != "600" ]; then
+    echo "Error: Private key $PRIV_KEY must have 0600 permissions, found $PERMS" >&2
+    exit 1
+fi
+
+KVER=$(uname -r)
+SIGN_FILE="/usr/src/linux-headers-$KVER/scripts/sign-file"
+
+if command -v kmodsign >/dev/null 2>&1; then
+    kmodsign sha256 "$PRIV_KEY" "$CERT" "$MODULE_PATH"
+elif [ -x "$SIGN_FILE" ]; then
+    "$SIGN_FILE" sha256 "$PRIV_KEY" "$CERT" "$MODULE_PATH"
+else
+    echo "Error: Neither kmodsign nor $SIGN_FILE found." >&2
+    exit 1
+fi
+
+echo "Module $MODULE_PATH signed successfully."


### PR DESCRIPTION
## Resumo
Added automated kernel module signing script for UEFI MOK private keys, checking for kmodsign or scripts/sign-file, and validating 0600 permissions.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| pending | Add scripts/dkms/sign-kernel-module.sh | Automate kernel module signing for Secure Boot compatibility | Validates inputs, checks private key permissions (0600), and uses kmodsign or sign-file. |

## Labels
type:packaging, type:kernel, type:upstream, type:security, area:dkms-secureboot

## Validacao
`sudo apt-get install -y shellcheck; shellcheck scripts/dkms/sign-kernel-module.sh; create mock files to test execution logic`

## Rollback trigger
Kernel module signing failure causes DKMS installation to abort

---
*PR created automatically by Jules for task [16015017652179329843](https://jules.google.com/task/16015017652179329843) started by @emersonbusson*