### PR TITLE
build: harden ramshared Makefile and add checkpatch

### DIFF
--- a/drivers/block/ramshared/Makefile
+++ b/drivers/block/ramshared/Makefile
@@ -7,12 +7,17 @@ obj-$(CONFIG_BLK_DEV_RAMSHARED) += ramshared.o
 
 ramshared-y := main.o dma.o queue.o
 
+EXTRA_CFLAGS += -Wall -Wextra -Werror
+
 # Standalone build support
 KDIR ?= /lib/modules/$(shell uname -r)/build
 PWD := $(shell pwd)
 
 default:
 	$(MAKE) -C $(KDIR) M=$(PWD) CONFIG_BLK_DEV_RAMSHARED=m modules
+
+checkpatch:
+	$(KDIR)/scripts/checkpatch.pl -f *.c *.h
 
 clean:
 	$(MAKE) -C $(KDIR) M=$(PWD) clean


### PR DESCRIPTION
Hardened the ramshared kernel module Makefile by adding strict compilation flags (-Wall -Wextra -Werror) and adding a checkpatch target to ensure code quality and prevent warnings from turning into runtime bugs.

---
*PR created automatically by Jules for task [16544284896630281213](https://jules.google.com/task/16544284896630281213) started by @emersonbusson*