### PR TITLE
fix(ramshared): guard blk_mq_free_tag_set with tags null check

### DIFF
--- a/drivers/block/ramshared/queue.c
+++ b/drivers/block/ramshared/queue.c
@@ -257,7 +257,8 @@ int ramshared_queue_init(struct ramshared_device *rs_dev,
 					    RAMSHARED_SECTOR_SIZE, 2048);
 	if (IS_ERR(rs_dev->disk)) {
 		ret = PTR_ERR(rs_dev->disk);
-		blk_mq_free_tag_set(&rs_dev->tag_set);
+		if (rs_dev->tag_set.tags)
+			blk_mq_free_tag_set(&rs_dev->tag_set);
 		return ret;
 	}
 


### PR DESCRIPTION
## Resumo
Guards blk_mq_free_tag_set against a double-free or null dereference by verifying tag_set.tags != NULL prior to freeing in the initialization error path. This improves safety and complies with kernel defensive programming principles.

## Commits
| Commit | O que fez | Por que fez | Detalhes |
|---|---|---|---|
| 06ea402 | Added guard clause to blk_mq_free_tag_set in init error path. | Prevents potential crash or UAF if tags allocation partially failed before disk setup. | In drivers/block/ramshared/queue.c |

## Labels
type:kernel
type:upstream
type:security
area:ramshared

## Validacao
./scripts/ci/check-kernel-style.sh

## Rollback trigger
If the guard causes issues or crashes during module initialization or rollback on any LTS kernel version.

---
*PR created automatically by Jules for task [16374517572586578853](https://jules.google.com/task/16374517572586578853) started by @emersonbusson*