### PR TITLE
feat(dkms): configure DEST_MODULE_LOCATION and POST_INSTALL hook

### DIFF
--- a/packaging/dkms/dkms.conf
+++ b/packaging/dkms/dkms.conf
@@ -10,10 +10,11 @@ CLEAN="make -C drivers/block/ramshared clean"
 MAKE[0]="make -C drivers/block/ramshared KDIR=/lib/modules/${kernelver}/build modules"
 BUILT_MODULE_NAME[0]="ramshared"
 BUILT_MODULE_LOCATION[0]="drivers/block/ramshared"
-DEST_MODULE_LOCATION[0]="/updates/dkms"
+DEST_MODULE_LOCATION[0]="/kernel/drivers/block/"
 STRIP[0]="yes"
 
 # Secure Boot / Kernel Lockdown Module Signing Integration
 SIGN_TOOL="/usr/lib/modules/${kernelver}/build/scripts/sign-file"
 MOK_SIGNING_KEY="/var/lib/dkms/mok.key"
 MOK_CERTIFICATE="/var/lib/dkms/mok.pub"
+POST_INSTALL="packaging/dkms/sign-module.sh"

--- a/packaging/dkms/sign-module.sh
+++ b/packaging/dkms/sign-module.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+# Secure Boot / Kernel Lockdown Module Signing Hook for DKMS
+# Runs during POST_INSTALL
+
+if [[ -z "${kernelver:-}" ]]; then
+    echo "Error: kernelver not set."
+    exit 1
+fi
+
+SIGN_TOOL="/usr/lib/modules/${kernelver}/build/scripts/sign-file"
+MOK_SIGNING_KEY="/var/lib/dkms/mok.key"
+MOK_CERTIFICATE="/var/lib/dkms/mok.pub"
+MODULE_PATH="/lib/modules/${kernelver}/kernel/drivers/block/ramshared.ko"
+
+if [[ ! -x "${SIGN_TOOL}" ]]; then
+    echo "Warning: sign-file tool not found or not executable at ${SIGN_TOOL}. Skipping module signing."
+    exit 0
+fi
+
+if [[ ! -f "${MOK_SIGNING_KEY}" || ! -f "${MOK_CERTIFICATE}" ]]; then
+    echo "Warning: MOK key or certificate not found. Skipping module signing."
+    exit 0
+fi
+
+if [[ ! -f "${MODULE_PATH}" ]]; then
+    echo "Error: Module not found at ${MODULE_PATH}."
+    exit 1
+fi
+
+echo "Signing module ${MODULE_PATH} with MOK..."
+"${SIGN_TOOL}" sha256 "${MOK_SIGNING_KEY}" "${MOK_CERTIFICATE}" "${MODULE_PATH}"
+echo "Module signed successfully."
+
+exit 0


### PR DESCRIPTION
## Issue
dkms-secureboot hook configuration for drivers/block/ramshared

## Responsavel/Owner
jules

## Resumo
Configured DEST_MODULE_LOCATION and POST_INSTALL hook in dkms.conf for secure boot integration.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| a8b4c84c341f676742c6a626d0a76f7cb23232b5 | Created sign-module.sh and updated dkms.conf | Support DKMS Secure Boot integration | Added hook and updated paths |

## Labels
area:dkms-secureboot

## Validacao
```bash
cat packaging/dkms/sign-module.sh
cat << 'EOF' > patch.js
const fs = require("fs");
let content = fs.readFileSync("packaging/dkms/dkms.conf", "utf8");
content = content.replace('DEST_MODULE_LOCATION[0]="/updates/dkms"', 'DEST_MODULE_LOCATION[0]="/kernel/drivers/block/"');
content = content.replace('MOK_CERTIFICATE="/var/lib/dkms/mok.pub"', 'MOK_CERTIFICATE="/var/lib/dkms/mok.pub"\nPOST_INSTALL="packaging/dkms/sign-module.sh"');
fs.writeFileSync("packaging/dkms/dkms.conf", content);
EOF
node patch.js
cat packaging/dkms/dkms.conf
rm patch.js
chmod +x packaging/dkms/sign-module.sh
shellcheck packaging/dkms/sign-module.sh
git add packaging/dkms/dkms.conf packaging/dkms/sign-module.sh
git commit -m "chore: setup dkms secureboot hooks"
cargo test
```

## Rollback trigger
Revert if DKMS build fails due to path errors or missing tools.

1. Read README.md, AGENTS.md, CLAUDE.md, trovaldo.md, and all pertinent .claude/rules/.
2. Baseline git SHA is 156355c4427b6e00321ebc68c7de9288dbf72e09 on origin/main.
3. Implement only the smallest safe orthogonal slice. Use TDD, run cargo test, shellcheck, or checkpatch where applicable, and open 1 PR strictly against jules/inbox.
4. If safe code modification is not possible, produce FINDING_ONLY with evidence in docs/jules/findings/.
5. Do not read, write, print, or persist credentials/secrets.
6. PRs remain unmerged on jules/inbox; human consolidation will merge verified gains into main.
7. English only for all source code, comments, identifiers, commits, and PR descriptions.
8. Follow Conventional Commits format (<=72 chars title, body explaining rationale and rollback trigger).
9. Format PR body with: Resumo, Commits table, Labels, Validacao, Rollback trigger.
10. All 10 contractual blocks MUST be generated in the plan before modifying any file.

---
*PR created automatically by Jules for task [2649331310886736643](https://jules.google.com/task/2649331310886736643) started by @emersonbusson*