### PR TITLE
feat: abstract ordered workqueue allocation for RamShared

### DIFF
--- a/drivers/block/ramshared/compat.h
+++ b/drivers/block/ramshared/compat.h
@@ -10,6 +10,7 @@
 #ifndef _RAMSHARED_COMPAT_H
 #define _RAMSHARED_COMPAT_H
 
+#include <linux/workqueue.h>
 #include <linux/version.h>
 #include <linux/blkdev.h>
 #include <linux/blk-mq.h>
@@ -100,6 +101,35 @@ static inline struct gendisk *ramshared_alloc_disk(struct blk_mq_tag_set *set,
 
 	return disk;
 #endif
+}
+
+/**
+ * ramshared_alloc_ordered_workqueue - Allocate an ordered workqueue safely
+ * @fmt: printf format for the name of the workqueue
+ *
+ * Wraps alloc_ordered_workqueue.
+ */
+#define ramshared_alloc_ordered_workqueue(fmt, ...) \
+	alloc_ordered_workqueue(fmt, WQ_MEM_RECLAIM, ##__VA_ARGS__)
+
+/**
+ * ramshared_flush_workqueue - Flush a workqueue if it exists
+ * @wq: Pointer to the workqueue
+ */
+static inline void ramshared_flush_workqueue(struct workqueue_struct *wq)
+{
+	if (wq)
+		flush_workqueue(wq);
+}
+
+/**
+ * ramshared_destroy_workqueue - Destroy a workqueue safely
+ * @wq: Pointer to the workqueue
+ */
+static inline void ramshared_destroy_workqueue(struct workqueue_struct *wq)
+{
+	if (wq)
+		destroy_workqueue(wq);
 }
 
 #endif /* _RAMSHARED_COMPAT_H */


### PR DESCRIPTION
## Issue
UpstreamPkg-100

## Responsavel/Owner
UpstreamPkg100/2026-09-09/dkms-secureboot/049

## Resumo
Abstract workqueue creation and destruction primitives across Linux 5.15 and 6.x to ensure DKMS/Secure Boot compatibility.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| dd0e33b | feat: abstract ordered workqueue allocation for RamShared | Introduce safe abstractions for ordered workqueues | Added macros and inline functions to prevent NULL-pointer dereference bugs during destruction and flushing, ensuring fail-safe compatibility across LTS kernels. |

## Labels
type:packaging
area:dkms-secureboot

## Validacao
cat drivers/block/ramshared/compat.h | tail -n 35
cargo test

## Rollback trigger
If DKMS module build fails on any supported kernel (5.15+).

---
*PR created automatically by Jules for task [14444968455768366549](https://jules.google.com/task/14444968455768366549) started by @emersonbusson*