### PR TITLE
refactor(gpu-backends): extract Vulkan memory allocation and mapping into memory module

### DIFF
--- a/crates/ramshared-vulkan/src/lib.rs
+++ b/crates/ramshared-vulkan/src/lib.rs
@@ -16,13 +16,18 @@
 use std::ffi::CStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+mod memory;
+pub use memory::VulkanMem;
+use memory::{DeviceBits, create_device_resources};
+
 use ash::vk;
-use ramshared_vram::{VramError, VramMemory, VramProvider};
+use ramshared_vram::{VramError, VramProvider};
+
 
 /// Single staging buffer per provider (no alloc on hot path, DT-8): 1 MiB. Larger I/O is sliced.
 const STAGING_BYTES: u64 = 1 << 20;
 
-fn vk_err(ctx: &str, e: impl std::fmt::Debug) -> VramError {
+pub(crate) fn vk_err(ctx: &str, e: impl std::fmt::Debug) -> VramError {
     VramError::Provider(format!("vulkan {ctx}: {e:?}"))
 }
 
@@ -41,93 +46,12 @@ fn pick_transfer_family(instance: &ash::Instance, phys: vk::PhysicalDevice) -> O
         .map(|i| i as u32)
 }
 
-/// Index of the first memory type that satisfies `type_bits` (bitmask of `MemoryRequirements`) and contains
-/// all `want` flags. `None` if none fit.
-fn pick_memory_type(
-    props: &vk::PhysicalDeviceMemoryProperties,
-    type_bits: u32,
-    want: vk::MemoryPropertyFlags,
-) -> Option<u32> {
-    (0..props.memory_type_count).find(|&i| {
-        (type_bits & (1 << i)) != 0 && props.memory_types[i as usize].property_flags.contains(want)
-    })
-}
-
-/// Logical device resources created in `open` (loaded into `VulkanProvider` on success).
-struct DeviceBits {
-    device: ash::Device,
-    queue: vk::Queue,
-    cmd_pool: vk::CommandPool,
-    cmd_buf: vk::CommandBuffer,
-    fence: vk::Fence,
-    staging_buffer: vk::Buffer,
-    staging_memory: vk::DeviceMemory,
-    staging_mapped: *mut u8,
-}
-
-/// RAII guard for the `goto out_err` (kernel idiom) in device creation: on error (any `?`),
-/// destroys the already created resources in reverse order **and** the device. On success, `disarm()` prevents
-/// cleanup and the handles are passed to the `VulkanProvider`.
-struct ResGuard {
-    device: ash::Device,
-    cmd_pool: Option<vk::CommandPool>,
-    fence: Option<vk::Fence>,
-    staging_buffer: Option<vk::Buffer>,
-    staging_memory: Option<vk::DeviceMemory>,
-    mapped: bool,
-    armed: bool,
-}
-
-impl ResGuard {
-    fn new(device: ash::Device) -> Self {
-        Self {
-            device,
-            cmd_pool: None,
-            fence: None,
-            staging_buffer: None,
-            staging_memory: None,
-            mapped: false,
-            armed: true,
-        }
-    }
-}
-
-impl Drop for ResGuard {
-    fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-        // SAFETY: all Some handles were created from self.device in this flow and are destroyed
-        // exactly once (in reverse order of allocation). device_wait_idle guarantees nothing is
-        // in-flight before freeing.
-        unsafe {
-            let _ = self.device.device_wait_idle();
-            if let Some(m) = self.staging_memory {
-                if self.mapped {
-                    self.device.unmap_memory(m);
-                }
-                self.device.free_memory(m, None);
-            }
-            if let Some(b) = self.staging_buffer {
-                self.device.destroy_buffer(b, None);
-            }
-            if let Some(f) = self.fence {
-                self.device.destroy_fence(f, None);
-            }
-            if let Some(p) = self.cmd_pool {
-                self.device.destroy_command_pool(p, None);
-            }
-            self.device.destroy_device(None);
-        }
-    }
-}
-
 /// Vulkan Provider (thread-affine — create/use in the same thread, same as CUDA context;
 /// the queue is externally synchronized, DT-7). Reuses 1 staging buffer + 1 cmd buffer + 1 fence.
 pub struct VulkanProvider {
-    instance: ash::Instance,
+    pub(crate) instance: ash::Instance,
     _entry: ash::Entry, // keeps the loader alive as long as the instance exists
-    phys: vk::PhysicalDevice,
+    pub(crate) phys: vk::PhysicalDevice,
     device: ash::Device,
     queue: vk::Queue,
     cmd_pool: vk::CommandPool,
@@ -136,7 +60,7 @@ pub struct VulkanProvider {
     staging_buffer: vk::Buffer,
     staging_memory: vk::DeviceMemory,
     staging_mapped: *mut u8,
-    allocated: AtomicU64, // Σ bytes allocated via `alloc` (fallback of `mem_info`, DT-10)
+    pub(crate) allocated: AtomicU64, // Σ bytes allocated via `alloc` (fallback of `mem_info`, DT-10)
     name: String,
 }
 
@@ -232,7 +156,7 @@ impl VulkanProvider {
     /// Records + submits + waits for 1 command on the transfer queue (synchronous, DT-5).
     /// `record` writes to the reused `cmd_buf`; after `wait`, the fence is reset.
     /// Single-threaded (DT-7): no races on shared cmd_buf/fence/staging.
-    fn submit_wait<F>(&self, record: F) -> Result<(), VramError>
+    pub(crate) fn submit_wait<F>(&self, record: F) -> Result<(), VramError>
     where
         F: FnOnce(&ash::Device, vk::CommandBuffer),
     {
@@ -264,122 +188,6 @@ impl VulkanProvider {
     }
 }
 
-/// Creates logical device + queue + cmd pool/buffer + fence + mapped staging buffer, with RAII cleanup on error.
-fn create_device_resources(
-    instance: &ash::Instance,
-    phys: vk::PhysicalDevice,
-    qf: u32,
-) -> Result<DeviceBits, VramError> {
-    let prio = [1.0f32];
-    let qci = [vk::DeviceQueueCreateInfo::default()
-        .queue_family_index(qf)
-        .queue_priorities(&prio)];
-    let dci = vk::DeviceCreateInfo::default().queue_create_infos(&qci);
-    // SAFETY: `dci`/`qci`/`prio` valid during call; `phys` enumerated from `instance`. Before
-    // device creation, there are no resources to clean up (returns directly on failure).
-    let device = unsafe { instance.create_device(phys, &dci, None) }
-        .map_err(|e| vk_err("create_device", e))?;
-
-    // From here on, every `?` is covered by `guard` (destroys children + device on error).
-    let mut guard = ResGuard::new(device);
-
-    // SAFETY: `guard.device`/`qf` valid.
-    let queue = unsafe { guard.device.get_device_queue(qf, 0) };
-
-    let pool_ci = vk::CommandPoolCreateInfo::default()
-        .queue_family_index(qf)
-        .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER);
-    // SAFETY: device + pool_ci valid.
-    let cmd_pool = unsafe { guard.device.create_command_pool(&pool_ci, None) }
-        .map_err(|e| vk_err("create_command_pool", e))?;
-    guard.cmd_pool = Some(cmd_pool);
-
-    let cb_ai = vk::CommandBufferAllocateInfo::default()
-        .command_pool(cmd_pool)
-        .level(vk::CommandBufferLevel::PRIMARY)
-        .command_buffer_count(1);
-    // SAFETY: device + cb_ai valid; the cmd buffer(s) are freed together with the pool.
-    let cbs = unsafe { guard.device.allocate_command_buffers(&cb_ai) }
-        .map_err(|e| vk_err("allocate_command_buffers", e))?;
-    let cmd_buf = cbs
-        .first()
-        .copied()
-        .ok_or_else(|| VramError::Provider("allocate_command_buffers returned empty".into()))?;
-
-    // SAFETY: device valid.
-    let fence = unsafe {
-        guard
-            .device
-            .create_fence(&vk::FenceCreateInfo::default(), None)
-    }
-    .map_err(|e| vk_err("create_fence", e))?;
-    guard.fence = Some(fence);
-
-    let buf_ci = vk::BufferCreateInfo::default()
-        .size(STAGING_BYTES)
-        .usage(vk::BufferUsageFlags::TRANSFER_SRC | vk::BufferUsageFlags::TRANSFER_DST)
-        .sharing_mode(vk::SharingMode::EXCLUSIVE);
-    // SAFETY: device + buf_ci valid.
-    let staging_buffer = unsafe { guard.device.create_buffer(&buf_ci, None) }
-        .map_err(|e| vk_err("create_buffer(staging)", e))?;
-    guard.staging_buffer = Some(staging_buffer);
-
-    // SAFETY: buffer valid.
-    let req = unsafe { guard.device.get_buffer_memory_requirements(staging_buffer) };
-    // SAFETY: phys valid.
-    let mprops = unsafe { instance.get_physical_device_memory_properties(phys) };
-    let mt = pick_memory_type(
-        &mprops,
-        req.memory_type_bits,
-        vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT,
-    )
-    .ok_or_else(|| {
-        VramError::Provider("sem memory type HOST_VISIBLE|COHERENT p/ staging".into())
-    })?;
-    let mai = vk::MemoryAllocateInfo::default()
-        .allocation_size(req.size)
-        .memory_type_index(mt);
-    // SAFETY: device + mai valid.
-    let staging_memory = unsafe { guard.device.allocate_memory(&mai, None) }
-        .map_err(|e| vk_err("allocate_memory(staging)", e))?;
-    guard.staging_memory = Some(staging_memory);
-
-    // SAFETY: buffer + memory valid; offset 0 satisfies the alignment of `req`.
-    unsafe {
-        guard
-            .device
-            .bind_buffer_memory(staging_buffer, staging_memory, 0)
-    }
-    .map_err(|e| vk_err("bind_buffer_memory(staging)", e))?;
-
-    // SAFETY: newly allocated HOST_VISIBLE memory; maps the entire range.
-    let raw = unsafe {
-        guard.device.map_memory(
-            staging_memory,
-            0,
-            STAGING_BYTES,
-            vk::MemoryMapFlags::empty(),
-        )
-    }
-    .map_err(|e| vk_err("map_memory(staging)", e))?;
-    guard.mapped = true;
-    let staging_mapped = raw.cast::<u8>();
-
-    // Success: disarms the guard and extracts the handles (the device is cloned — lightweight handle from ash;
-    // the actual destroy is done in Drop of VulkanProvider).
-    guard.armed = false;
-    Ok(DeviceBits {
-        device: guard.device.clone(),
-        queue,
-        cmd_pool,
-        cmd_buf,
-        fence,
-        staging_buffer,
-        staging_memory,
-        staging_mapped,
-    })
-}
-
 impl VramProvider for VulkanProvider {
     // GAT: memory borrows &self (same as CUDA's DeviceMem) -> thread affinity without Arc.
     type Mem<'p>
@@ -388,66 +196,7 @@ impl VramProvider for VulkanProvider {
         Self: 'p;
 
     fn alloc(&self, bytes: usize) -> Result<Self::Mem<'_>, VramError> {
-        // Rounds buffer size to a multiple of 4 (requirement for vkCmdFillBuffer with WHOLE_SIZE
-        // in zero); the logical len remains `bytes`.
-        let buf_size = ((bytes as u64).max(1) + 3) & !3;
-        let buf_ci = vk::BufferCreateInfo::default()
-            .size(buf_size)
-            .usage(vk::BufferUsageFlags::TRANSFER_SRC | vk::BufferUsageFlags::TRANSFER_DST)
-            .sharing_mode(vk::SharingMode::EXCLUSIVE);
-        // SAFETY: device + buf_ci valid.
-        let buffer = unsafe { self.device.create_buffer(&buf_ci, None) }
-            .map_err(|e| vk_err("create_buffer", e))?;
-
-        // SAFETY: buffer valid.
-        let req = unsafe { self.device.get_buffer_memory_requirements(buffer) };
-        // SAFETY: phys valid.
-        let mprops = unsafe {
-            self.instance
-                .get_physical_device_memory_properties(self.phys)
-        };
-        let mt = match pick_memory_type(
-            &mprops,
-            req.memory_type_bits,
-            vk::MemoryPropertyFlags::DEVICE_LOCAL,
-        ) {
-            Some(i) => i,
-            None => {
-                // SAFETY: buffer created above; destroyed before returning (no leak).
-                unsafe { self.device.destroy_buffer(buffer, None) };
-                return Err(VramError::Provider(
-                    "no DEVICE_LOCAL memory type for the buffer".into(),
-                ));
-            }
-        };
-        let mai = vk::MemoryAllocateInfo::default()
-            .allocation_size(req.size)
-            .memory_type_index(mt);
-        // SAFETY: device + mai valid.
-        let memory = match unsafe { self.device.allocate_memory(&mai, None) } {
-            Ok(m) => m,
-            Err(e) => {
-                // SAFETY: buffer created above; destroyed on error.
-                unsafe { self.device.destroy_buffer(buffer, None) };
-                return Err(vk_err("allocate_memory", e));
-            }
-        };
-        // SAFETY: buffer + memory valid; offset 0.
-        if let Err(e) = unsafe { self.device.bind_buffer_memory(buffer, memory, 0) } {
-            // SAFETY: buffer + memory created above; freed in reverse order on error.
-            unsafe {
-                self.device.free_memory(memory, None);
-                self.device.destroy_buffer(buffer, None);
-            }
-            return Err(vk_err("bind_buffer_memory", e));
-        }
-        self.allocated.fetch_add(bytes as u64, Ordering::Relaxed);
-        Ok(VulkanMem {
-            provider: self,
-            buffer,
-            memory,
-            len: bytes,
-        })
+        memory::alloc_memory(self, bytes)
     }
 
     fn mem_info(&self) -> Result<(u64, u64), VramError> {
@@ -477,117 +226,11 @@ impl Drop for VulkanProvider {
     }
 }
 
-/// Vulkan VRAM region (GAT: borrows `&'p VulkanProvider`). RAII: `Drop` frees buffer+memory.
-pub struct VulkanMem<'p> {
-    provider: &'p VulkanProvider,
-    buffer: vk::Buffer,
-    memory: vk::DeviceMemory,
-    len: usize,
-}
-
-impl VulkanMem<'_> {
-    /// `off + len <= self.len`, otherwise `OutOfRange` (mirrors CUDA's bounds check).
-    fn check_bounds(&self, off: u64, len: usize) -> Result<(), VramError> {
-        match off.checked_add(len as u64) {
-            Some(end) if end <= self.len as u64 => Ok(()),
-            _ => Err(VramError::OutOfRange {
-                off,
-                len: len as u64,
-                size: self.len as u64,
-            }),
-        }
-    }
-}
-
-impl VramMemory for VulkanMem<'_> {
-    fn len(&self) -> usize {
-        self.len
-    }
-
-    fn zero(&mut self) -> Result<(), VramError> {
-        let buffer = self.buffer;
-        self.provider.submit_wait(|dev, cmd| {
-            // SAFETY: `cmd` in recording; `buffer` of this provider; `WHOLE_SIZE` zeroes the
-            // entire buffer (allocated as a multiple of 4 to satisfy `vkCmdFillBuffer`).
-            unsafe { dev.cmd_fill_buffer(cmd, buffer, 0, vk::WHOLE_SIZE, 0) };
-        })
-    }
-
-    fn read_at(&self, off: u64, dst: &mut [u8]) -> Result<(), VramError> {
-        self.check_bounds(off, dst.len())?;
-        let p = self.provider;
-        let buffer = self.buffer;
-        let mut done = 0usize;
-        while done < dst.len() {
-            let chunk = (dst.len() - done).min(STAGING_BYTES as usize);
-            let src_off = off + done as u64;
-            // GPU: copies `[src_off, src_off + chunk)` from the `DEVICE_LOCAL` buffer -> staging.
-            p.submit_wait(|dev, cmd| {
-                let region = [vk::BufferCopy::default()
-                    .src_offset(src_off)
-                    .dst_offset(0)
-                    .size(chunk as u64)];
-                // SAFETY: buffers belong to the provider; `chunk <= STAGING_BYTES` and bounds-checked on the buffer.
-                unsafe { dev.cmd_copy_buffer(cmd, buffer, p.staging_buffer, &region) };
-            })?;
-            // Host: staging.mapped -> dst[done..].
-            // SAFETY: `staging_mapped` has `STAGING_BYTES` bytes (`HOST_VISIBLE|HOST_COHERENT`, no flush);
-            // `chunk <= STAGING_BYTES`; `dst[done..done+chunk]` is valid (slice bounds).
-            unsafe {
-                std::ptr::copy_nonoverlapping(p.staging_mapped, dst.as_mut_ptr().add(done), chunk)
-            };
-            done += chunk;
-        }
-        Ok(())
-    }
-
-    fn write_at(&mut self, off: u64, src: &[u8]) -> Result<(), VramError> {
-        self.check_bounds(off, src.len())?;
-        let p = self.provider;
-        let buffer = self.buffer;
-        let mut done = 0usize;
-        while done < src.len() {
-            let chunk = (src.len() - done).min(STAGING_BYTES as usize);
-            // Host: src[done..] -> staging.mapped.
-            // SAFETY: `staging_mapped` has `STAGING_BYTES` bytes; `chunk <= STAGING_BYTES`;
-            // `src[done..done+chunk]` is valid (slice bounds). `HOST_COHERENT`: no flush.
-            unsafe {
-                std::ptr::copy_nonoverlapping(src.as_ptr().add(done), p.staging_mapped, chunk)
-            };
-            let dst_off = off + done as u64;
-            // GPU: copies staging -> `[dst_off, dst_off + chunk)` on the `DEVICE_LOCAL` buffer.
-            p.submit_wait(|dev, cmd| {
-                let region = [vk::BufferCopy::default()
-                    .src_offset(0)
-                    .dst_offset(dst_off)
-                    .size(chunk as u64)];
-                // SAFETY: buffers belong to the provider; `chunk <= STAGING_BYTES` and bounds-checked on the buffer.
-                unsafe { dev.cmd_copy_buffer(cmd, p.staging_buffer, buffer, &region) };
-            })?;
-            done += chunk;
-        }
-        Ok(())
-    }
-}
-
-impl Drop for VulkanMem<'_> {
-    fn drop(&mut self) {
-        // SAFETY: buffer+memory created in `alloc` of this provider; destroyed once in reverse
-        // order. The device remains alive (borrowing `&'p provider`).
-        unsafe {
-            self.provider.device.destroy_buffer(self.buffer, None);
-            self.provider.device.free_memory(self.memory, None);
-        }
-        self.provider
-            .allocated
-            .fetch_sub(self.len as u64, Ordering::Relaxed);
-    }
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use ramshared_vram::VramMemory;
 
     #[test]
     #[ignore = "requires Vulkan loader + ICD (lavapipe/llvmpipe is enough; run with --ignored)"]

--- a/crates/ramshared-vulkan/src/memory.rs
+++ b/crates/ramshared-vulkan/src/memory.rs
@@ -1,0 +1,405 @@
+//! Memory allocation and mapping for Vulkan backend.
+
+use ash::vk;
+use ramshared_vram::{VramError, VramMemory};
+use std::sync::atomic::Ordering;
+
+use crate::{VulkanProvider, STAGING_BYTES};
+
+/// Index of the first memory type that satisfies `type_bits` (bitmask of `MemoryRequirements`) and contains
+/// all `want` flags. `None` if none fit.
+pub(crate) fn pick_memory_type(
+    props: &vk::PhysicalDeviceMemoryProperties,
+    type_bits: u32,
+    want: vk::MemoryPropertyFlags,
+) -> Option<u32> {
+    (0..props.memory_type_count).find(|&i| {
+        (type_bits & (1 << i)) != 0 && props.memory_types[i as usize].property_flags.contains(want)
+    })
+}
+
+/// Vulkan VRAM region (GAT: borrows `&'p VulkanProvider`). RAII: `Drop` frees buffer+memory.
+pub struct VulkanMem<'p> {
+    pub(crate) provider: &'p VulkanProvider,
+    pub(crate) buffer: vk::Buffer,
+    pub(crate) memory: vk::DeviceMemory,
+    pub(crate) len: usize,
+}
+
+impl VulkanMem<'_> {
+    /// `off + len <= self.len`, otherwise `OutOfRange` (mirrors CUDA's bounds check).
+    fn check_bounds(&self, off: u64, len: usize) -> Result<(), VramError> {
+        match off.checked_add(len as u64) {
+            Some(end) if end <= self.len as u64 => Ok(()),
+            _ => Err(VramError::OutOfRange {
+                off,
+                len: len as u64,
+                size: self.len as u64,
+            }),
+        }
+    }
+}
+
+impl VramMemory for VulkanMem<'_> {
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn zero(&mut self) -> Result<(), VramError> {
+        let buffer = self.buffer;
+        self.provider.submit_wait(|dev, cmd| {
+            // SAFETY: `cmd` in recording; `buffer` of this provider; `WHOLE_SIZE` zeroes the
+            // entire buffer (allocated as a multiple of 4 to satisfy `vkCmdFillBuffer`).
+            unsafe { dev.cmd_fill_buffer(cmd, buffer, 0, vk::WHOLE_SIZE, 0) };
+        })
+    }
+
+    fn read_at(&self, off: u64, dst: &mut [u8]) -> Result<(), VramError> {
+        self.check_bounds(off, dst.len())?;
+        let p = self.provider;
+        let buffer = self.buffer;
+        let mut done = 0usize;
+        while done < dst.len() {
+            let chunk = (dst.len() - done).min(STAGING_BYTES as usize);
+            let src_off = off + done as u64;
+            // GPU: copies `[src_off, src_off + chunk)` from the `DEVICE_LOCAL` buffer -> staging.
+            p.submit_wait(|dev, cmd| {
+                let region = [vk::BufferCopy::default()
+                    .src_offset(src_off)
+                    .dst_offset(0)
+                    .size(chunk as u64)];
+                // SAFETY: buffers belong to the provider; `chunk <= STAGING_BYTES` and bounds-checked on the buffer.
+                unsafe { dev.cmd_copy_buffer(cmd, buffer, p.staging_buffer, &region) };
+            })?;
+            // Host: staging.mapped -> dst[done..].
+            // SAFETY: `staging_mapped` has `STAGING_BYTES` bytes (`HOST_VISIBLE|HOST_COHERENT`, no flush);
+            // `chunk <= STAGING_BYTES`; `dst[done..done+chunk]` is valid (slice bounds).
+            unsafe {
+                std::ptr::copy_nonoverlapping(p.staging_mapped, dst.as_mut_ptr().add(done), chunk)
+            };
+            done += chunk;
+        }
+        Ok(())
+    }
+
+    fn write_at(&mut self, off: u64, src: &[u8]) -> Result<(), VramError> {
+        self.check_bounds(off, src.len())?;
+        let p = self.provider;
+        let buffer = self.buffer;
+        let mut done = 0usize;
+        while done < src.len() {
+            let chunk = (src.len() - done).min(STAGING_BYTES as usize);
+            // Host: src[done..] -> staging.mapped.
+            // SAFETY: `staging_mapped` has `STAGING_BYTES` bytes; `chunk <= STAGING_BYTES`;
+            // `src[done..done+chunk]` is valid (slice bounds). `HOST_COHERENT`: no flush.
+            unsafe {
+                std::ptr::copy_nonoverlapping(src.as_ptr().add(done), p.staging_mapped, chunk)
+            };
+            let dst_off = off + done as u64;
+            // GPU: copies staging -> `[dst_off, dst_off + chunk)` on the `DEVICE_LOCAL` buffer.
+            p.submit_wait(|dev, cmd| {
+                let region = [vk::BufferCopy::default()
+                    .src_offset(0)
+                    .dst_offset(dst_off)
+                    .size(chunk as u64)];
+                // SAFETY: buffers belong to the provider; `chunk <= STAGING_BYTES` and bounds-checked on the buffer.
+                unsafe { dev.cmd_copy_buffer(cmd, p.staging_buffer, buffer, &region) };
+            })?;
+            done += chunk;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for VulkanMem<'_> {
+    fn drop(&mut self) {
+        // SAFETY: buffer+memory created in `alloc` of this provider; destroyed once in reverse
+        // order. The device remains alive (borrowing `&'p provider`).
+        unsafe {
+            self.provider.device.destroy_buffer(self.buffer, None);
+            self.provider.device.free_memory(self.memory, None);
+        }
+        self.provider
+            .allocated
+            .fetch_sub(self.len as u64, Ordering::Relaxed);
+    }
+}
+
+
+/// Logical device resources created in `open` (loaded into `VulkanProvider` on success).
+pub(crate) struct DeviceBits {
+    pub device: ash::Device,
+    pub(crate) queue: vk::Queue,
+    pub(crate) cmd_pool: vk::CommandPool,
+    pub(crate) cmd_buf: vk::CommandBuffer,
+    pub(crate) fence: vk::Fence,
+    pub staging_buffer: vk::Buffer,
+    pub(crate) staging_memory: vk::DeviceMemory,
+    pub staging_mapped: *mut u8,
+}
+
+/// RAII guard for the `goto out_err` (kernel idiom) in device creation: on error (any `?`),
+/// destroys the already created resources in reverse order **and** the device. On success, `disarm()` prevents
+/// cleanup and the handles are passed to the `VulkanProvider`.
+struct ResGuard {
+    device: ash::Device,
+    cmd_pool: Option<vk::CommandPool>,
+    fence: Option<vk::Fence>,
+    staging_buffer: Option<vk::Buffer>,
+    staging_memory: Option<vk::DeviceMemory>,
+    mapped: bool,
+    armed: bool,
+}
+
+impl ResGuard {
+    fn new(device: ash::Device) -> Self {
+        Self {
+            device,
+            cmd_pool: None,
+            fence: None,
+            staging_buffer: None,
+            staging_memory: None,
+            mapped: false,
+            armed: true,
+        }
+    }
+}
+
+impl Drop for ResGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // SAFETY: all Some handles were created from self.device in this flow and are destroyed
+        // exactly once (in reverse order of allocation). device_wait_idle guarantees nothing is
+        // in-flight before freeing.
+        unsafe {
+            let _ = self.device.device_wait_idle();
+            if let Some(m) = self.staging_memory {
+                if self.mapped {
+                    self.device.unmap_memory(m);
+                }
+                self.device.free_memory(m, None);
+            }
+            if let Some(b) = self.staging_buffer {
+                self.device.destroy_buffer(b, None);
+            }
+            if let Some(f) = self.fence {
+                self.device.destroy_fence(f, None);
+            }
+            if let Some(p) = self.cmd_pool {
+                self.device.destroy_command_pool(p, None);
+            }
+            self.device.destroy_device(None);
+        }
+    }
+}
+
+
+
+/// Creates logical device + queue + cmd pool/buffer + fence + mapped staging buffer, with RAII cleanup on error.
+pub(crate) fn create_device_resources(
+    instance: &ash::Instance,
+    phys: vk::PhysicalDevice,
+    qf: u32,
+) -> Result<DeviceBits, VramError> {
+    let prio = [1.0f32];
+    let qci = [vk::DeviceQueueCreateInfo::default()
+        .queue_family_index(qf)
+        .queue_priorities(&prio)];
+    let dci = vk::DeviceCreateInfo::default().queue_create_infos(&qci);
+    // SAFETY: `dci`/`qci`/`prio` valid during call; `phys` enumerated from `instance`. Before
+    // device creation, there are no resources to clean up (returns directly on failure).
+    let device = unsafe { instance.create_device(phys, &dci, None) }
+        .map_err(|e| crate::vk_err("create_device", e))?;
+
+    // From here on, every `?` is covered by `guard` (destroys children + device on error).
+    let mut guard = ResGuard::new(device);
+
+    // SAFETY: `guard.device`/`qf` valid.
+    let queue = unsafe { guard.device.get_device_queue(qf, 0) };
+
+    let pool_ci = vk::CommandPoolCreateInfo::default()
+        .queue_family_index(qf)
+        .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER);
+    // SAFETY: device + pool_ci valid.
+    let cmd_pool = unsafe { guard.device.create_command_pool(&pool_ci, None) }
+        .map_err(|e| crate::vk_err("create_command_pool", e))?;
+    guard.cmd_pool = Some(cmd_pool);
+
+    let cb_ai = vk::CommandBufferAllocateInfo::default()
+        .command_pool(cmd_pool)
+        .level(vk::CommandBufferLevel::PRIMARY)
+        .command_buffer_count(1);
+    // SAFETY: device + cb_ai valid; the cmd buffer(s) are freed together with the pool.
+    let cbs = unsafe { guard.device.allocate_command_buffers(&cb_ai) }
+        .map_err(|e| crate::vk_err("allocate_command_buffers", e))?;
+    let cmd_buf = cbs
+        .first()
+        .copied()
+        .ok_or_else(|| VramError::Provider("allocate_command_buffers returned empty".into()))?;
+
+    // SAFETY: device valid.
+    let fence = unsafe {
+        guard
+            .device
+            .create_fence(&vk::FenceCreateInfo::default(), None)
+    }
+    .map_err(|e| crate::vk_err("create_fence", e))?;
+    guard.fence = Some(fence);
+
+    let buf_ci = vk::BufferCreateInfo::default()
+        .size(STAGING_BYTES)
+        .usage(vk::BufferUsageFlags::TRANSFER_SRC | vk::BufferUsageFlags::TRANSFER_DST)
+        .sharing_mode(vk::SharingMode::EXCLUSIVE);
+    // SAFETY: device + buf_ci valid.
+    let staging_buffer = unsafe { guard.device.create_buffer(&buf_ci, None) }
+        .map_err(|e| crate::vk_err("create_buffer(staging)", e))?;
+    guard.staging_buffer = Some(staging_buffer);
+
+    // SAFETY: buffer valid.
+    let req = unsafe { guard.device.get_buffer_memory_requirements(staging_buffer) };
+    // SAFETY: phys valid.
+    let mprops = unsafe { instance.get_physical_device_memory_properties(phys) };
+    let mt = pick_memory_type(
+        &mprops,
+        req.memory_type_bits,
+        vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT,
+    )
+    .ok_or_else(|| {
+        VramError::Provider("sem memory type HOST_VISIBLE|COHERENT p/ staging".into())
+    })?;
+    let mai = vk::MemoryAllocateInfo::default()
+        .allocation_size(req.size)
+        .memory_type_index(mt);
+    // SAFETY: device + mai valid.
+    let staging_memory = unsafe { guard.device.allocate_memory(&mai, None) }
+        .map_err(|e| crate::vk_err("allocate_memory(staging)", e))?;
+    guard.staging_memory = Some(staging_memory);
+
+    // SAFETY: buffer + memory valid; offset 0 satisfies the alignment of `req`.
+    unsafe {
+        guard
+            .device
+            .bind_buffer_memory(staging_buffer, staging_memory, 0)
+    }
+    .map_err(|e| crate::vk_err("bind_buffer_memory(staging)", e))?;
+
+    // SAFETY: newly allocated HOST_VISIBLE memory; maps the entire range.
+    let raw = unsafe {
+        guard.device.map_memory(
+            staging_memory,
+            0,
+            STAGING_BYTES,
+            vk::MemoryMapFlags::empty(),
+        )
+    }
+    .map_err(|e| crate::vk_err("map_memory(staging)", e))?;
+    guard.mapped = true;
+    let staging_mapped = raw.cast::<u8>();
+
+    // Success: disarms the guard and extracts the handles (the device is cloned — lightweight handle from ash;
+    // the actual destroy is done in Drop of VulkanProvider).
+    guard.armed = false;
+    Ok(DeviceBits {
+        device: guard.device.clone(),
+        queue,
+        cmd_pool,
+        cmd_buf,
+        fence,
+        staging_buffer,
+        staging_memory,
+        staging_mapped,
+    })
+}
+
+
+
+pub(crate) fn alloc_memory<'p>(provider: &'p VulkanProvider, bytes: usize) -> Result<VulkanMem<'p>, VramError> {
+    // Rounds buffer size to a multiple of 4 (requirement for vkCmdFillBuffer with WHOLE_SIZE
+    // in zero); the logical len remains `bytes`.
+    let buf_size = ((bytes as u64).max(1) + 3) & !3;
+    let buf_ci = vk::BufferCreateInfo::default()
+        .size(buf_size)
+        .usage(vk::BufferUsageFlags::TRANSFER_SRC | vk::BufferUsageFlags::TRANSFER_DST)
+        .sharing_mode(vk::SharingMode::EXCLUSIVE);
+    // SAFETY: device + buf_ci valid.
+    let buffer = unsafe { provider.device.create_buffer(&buf_ci, None) }
+        .map_err(|e| crate::vk_err("create_buffer", e))?;
+
+    // SAFETY: buffer valid.
+    let req = unsafe { provider.device.get_buffer_memory_requirements(buffer) };
+    // SAFETY: phys valid.
+    let mprops = unsafe {
+        provider.instance
+            .get_physical_device_memory_properties(provider.phys)
+    };
+    let mt = match pick_memory_type(
+        &mprops,
+        req.memory_type_bits,
+        vk::MemoryPropertyFlags::DEVICE_LOCAL,
+    ) {
+        Some(i) => i,
+        None => {
+            // SAFETY: buffer created above; destroyed before returning (no leak).
+            unsafe { provider.device.destroy_buffer(buffer, None) };
+            return Err(VramError::Provider(
+                "no DEVICE_LOCAL memory type for the buffer".into(),
+            ));
+        }
+    };
+    let mai = vk::MemoryAllocateInfo::default()
+        .allocation_size(req.size)
+        .memory_type_index(mt);
+    // SAFETY: device + mai valid.
+    let memory = match unsafe { provider.device.allocate_memory(&mai, None) } {
+        Ok(m) => m,
+        Err(e) => {
+            // SAFETY: buffer created above; destroyed on error.
+            unsafe { provider.device.destroy_buffer(buffer, None) };
+            return Err(crate::vk_err("allocate_memory", e));
+        }
+    };
+    // SAFETY: buffer + memory valid; offset 0.
+    if let Err(e) = unsafe { provider.device.bind_buffer_memory(buffer, memory, 0) } {
+        // SAFETY: buffer + memory created above; freed in reverse order on error.
+        unsafe {
+            provider.device.free_memory(memory, None);
+            provider.device.destroy_buffer(buffer, None);
+        }
+        return Err(crate::vk_err("bind_buffer_memory", e));
+    }
+    provider.allocated.fetch_add(bytes as u64, Ordering::Relaxed);
+    Ok(VulkanMem {
+        provider,
+        buffer,
+        memory,
+        len: bytes,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pick_memory_type_finds_match() {
+        let mut props = vk::PhysicalDeviceMemoryProperties { memory_type_count: 2, ..Default::default() };
+
+        props.memory_types[0].property_flags = vk::MemoryPropertyFlags::DEVICE_LOCAL;
+        props.memory_types[1].property_flags = vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT;
+
+        // bits: 0b10 (type 1)
+        let mt = pick_memory_type(&props, 2, vk::MemoryPropertyFlags::HOST_VISIBLE);
+        assert_eq!(mt, Some(1));
+
+        // bits: 0b01 (type 0)
+        let mt2 = pick_memory_type(&props, 1, vk::MemoryPropertyFlags::DEVICE_LOCAL);
+        assert_eq!(mt2, Some(0));
+
+        // flags don't match
+        let mt3 = pick_memory_type(&props, 1, vk::MemoryPropertyFlags::HOST_VISIBLE);
+        assert_eq!(mt3, None);
+    }
+}

--- a/patch_lib2.js
+++ b/patch_lib2.js
@@ -1,0 +1,148 @@
+const fs = require('fs');
+let content = fs.readFileSync('crates/ramshared-vulkan/src/lib.rs', 'utf8');
+
+const allocStart = content.indexOf('    fn alloc(&self, bytes: usize) -> Result<Self::Mem<\'_>, VramError> {');
+const memInfoStart = content.indexOf('    fn mem_info(&self) -> Result<(u64, u64), VramError> {');
+
+let libAllocContent = content.slice(allocStart, memInfoStart);
+
+content = content.replace(libAllocContent,
+`    fn alloc(&self, bytes: usize) -> Result<Self::Mem<'_>, VramError> {
+        memory::alloc_memory(self, bytes)
+    }
+
+`);
+
+// Also extract `create_device_resources` since it has `allocate_memory` and `map_memory`
+const createStart = content.indexOf('/// Creates logical device + queue + cmd pool/buffer + fence + mapped staging buffer, with RAII cleanup on error.');
+const createEnd = content.indexOf('impl VramProvider for VulkanProvider {');
+
+let createResourcesContent = content.slice(createStart, createEnd);
+
+content = content.replace(createResourcesContent, '');
+
+// Also DeviceBits and ResGuard
+const bitsStart = content.indexOf('/// Logical device resources created in `open` (loaded into `VulkanProvider` on success).');
+const bitsEnd = content.indexOf('/// Vulkan Provider (thread-affine');
+
+let bitsContent = content.slice(bitsStart, bitsEnd);
+
+content = content.replace(bitsContent, '');
+
+content = content.replace('use memory::pick_memory_type;', '');
+content = content.replace('pub use memory::VulkanMem;', 'pub use memory::VulkanMem;\nuse memory::{DeviceBits, create_device_resources};');
+
+content = content.replace('fn vk_err', 'pub(crate) fn vk_err');
+
+content = content.replace(
+    '    instance: ash::Instance,',
+    '    pub(crate) instance: ash::Instance,'
+);
+content = content.replace(
+    '    phys: vk::PhysicalDevice,',
+    '    pub(crate) phys: vk::PhysicalDevice,'
+);
+
+fs.writeFileSync('crates/ramshared-vulkan/src/lib.rs', content);
+
+let memoryContent = fs.readFileSync('crates/ramshared-vulkan/src/memory.rs', 'utf8');
+
+memoryContent += `
+
+${bitsContent.replace(/pub\(crate\) device:/g, 'pub device:').replace(/pub\(crate\) staging_buffer:/g, 'pub staging_buffer:').replace(/pub\(crate\) staging_mapped:/g, 'pub staging_mapped:')}
+
+${createResourcesContent.replace('fn create_device_resources', 'pub(crate) fn create_device_resources').replace('fn vk_err', 'crate::vk_err').replace(/vk_err/g, 'crate::vk_err').replace('crate::vk_err("alloc', 'crate::vk_err("alloc')}
+
+pub(crate) fn alloc_memory<'p>(provider: &'p VulkanProvider, bytes: usize) -> Result<VulkanMem<'p>, VramError> {
+    // Rounds buffer size to a multiple of 4 (requirement for vkCmdFillBuffer with WHOLE_SIZE
+    // in zero); the logical len remains \`bytes\`.
+    let buf_size = ((bytes as u64).max(1) + 3) & !3;
+    let buf_ci = vk::BufferCreateInfo::default()
+        .size(buf_size)
+        .usage(vk::BufferUsageFlags::TRANSFER_SRC | vk::BufferUsageFlags::TRANSFER_DST)
+        .sharing_mode(vk::SharingMode::EXCLUSIVE);
+    // SAFETY: device + buf_ci valid.
+    let buffer = unsafe { provider.device.create_buffer(&buf_ci, None) }
+        .map_err(|e| crate::vk_err("create_buffer", e))?;
+
+    // SAFETY: buffer valid.
+    let req = unsafe { provider.device.get_buffer_memory_requirements(buffer) };
+    // SAFETY: phys valid.
+    let mprops = unsafe {
+        provider.instance
+            .get_physical_device_memory_properties(provider.phys)
+    };
+    let mt = match pick_memory_type(
+        &mprops,
+        req.memory_type_bits,
+        vk::MemoryPropertyFlags::DEVICE_LOCAL,
+    ) {
+        Some(i) => i,
+        None => {
+            // SAFETY: buffer created above; destroyed before returning (no leak).
+            unsafe { provider.device.destroy_buffer(buffer, None) };
+            return Err(VramError::Provider(
+                "no DEVICE_LOCAL memory type for the buffer".into(),
+            ));
+        }
+    };
+    let mai = vk::MemoryAllocateInfo::default()
+        .allocation_size(req.size)
+        .memory_type_index(mt);
+    // SAFETY: device + mai valid.
+    let memory = match unsafe { provider.device.allocate_memory(&mai, None) } {
+        Ok(m) => m,
+        Err(e) => {
+            // SAFETY: buffer created above; destroyed on error.
+            unsafe { provider.device.destroy_buffer(buffer, None) };
+            return Err(crate::vk_err("allocate_memory", e));
+        }
+    };
+    // SAFETY: buffer + memory valid; offset 0.
+    if let Err(e) = unsafe { provider.device.bind_buffer_memory(buffer, memory, 0) } {
+        // SAFETY: buffer + memory created above; freed in reverse order on error.
+        unsafe {
+            provider.device.free_memory(memory, None);
+            provider.device.destroy_buffer(buffer, None);
+        }
+        return Err(crate::vk_err("bind_buffer_memory", e));
+    }
+    provider.allocated.fetch_add(bytes as u64, Ordering::Relaxed);
+    Ok(VulkanMem {
+        provider,
+        buffer,
+        memory,
+        len: bytes,
+    })
+}
+`;
+
+memoryContent += `
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pick_memory_type_finds_match() {
+        let mut props = vk::PhysicalDeviceMemoryProperties::default();
+        props.memory_type_count = 2;
+        props.memory_types[0].property_flags = vk::MemoryPropertyFlags::DEVICE_LOCAL;
+        props.memory_types[1].property_flags = vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT;
+
+        // bits: 0b10 (type 1)
+        let mt = pick_memory_type(&props, 2, vk::MemoryPropertyFlags::HOST_VISIBLE);
+        assert_eq!(mt, Some(1));
+
+        // bits: 0b01 (type 0)
+        let mt2 = pick_memory_type(&props, 1, vk::MemoryPropertyFlags::DEVICE_LOCAL);
+        assert_eq!(mt2, Some(0));
+
+        // flags don't match
+        let mt3 = pick_memory_type(&props, 1, vk::MemoryPropertyFlags::HOST_VISIBLE);
+        assert_eq!(mt3, None);
+    }
+}
+`;
+
+fs.writeFileSync('crates/ramshared-vulkan/src/memory.rs', memoryContent);


### PR DESCRIPTION
## Summary

Extract Vulkan memory allocation and mapping into memory.rs module.

## Commits

| Commit | What was done | Why it was done | Details |
|---|---|---|---|
| 55fc6f8 | refactor(gpu-backends): extract Vulkan memory allocation and mapping into memory module | Extract vkAllocateMemory, vkMapMemory, and memory type selection into memory.rs module to satisfy architectural specification | <details><summary>Details</summary>Extracted VulkanMem, pick_memory_type, create_device_resources and alloc logic to memory.rs. Tested via newly added tests for pick_memory_type. Rollback trigger: Kernel panic, stall > 1ms, test failure</details> |

## Issue

Closes #000

## Assignee

@jules

## Labels

type:refactor
area:gpu-backends

## Validation

- [x] cargo clippy --all-targets passes
- [x] cargo test passes

## Rollback trigger

Rollback trigger: Kernel panic, stall > 1ms, test failure

---
*PR created automatically by Jules for task [12518938573208732482](https://jules.google.com/task/12518938573208732482) started by @emersonbusson*