### PR TITLE
feat(dkms): add pre-build script to validate kernel headers

### DIFF
--- a/scripts/dkms/dkms-pre-build.sh
+++ b/scripts/dkms/dkms-pre-build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# dkms-pre-build.sh - Verify kernel headers presence before DKMS build
+#
+# Usage: dkms-pre-build.sh <kernel_version>
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "ERROR: Kernel version argument is required." >&2
+    echo "Usage: $0 <kernel_version>" >&2
+    exit 1
+fi
+
+KERNEL_VER="$1"
+BUILD_DIR="/lib/modules/${KERNEL_VER}/build"
+MAKEFILE="${BUILD_DIR}/Makefile"
+
+echo "INFO: Validating kernel headers for ${KERNEL_VER}..."
+
+if ! test -d "${BUILD_DIR}"; then
+    echo "ERROR: Kernel build directory not found: ${BUILD_DIR}" >&2
+    echo "Please install the appropriate linux-headers package for kernel ${KERNEL_VER}." >&2
+    exit 1
+fi
+
+if ! test -f "${MAKEFILE}"; then
+    echo "ERROR: Kernel Makefile not found: ${MAKEFILE}" >&2
+    echo "The kernel headers installation appears incomplete or corrupted." >&2
+    exit 1
+fi
+
+echo "INFO: Kernel headers validation successful for ${KERNEL_VER}."
+exit 0


### PR DESCRIPTION
Implemented scripts/dkms/dkms-pre-build.sh to validate the presence of kernel headers before DKMS compilation. This fail-fast script checks for the kernel build directory and Makefile to ensure a complete environment, adhering to strict shell hardening principles.

---
*PR created automatically by Jules for task [5305299104392412885](https://jules.google.com/task/5305299104392412885) started by @emersonbusson*