### PR TITLE
feat(dkms): add post-remove hook for cache cleanup

### DIFF
--- a/packaging/dkms/dkms.conf
+++ b/packaging/dkms/dkms.conf
@@ -17,3 +17,6 @@ STRIP[0]="yes"
 SIGN_TOOL="/usr/lib/modules/${kernelver}/build/scripts/sign-file"
 MOK_SIGNING_KEY="/var/lib/dkms/mok.key"
 MOK_CERTIFICATE="/var/lib/dkms/mok.pub"
+
+# Post remove hook
+POST_REMOVE="scripts/dkms/dkms-post-remove.sh ${kernelver}"

--- a/scripts/dkms/dkms-post-remove.sh
+++ b/scripts/dkms/dkms-post-remove.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# dkms-post-remove.sh - RamShared DKMS post-remove hook
+#
+# Cleans up module cache and runs depmod after module removal.
+#
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <kernel-version>"
+    exit 1
+fi
+
+KERNEL_VER="$1"
+MODULE_NAME="ramshared"
+
+echo "Executing RamShared DKMS post-remove hook for kernel $KERNEL_VER"
+
+if command -v depmod >/dev/null 2>&1; then
+    echo "Running depmod -a $KERNEL_VER..."
+    depmod -a "$KERNEL_VER"
+else
+    echo "Warning: depmod not found, skipping module dependency update."
+fi
+
+# Clean up any stale signature artifacts specific to this version
+SIG_FILE="/lib/modules/${KERNEL_VER}/updates/dkms/${MODULE_NAME}.ko.sig"
+if [ -f "$SIG_FILE" ]; then
+    echo "Removing stale signature file: $SIG_FILE"
+    rm -f "$SIG_FILE"
+fi
+
+echo "DKMS post-remove hook completed successfully."
+exit 0


### PR DESCRIPTION
1. Read README.md, AGENTS.md, CLAUDE.md, trovaldo.md, and all pertinent .claude/rules/.
2. Baseline git SHA is 156355c4427b6e00321ebc68c7de9288dbf72e09 on origin/main.
3. Implement only the smallest safe orthogonal slice. Use TDD, run cargo test, shellcheck, or checkpatch where applicable, and open 1 PR strictly against jules/inbox.
4. If safe code modification is not possible, produce FINDING_ONLY with evidence in docs/jules/findings/.
5. Do not read, write, print, or persist credentials/secrets.
6. PRs remain unmerged on jules/inbox; human consolidation will merge verified gains into main.
7. English only for all source code, comments, identifiers, commits, and PR descriptions.
8. Follow Conventional Commits format (<=72 chars title, body explaining rationale and rollback trigger).
9. Format PR body with: Resumo, Commits, Labels, Validacao, Rollback trigger.
10. All 10 contractual blocks MUST be generated in the plan before modifying any file.

## Resumo
Added DKMS post-remove hook to run depmod and clean up stale module signatures.

## Issue
Task: DKMS post-remove hook for module cache cleanup and depmod update

## Responsavel/Owner
UpstreamPkg100/2026-09-09/dkms-secureboot/040

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| b231a07a93649343980ba681facf3898c7ca3f56 | Added DKMS post-remove hook | Clean up module cache and signatures | Runs depmod and removes .ko.sig |

## Labels
area:dkms, type:packaging, type:kernel

## Validacao
cat scripts/dkms/dkms-post-remove.sh
cat packaging/dkms/dkms.conf
sudo apt-get update && sudo apt-get install -y shellcheck && shellcheck scripts/dkms/dkms-post-remove.sh
rm patch.diff
cargo test

## Rollback trigger
Revert if module uninstallation hangs or depmod causes errors during dkms remove.

---
*PR created automatically by Jules for task [10042943751679707443](https://jules.google.com/task/10042943751679707443) started by @emersonbusson*