### PR TITLE
fix: configure shutdown ordering for ramshared-vram

### DIFF
--- a/packaging/systemd/ramshared-vram.service
+++ b/packaging/systemd/ramshared-vram.service
@@ -1,4 +1,7 @@
 [Unit]
+DefaultDependencies=no
+Before=umount.target swap.target
+Requires=local-fs.target
 Description=RamShared Zero-Copy GPU VRAM Memory Tier Service
 Documentation=https://github.com/emersonbusson/ramshared
 After=systemd-udevd.service local-fs.target


### PR DESCRIPTION
## Issue

## Responsavel/Owner

## Resumo
Configure shutdown ordering dependencies (Before=umount.target swap.target, Requires=local-fs.target, DefaultDependencies=no) to guarantee swapoff before daemon termination.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 98f6e6c5d374340f78f63be9addbe8723f137cfe | Configure shutdown ordering dependencies | To guarantee swapoff before daemon termination | Configured Before=umount.target swap.target, Requires=local-fs.target, DefaultDependencies=no |

## Labels
type:packaging, type:systemd

## Validacao
systemd-analyze verify packaging/systemd/ramshared-vram.service

## Rollback trigger
Revert if systemd startup fails or shutdown order causes system hang.

1. Read README.md, AGENTS.md, CLAUDE.md, trovaldo.md, and all pertinent .claude/rules/.
2. Baseline git SHA is 156355c4427b6e00321ebc68c7de9288dbf72e09 on origin/main.
3. Implement only the smallest safe orthogonal slice. Use TDD, run cargo test, shellcheck, or checkpatch where applicable, and open 1 PR strictly against jules/inbox.
4. If safe code modification is not possible, produce FINDING_ONLY with evidence in docs/jules/findings/.
5. Do not read, write, print, or persist credentials/secrets.
6. PRs remain unmerged on jules/inbox; human consolidation will merge verified gains into main.
7. English only for all source code, comments, identifiers, commits, and PR descriptions.
8. Follow Conventional Commits format (<=72 chars title, body explaining rationale and rollback trigger).
9. Format PR body with: Resumo, Commits, Labels, Validacao, Rollback trigger.
10. All 10 contractual blocks MUST be generated in the plan before modifying any file.

---
*PR created automatically by Jules for task [13453654738942188070](https://jules.google.com/task/13453654738942188070) started by @emersonbusson*