### PR TITLE
feat(systemd-udev): add SELinux context propagation rules

### DIFF
--- a/packaging/udev/99-ramshared.rules
+++ b/packaging/udev/99-ramshared.rules
@@ -1,0 +1,2 @@
+# SELinux context attribute propagation for ramshared device
+SUBSYSTEM=="block", KERNEL=="ramshared*", SECLABEL{selinux}="system_u:object_r:ramshared_device_t:s0"


### PR DESCRIPTION
## Issue
SELinux context attribute propagation in udev rules

## Responsavel/Owner
jules

## Resumo
Propagate SELinux device context labels correctly during udev device node creation.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| c6a6d84 | Added 99-ramshared.rules | Enforce SELinux contexts | Assigns ramshared_device_t |
| 156355c | feat(core): consolidate multi-tier resilience hardening and verified audit | Ensure stability | Pre-existing commit |

## Labels
type:packaging, area:systemd

## Validacao
udevadm verify packaging/udev/99-ramshared.rules

## Rollback trigger
Revert if devices fail to get SELinux contexts.

---
*PR created automatically by Jules for task [653976152971853289](https://jules.google.com/task/653976152971853289) started by @emersonbusson*