### PR TITLE
feat(packaging): add ramshared-scrub.timer for memory integrity scrubbing

### DIFF
--- a/packaging/systemd/ramshared-scrub.timer
+++ b/packaging/systemd/ramshared-scrub.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Weekly automated memory integrity scrub for RamShared
+ConditionPathExists=/sys/module/ramshared
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+RandomizedDelaySec=1h
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Added a systemd timer (ramshared-scrub.timer) in packaging/systemd/ that triggers weekly automated memory integrity scrubbing. It includes `OnCalendar=weekly`, `Persistent=true`, and `RandomizedDelaySec=1h` as requested.

---
*PR created automatically by Jules for task [7609224145489430638](https://jules.google.com/task/7609224145489430638) started by @emersonbusson*