### PR TITLE
feat(packaging): add DKMS post-install hook for modules-load.d

### DIFF
--- a/drivers/block/ramshared/dkms.conf
+++ b/drivers/block/ramshared/dkms.conf
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# RamShared Dynamic Kernel Module Support (DKMS) Configuration
+
+PACKAGE_NAME="ramshared"
+PACKAGE_VERSION="0.9.0"
+AUTOINSTALL="yes"
+
+# Build definition
+CLEAN="make -C drivers/block/ramshared clean"
+MAKE[0]="make -C drivers/block/ramshared KDIR=/lib/modules/${kernelver}/build modules"
+BUILT_MODULE_NAME[0]="ramshared"
+BUILT_MODULE_LOCATION[0]="drivers/block/ramshared"
+DEST_MODULE_LOCATION[0]="/updates/dkms"
+STRIP[0]="yes"
+
+# Secure Boot / Kernel Lockdown Module Signing Integration
+SIGN_TOOL="/usr/lib/modules/${kernelver}/build/scripts/sign-file"
+MOK_SIGNING_KEY="/var/lib/dkms/mok.key"
+MOK_CERTIFICATE="/var/lib/dkms/mok.pub"
+
+# Post-install/remove hooks for modules-load.d provisioning
+POST_INSTALL="post_install.sh"
+POST_REMOVE="post_remove.sh"

--- a/drivers/block/ramshared/post_install.sh
+++ b/drivers/block/ramshared/post_install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Validate prerequisites
+command -v mkdir >/dev/null 2>&1 || { echo "mkdir is required but not installed. Aborting."; exit 1; }
+command -v echo >/dev/null 2>&1 || { echo "echo is required but not installed. Aborting."; exit 1; }
+command -v chmod >/dev/null 2>&1 || { echo "chmod is required but not installed. Aborting."; exit 1; }
+
+CONF_DIR="/etc/modules-load.d"
+CONF_FILE="${CONF_DIR}/ramshared.conf"
+
+if ! test -d "${CONF_DIR}"; then
+    mkdir -p "${CONF_DIR}"
+fi
+
+echo "ramshared" > "${CONF_FILE}"
+chmod 0644 "${CONF_FILE}"

--- a/drivers/block/ramshared/post_remove.sh
+++ b/drivers/block/ramshared/post_remove.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# Validate prerequisites
+command -v rm >/dev/null 2>&1 || { echo "rm is required but not installed. Aborting."; exit 1; }
+
+CONF_FILE="/etc/modules-load.d/ramshared.conf"
+
+if test -f "${CONF_FILE}"; then
+    rm -f "${CONF_FILE}"
+fi


### PR DESCRIPTION
## Resumo
Added POST_INSTALL and POST_REMOVE scripts to drivers/block/ramshared/dkms.conf to automatically provision /etc/modules-load.d/ramshared.conf during DKMS installation and remove it during uninstallation, satisfying the MODULES_CONF target.

## Issue
UpstreamPkg100/2026-09-09/dkms-secureboot/043

## Responsavel/Owner
jules

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 4b1970d8d43b26d674dcf91c207577b295d8dd36 | Added POST_INSTALL and POST_REMOVE scripts | To ensure ramshared is automatically loaded on boot | Configured drivers/block/ramshared/dkms.conf and added shell-safe scripts with precondition checks. |

## Labels
area:packaging, type:feature

## Validacao
shellcheck drivers/block/ramshared/post_install.sh drivers/block/ramshared/post_remove.sh

## Rollback trigger
If the post-install script fails during DKMS install or module loading fails on boot, revert this change and manually configure /etc/modules-load.d/ramshared.conf.

## Rules
1. Read README.md, AGENTS.md, CLAUDE.md, trovaldo.md, and all pertinent .claude/rules/.
2. Baseline git SHA is 156355c4427b6e00321ebc68c7de9288dbf72e09 on origin/main.
3. Implement only the smallest safe orthogonal slice. Use TDD, run cargo test, shellcheck, or checkpatch where applicable, and open 1 PR strictly against jules/inbox.
4. If safe code modification is not possible, produce FINDING_ONLY with evidence in docs/jules/findings/.
5. Do not read, write, print, or persist credentials/secrets.
6. PRs remain unmerged on jules/inbox; human consolidation will merge verified gains into main.
7. English only for all source code, comments, identifiers, commits, and PR descriptions.
8. Follow Conventional Commits format (<=72 chars title, body explaining rationale and rollback trigger).
9. Format PR body with: Resumo, Commits, Labels, Validacao, Rollback trigger.
10. All 10 contractual blocks MUST be generated in the plan before modifying any file.

---
*PR created automatically by Jules for task [276366911077729395](https://jules.google.com/task/276366911077729395) started by @emersonbusson*