### PR TITLE
fix: add bvec segment iterator defensive checks

### DIFF
--- a/drivers/block/ramshared/queue.c
+++ b/drivers/block/ramshared/queue.c
@@ -44,8 +44,18 @@ static blk_status_t ramshared_process_bio(struct ramshared_device *rs_dev,
 	vram_ptr = rs_dev->dma.cpu_addr + pos;
 
 	bio_for_each_segment(bvec, bio, iter) {
-		void *src_or_dst = bvec_kmap_local(&bvec);
-		size_t len = bvec.bv_len;
+		void *src_or_dst;
+		size_t len;
+
+		if (unlikely(!bvec.bv_page || bvec.bv_len == 0)) {
+			dev_err_ratelimited(rs_dev->dev,
+					    "Invalid bvec segment: page=%p, len=%u\n",
+					    bvec.bv_page, bvec.bv_len);
+			return BLK_STS_IOERR;
+		}
+
+		src_or_dst = bvec_kmap_local(&bvec);
+		len = bvec.bv_len;
 
 		if (op == REQ_OP_READ) {
 			dma_rmb();


### PR DESCRIPTION
## Resumo
Added fail-fast guard clauses in ramshared_process_bio to validate bvec.bv_page != NULL and bvec.bv_len > 0, preventing potential NULL pointer dereferences.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 7086a2e | add bvec segment iterator defensive checks | preventing potential NULL pointer dereferences | |

## Labels
type:kernel
area:upstream

## Validacao
cd /home/jules/workspace/drivers/block/ramshared/ && make clean || true

## Rollback trigger
Revert if valid I/O operations are spuriously rejected with BLK_STS_IOERR or if module build fails.

---
*PR created automatically by Jules for task [7108426513544831057](https://jules.google.com/task/7108426513544831057) started by @emersonbusson*