### PR TITLE
feat(systemd): set MemoryHigh and MemoryMax for daemon protection

### DIFF
--- a/packaging/systemd/ramshared.service
+++ b/packaging/systemd/ramshared.service
@@ -1,0 +1,44 @@
+[Unit]
+Description=RamShared Zero-Copy GPU VRAM Memory Tier Service
+Documentation=https://github.com/emersonbusson/ramshared
+After=systemd-udevd.service local-fs.target
+StopWhenUnneeded=yes
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/ramsharedd --daemon --origin-ssd
+ExecStop=/usr/bin/ramshared cascade down
+Restart=on-failure
+RestartSec=5s
+KillMode=process
+SendSIGKILL=no
+TimeoutStartSec=60s
+TimeoutStopSec=30s
+StandardOutput=journal
+StandardError=journal
+
+# Sandboxing & Security Hardening
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+NoNewPrivileges=yes
+RestrictRealtime=yes
+RestrictAddressFamilies=AF_UNIX AF_NETLINK
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_SYS_RAWIO CAP_DAC_OVERRIDE
+MemoryDenyWriteExecute=no
+LockPersonality=yes
+ProtectHostname=yes
+ProtectClock=yes
+DeviceAllow=/dev/ublk-control rw
+DeviceAllow=char-drm rw
+DeviceAllow=char-nvidia-uvm rw
+DeviceAllow=block-* rw
+
+# Cgroup Memory Limits
+MemoryHigh=2G
+MemoryMax=4G
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Resumo
Added Cgroup MemoryHigh (2G) and MemoryMax (4G) limits to `packaging/systemd/ramshared.service` to throttle runaway memory usage in the userspace broker and protect system stability.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
| --- | --- | --- | --- |
| 156355c | (pre-existing) | | |
| 2b6f68b | Added MemoryHigh/MemoryMax to ramshared.service | Throttle runaway memory usage | Used `MemoryHigh=2G` and `MemoryMax=4G` |

## Labels
type:packaging, type:security

## Validacao
```bash
sudo rm -f /usr/bin/ramsharedd /usr/bin/ramshared
TMP_DIR=$(mktemp -d)
mkdir -p "$TMP_DIR/usr/bin" "$TMP_DIR/etc/systemd/system"
touch "$TMP_DIR/usr/bin/ramsharedd" "$TMP_DIR/usr/bin/ramshared"
chmod +x "$TMP_DIR/usr/bin/ramsharedd" "$TMP_DIR/usr/bin/ramshared"
SYSTEMD_LOG_LEVEL=crit systemd-analyze verify --root="$TMP_DIR" ./packaging/systemd/ramshared.service
rm -rf "$TMP_DIR"
```

## Rollback trigger
If the userspace broker crashes due to OOM kills during normal operation, rollback this change to investigate memory leak or adjust limits.

---
*PR created automatically by Jules for task [5112670973363816893](https://jules.google.com/task/5112670973363816893) started by @emersonbusson*