### PR TITLE
sys: configure journald syslog identifier for ramshared service

### DIFF
--- a/packaging/systemd/ramshared-vram.service
+++ b/packaging/systemd/ramshared-vram.service
@@ -16,6 +16,7 @@ TimeoutStartSec=60s
 TimeoutStopSec=30s
 StandardOutput=journal
 StandardError=journal
+SyslogIdentifier=ramshared-vram
 
 # Sandboxing & Security Hardening
 ProtectSystem=strict


### PR DESCRIPTION
## Resumo

Configure `SyslogIdentifier=ramshared-vram` in the `ramshared-vram.service` systemd unit file to ensure consistent and identifiable journald logging. This aligns the service output streams (StandardOutput and StandardError) with standard systemd logging practices, improving observability and debugging capabilities for the RamShared Zero-Copy GPU VRAM Memory Tier Service.

## Issue

Fixes #N/A (Directly addresses PR requirement for StandardOutput and StandardError journald logging configuration)

## Responsavel/Owner

UpstreamPkg-100

## Commits

| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 60a7814 | Configure SyslogIdentifier in ramshared-vram.service | To ensure consistent and identifiable journald logging | Added SyslogIdentifier=ramshared-vram to the systemd service file |

## Labels

type:packaging, area:systemd-udev

## Validacao

```bash
MOCK_ROOT=$(mktemp -d)
mkdir -p "$MOCK_ROOT/usr/bin"
touch "$MOCK_ROOT/usr/bin/ramsharedd" "$MOCK_ROOT/usr/bin/ramshared"
chmod +x "$MOCK_ROOT/usr/bin/ramsharedd" "$MOCK_ROOT/usr/bin/ramshared"
systemd-analyze verify --root="$MOCK_ROOT" packaging/systemd/ramshared-vram.service || true
systemd-analyze verify packaging/systemd/ramshared-vram.service 2>&1 | grep -v "not executable" || true
cargo test
```

## Rollback trigger

Revert this PR if the modified ramshared-vram.service fails systemd syntax validation, causes unexpected logging behavior in journald, or prevents the service from starting correctly.

---
*PR created automatically by Jules for task [9387174698015971171](https://jules.google.com/task/9387174698015971171) started by @emersonbusson*