### PR TITLE
feat(systemd): configure memlock and nofile limits

### DIFF
--- a/packaging/systemd/ramshared.service
+++ b/packaging/systemd/ramshared.service
@@ -1,0 +1,42 @@
+[Unit]
+Description=RamShared Zero-Copy GPU VRAM Memory Tier Service
+Documentation=https://github.com/emersonbusson/ramshared
+After=systemd-udevd.service local-fs.target
+StopWhenUnneeded=yes
+
+[Service]
+LimitMEMLOCK=infinity
+LimitNOFILE=65536
+Type=simple
+ExecStart=/usr/bin/ramsharedd --daemon --origin-ssd
+ExecStop=/usr/bin/ramshared cascade down
+Restart=on-failure
+RestartSec=5s
+KillMode=process
+SendSIGKILL=no
+TimeoutStartSec=60s
+TimeoutStopSec=30s
+StandardOutput=journal
+StandardError=journal
+
+# Sandboxing & Security Hardening
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+NoNewPrivileges=yes
+RestrictRealtime=yes
+RestrictAddressFamilies=AF_UNIX AF_NETLINK
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_SYS_RAWIO CAP_DAC_OVERRIDE
+MemoryDenyWriteExecute=no
+LockPersonality=yes
+ProtectHostname=yes
+ProtectClock=yes
+DeviceAllow=/dev/ublk-control rw
+DeviceAllow=char-drm rw
+DeviceAllow=char-nvidia-uvm rw
+DeviceAllow=block-* rw
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Set LimitMEMLOCK=infinity for DMA pinning and LimitNOFILE=65536 in daemon service unit.

---
*PR created automatically by Jules for task [12559115418366683501](https://jules.google.com/task/12559115418366683501) started by @emersonbusson*