### PR TITLE
feat: Check Secure Boot state via mokutil before MOK enrollment

### DIFF
--- a/scripts/dkms/enroll-mok-key.sh
+++ b/scripts/dkms/enroll-mok-key.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-only
+# RamShared Automated Machine Owner Key (MOK) Enrollment for UEFI Secure Boot
+set -euo pipefail
+
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "==> [RamShared Security] ERROR: openssl is required but not installed." >&2
+    exit 1
+fi
+
+MOK_DIR="/var/lib/dkms"
+MOK_KEY="${MOK_DIR}/mok.key"
+MOK_DER="${MOK_DIR}/mok.der"
+MOK_PUB="${MOK_DIR}/mok.pub"
+
+mkdir -p "${MOK_DIR}"
+chmod 0700 "${MOK_DIR}"
+
+if [[ ! -f "${MOK_KEY}" || ! -f "${MOK_DER}" ]]; then
+    echo "==> [RamShared Security] Generating local X.509 MOK keypair for kernel module signing..."
+    openssl req -new -x509 -newkey rsa:2048 -nodes \
+        -keyout "${MOK_KEY}" -out "${MOK_PUB}" \
+        -days 36500 -subj "/CN=RamShared DKMS Module Signing Key/" >/dev/null 2>&1
+    openssl x509 -in "${MOK_PUB}" -outform DER -out "${MOK_DER}" >/dev/null 2>&1
+    chmod 0600 "${MOK_KEY}"
+    chmod 0644 "${MOK_PUB}" "${MOK_DER}"
+fi
+
+# Check if Secure Boot is active
+if command -v mokutil >/dev/null 2>&1 && mokutil --sb-state 2>&1 | grep -q "SecureBoot enabled"; then
+    echo "==> [RamShared Security] Secure Boot is ENABLED."
+    if ! mokutil --test-key "${MOK_DER}" 2>&1 | grep -q "is already enrolled"; then
+        echo "==> [RamShared Security] Staging MOK certificate for enrollment..."
+        mokutil --import "${MOK_DER}" || true
+    fi
+fi


### PR DESCRIPTION
1. Read README.md, AGENTS.md, CLAUDE.md, trovaldo.md, and all pertinent .claude/rules/.
2. Baseline git SHA is 156355c4427b6e00321ebc68c7de9288dbf72e09 on origin/main.
3. Implement only the smallest safe orthogonal slice. Use TDD, run cargo test, shellcheck, or checkpatch where applicable, and open 1 PR strictly against jules/inbox.
4. If safe code modification is not possible, produce FINDING_ONLY with evidence in docs/jules/findings/.
5. Do not read, write, print, or persist credentials/secrets.
6. PRs remain unmerged on jules/inbox; human consolidation will merge verified gains into main.
7. English only for all source code, comments, identifiers, commits, and PR descriptions.
8. Follow Conventional Commits format.
9. Format PR body with: Resumo, Commits, Labels...
10. All 10 contractual blocks MUST be generated in the plan before modifying any file.

## Resumo
Implemented scripts/dkms/enroll-mok-key.sh to check for Secure Boot active state using mokutil --sb-state before staging MOK keys.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| d2ddf204a694f122c622582f6e8e0495b5d44231 | Added enroll-mok-key.sh | Prevent unnecessary MOK enrollments when Secure Boot is disabled | Added check via `mokutil --sb-state` |

## Labels
area:dkms-secureboot, type:packaging, type:security

## Validacao
```bash
mkdir -p scripts/dkms/
cat << \"EOF\" > scripts/dkms/enroll-mok-key.sh
#!/usr/bin/env bash
# SPDX-License-Identifier: GPL-2.0-only
# RamShared Automated Machine Owner Key (MOK) Enrollment for UEFI Secure Boot
set -euo pipefail

MOK_DIR="/var/lib/dkms"
MOK_KEY="${MOK_DIR}/mok.key"
MOK_DER="${MOK_DIR}/mok.der"
MOK_PUB="${MOK_DIR}/mok.pub"

mkdir -p "${MOK_DIR}"
chmod 0700 "${MOK_DIR}"

if [[ ! -f "${MOK_KEY}" || ! -f "${MOK_DER}" ]]; then
    echo "==> [RamShared Security] Generating local X.509 MOK keypair for kernel module signing..."
    openssl req -new -x509 -newkey rsa:2048 -nodes \
        -keyout "${MOK_KEY}" -out "${MOK_PUB}" \
        -days 36500 -subj "/CN=RamShared DKMS Module Signing Key/" >/dev/null 2>&1
    openssl x509 -in "${MOK_PUB}" -outform DER -out "${MOK_DER}" >/dev/null 2>&1
    chmod 0600 "${MOK_KEY}"
    chmod 0644 "${MOK_PUB}" "${MOK_DER}"
fi

# Check if Secure Boot is active
if command -v mokutil >/dev/null 2>&1 && mokutil --sb-state 2>&1 | grep -q "SecureBoot enabled"; then
    echo "==> [RamShared Security] Secure Boot is ENABLED."
    if ! mokutil --test-key "${MOK_DER}" 2>&1 | grep -q "is already enrolled"; then
        echo "==> [RamShared Security] Staging MOK certificate for enrollment..."
        mokutil --import "${MOK_DER}" || true
    fi
fi
EOF
cat scripts/dkms/enroll-mok-key.sh
chmod 0755 scripts/dkms/enroll-mok-key.sh
shellcheck scripts/dkms/enroll-mok-key.sh
git add scripts/dkms/enroll-mok-key.sh; git commit -m "feat: Check Secure Boot state via mokutil before MOK enrollment"
cargo test
```

## Rollback trigger
If the script fails to detect the Secure Boot state accurately or causes unexpected failures during DKMS module installation.

---
*PR created automatically by Jules for task [15208298639876418193](https://jules.google.com/task/15208298639876418193) started by @emersonbusson*