### PR TITLE
fix(ramshared): clear PCI master before unmapping BAR

### DIFF
--- a/drivers/block/ramshared/main.c
+++ b/drivers/block/ramshared/main.c
@@ -135,9 +135,9 @@ static void ramshared_pci_remove(struct pci_dev *pdev)
 		return;
 
 	ramshared_queue_cleanup(rs_dev);
+	pci_clear_master(pdev);
 	ramshared_dma_cleanup(rs_dev);
 	pci_release_mem_regions(pdev);
-	pci_clear_master(pdev);
 	pci_disable_device(pdev);
 
 	dev_info(&pdev->dev, "RamShared device removed successfully\n");


### PR DESCRIPTION
{"title": "fix(ramshared): clear PCI master before unmapping BAR", "body": "## Resumo\nExplicitly call pci_clear_master(pdev) in ramshared_pci_remove before unmapping BAR memory (ramshared_dma_cleanup) to halt DMA engines and prevent DMA faults during teardown.\n\n## Commits\n| Commit | O que fez | Por que fez | Detalhes |\n|---|---|---|---|\n| 65f2a5c | Move pci_clear_master call | Fix DMA faults during teardown | Halt DMA engines before unmapping BAR memory |\n\n## Labels\ntype:kernel, type:upstream\n\n## Validacao\ngrep -n -C 2 \\\"pci_clear_master(pdev)\\\" drivers/block/ramshared/main.c\n\n## Rollback trigger\nKernel panic or DMA fault observed during rmmod or RamShared PCIe device removal."}

---
*PR created automatically by Jules for task [912529264697454918](https://jules.google.com/task/912529264697454918) started by @emersonbusson*