### PR TITLE
feat(dkms): enforce strict 0600 permissions on MOK key

### DIFF
--- a/scripts/dkms/enroll-mok-key.sh
+++ b/scripts/dkms/enroll-mok-key.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <path-to-mok-priv-key>" >&2
+    (exit 1) || return 1 2>/dev/null
+fi
+
+MOK_PRIV="$1"
+
+if [ ! -f "$MOK_PRIV" ]; then
+    echo "ERROR: MOK private key not found at $MOK_PRIV" >&2
+    (exit 1) || return 1 2>/dev/null
+fi
+
+PERMS=$(stat -c "%a" "$MOK_PRIV")
+
+if [ "$PERMS" != "600" ]; then
+    echo "ERROR: MOK private key $MOK_PRIV has insecure permissions: $PERMS. Expected 600." >&2
+    (exit 1) || return 1 2>/dev/null
+fi
+
+echo "MOK private key permissions are secure (0600)."


### PR DESCRIPTION
This commit adds defensive permission checks to `scripts/dkms/enroll-mok-key.sh` to prevent world-readable or group-readable private keys. It enforces a strict 0600 permission policy on the MOK.priv file.

Rollback trigger: If DKMS module signing fails due to valid MOK.priv key ownership but false-positive permission rejection.

## Resumo
Added strict 0600 permission check for MOK.priv to `scripts/dkms/enroll-mok-key.sh`.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| f3afed20ab99ce7ec3d994e6cfb99b50db6d36e2 | Added 0600 check to enroll-mok-key.sh | Prevent insecure keys | Fail-fast if perms != 600 |

## Labels
area:dkms-secureboot, type:security, type:packaging

## Validacao
```bash
mkdir -p scripts/dkms
cat << 'EOF' > scripts/dkms/enroll-mok-key.sh
#!/bin/bash
set -euo pipefail

if [ "$#" -lt 1 ]; then
    echo "Usage: $0 <path-to-mok-priv-key>" >&2
    (exit 1) || return 1 2>/dev/null
fi

MOK_PRIV="$1"

if [ ! -f "$MOK_PRIV" ]; then
    echo "ERROR: MOK private key not found at $MOK_PRIV" >&2
    (exit 1) || return 1 2>/dev/null
fi

PERMS=$(stat -c "%a" "$MOK_PRIV")

if [ "$PERMS" != "600" ]; then
    echo "ERROR: MOK private key $MOK_PRIV has insecure permissions: $PERMS. Expected 600." >&2
    (exit 1) || return 1 2>/dev/null
fi

echo "MOK private key permissions are secure (0600)."
EOF
chmod +x scripts/dkms/enroll-mok-key.sh
sudo apt-get update && sudo apt-get install -y shellcheck
shellcheck scripts/dkms/enroll-mok-key.sh
cat << 'EOF' > test_enroll.sh
#!/bin/bash

touch test_mok.priv

chmod 644 test_mok.priv
if ./scripts/dkms/enroll-mok-key.sh test_mok.priv 2>/dev/null; then
    echo "FAILED: script should have failed on 644"
else
    echo "PASSED: script failed correctly on 644"
fi

chmod 600 test_mok.priv
if ./scripts/dkms/enroll-mok-key.sh test_mok.priv; then
    echo "PASSED: script succeeded correctly on 600"
else
    echo "FAILED: script should have succeeded on 600"
fi

rm test_mok.priv test_enroll.sh
EOF
chmod +x test_enroll.sh
./test_enroll.sh
```

## Rollback trigger
If DKMS module signing fails due to valid MOK.priv key ownership but false-positive permission rejection.

## Issue
Task: defensive key permission check preventing world-readable private keys

## Responsavel/Owner
UpstreamPkg-100

Contractual Rules:
1. Read README.md, AGENTS.md, CLAUDE.md, trovaldo.md, and all pertinent .claude/rules/.
2. Baseline git SHA is 156355c4427b6e00321ebc68c7de9288dbf72e09 on origin/main.
3. Implement only the smallest safe orthogonal slice. Use TDD, run cargo test, shellcheck, or checkpatch where applicable, and open 1 PR strictly against jules/inbox.
4. If safe code modification is not possible, produce FINDING_ONLY with evidence in docs/jules/findings/.
5. Do not read, write, print, or persist credentials/secrets.
6. PRs remain unmerged on jules/inbox; human consolidation will merge verified gains into main.
7. English only for all source code, comments, identifiers, commits, and PR descriptions.
8. Follow Conventional Commits format (<=72 chars title, body explaining rationale and rollback trigger).
9. Format PR body with: Resumo, Commits, Labels, Validacao, Rollback trigger.
10. All 10 contractual blocks MUST be generated in the plan before modifying any file.

---
*PR created automatically by Jules for task [2597850417059683008](https://jules.google.com/task/2597850417059683008) started by @emersonbusson*