### PR TITLE
feat(kernel): enforce checked pci_enable_device and pci_set_master

### DIFF
--- a/drivers/block/ramshared/compat.h
+++ b/drivers/block/ramshared/compat.h
@@ -102,4 +102,53 @@ static inline struct gendisk *ramshared_alloc_disk(struct blk_mq_tag_set *set,
 #endif
 }
 
+
+#ifndef _RAMSHARED_PCI_COMPAT_H
+#define _RAMSHARED_PCI_COMPAT_H
+
+#include <linux/pci.h>
+
+/**
+ * ramshared_pci_enable_device_mem - Enable PCI memory device with checked returns
+ * @pdev: PCI device
+ */
+static inline int __must_check ramshared_pci_enable_device_mem(struct pci_dev *pdev)
+{
+	int ret;
+
+	if (!pdev)
+		return -EINVAL;
+
+	ret = pci_enable_device_mem(pdev);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+/**
+ * ramshared_pci_set_master - Assert Bus Master with validation
+ * @pdev: PCI device
+ */
+static inline int __must_check ramshared_pci_set_master(struct pci_dev *pdev)
+{
+	u16 cmd;
+
+	if (!pdev)
+		return -EINVAL;
+
+	pci_set_master(pdev);
+
+	if (!pdev->is_busmaster)
+		return -EIO;
+
+	pci_read_config_word(pdev, PCI_COMMAND, &cmd);
+	if (!(cmd & PCI_COMMAND_MASTER))
+		return -EIO;
+
+	return 0;
+}
+
+#endif /* _RAMSHARED_PCI_COMPAT_H */
+
 #endif /* _RAMSHARED_COMPAT_H */

--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -10,6 +10,7 @@
 #include <linux/init.h>
 #include <linux/pci.h>
 #include "ramshared.h"
+#include "compat.h"
 
 MODULE_AUTHOR("Emerson Busson");
 MODULE_DESCRIPTION("Hardware-Accelerated VRAM Block Driver");
@@ -66,13 +67,17 @@ static int ramshared_pci_probe(struct pci_dev *pdev,
 	atomic64_set(&rs_dev->read_bytes, 0);
 	atomic64_set(&rs_dev->write_bytes, 0);
 
-	ret = pci_enable_device_mem(pdev);
+	ret = ramshared_pci_enable_device_mem(pdev);
 	if (ret) {
 		dev_err(&pdev->dev, "failed to enable PCIe memory device\n");
 		return -ENODEV;
 	}
 
-	pci_set_master(pdev);
+	ret = ramshared_pci_set_master(pdev);
+	if (ret) {
+		dev_err(&pdev->dev, "failed to set PCI bus master\n");
+		goto err_disable_pci;
+	}
 
 	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
 	if (ret) {


### PR DESCRIPTION
## Resumo
Enforce checked return values for pci_enable_device and pci_set_master in compat.h to strictly validate PCIe hardware activation and Bus Master negotiation, returning deterministic error codes when PCI initialization fails.

## Issue
pci_enable_device and pci_set_master error handling shims

## Responsavel/Owner
Emerson Busson

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| e69b305648a4a19d4bf843819ddfb9a5433991ae | Added ramshared_pci_enable_device_mem and ramshared_pci_set_master shims | To enforce return value checks and validate is_busmaster | Modified drivers/block/ramshared/compat.h and drivers/block/ramshared/main.c |

## Labels
area:kernel, type:upstream, type:security, type:packaging

## Validacao
node patch_compat.js
node patch_main.js
git diff
./scripts/ci/check-kernel-style.sh

## Rollback trigger
Revert if PCI probe failures or system boot regressions occur in standard hardware matrices due to overly strict is_busmaster verification.

1. Read README.md, AGENTS.md, CLAUDE.md, trovaldo.md, and all pertinent .claude/rules/.
2. Baseline git SHA is 156355c4427b6e00321ebc68c7de9288dbf72e09 on origin/main.
3. Implement only the smallest safe orthogonal slice. Use TDD, run cargo test, shellcheck, or checkpatch where applicable, and open 1 PR strictly against jules/inbox.
4. If safe code modification is not possible, produce FINDING_ONLY with evidence in docs/jules/findings/.
5. Do not read, write, print, or persist credentials/secrets.
6. PRs remain unmerged on jules/inbox; human consolidation will merge verified gains into main.
7. English only for all source code, comments, identifiers, commits, and PR descriptions.
8. Follow Conventional Commits format (<=72 chars title, body explaining rationale and rollback trigger).
9. Format PR body with: Resumo, Commits, Labels, Validacao, Rollback trigger.
10. All 10 contractual blocks MUST be generated in the plan before modifying any file.

---
*PR created automatically by Jules for task [8906587270503793280](https://jules.google.com/task/8906587270503793280) started by @emersonbusson*