### PR TITLE
feat(systemd): add Condition guards for virtualization branching

### DIFF
--- a/packaging/systemd/ramshared-vram.service
+++ b/packaging/systemd/ramshared-vram.service
@@ -2,6 +2,8 @@
 Description=RamShared Zero-Copy GPU VRAM Memory Tier Service
 Documentation=https://github.com/emersonbusson/ramshared
 After=systemd-udevd.service local-fs.target
+ConditionPathExists=|/sys/class/drm
+ConditionVirtualization=|wsl
 StopWhenUnneeded=yes
 
 [Service]


### PR DESCRIPTION
Added `ConditionPathExists=|/sys/class/drm` and `ConditionVirtualization=|wsl` to `packaging/systemd/ramshared-vram.service`. This allows the unit to seamlessly branch between native host (DRM presence) and WSL2 virtualization environments using systemd fail-fast guard clauses.

---
*PR created automatically by Jules for task [14969670811677850480](https://jules.google.com/task/14969670811677850480) started by @emersonbusson*