### PR TITLE
feat(vulkan): enable validation layers in debug builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "palette"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +540,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -652,6 +664,7 @@ version = "0.1.0"
 dependencies = [
  "ash",
  "ramshared-vram",
+ "tracing",
 ]
 
 [[package]]
@@ -1070,6 +1083,37 @@ name = "toml_writer"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "typenum"

--- a/crates/ramshared-vulkan/Cargo.toml
+++ b/crates/ramshared-vulkan/Cargo.toml
@@ -10,6 +10,7 @@ publish.workspace = true
 [dependencies]
 ramshared-vram = { path = "../ramshared-vram" }
 ash = "0.38"
+tracing = "0.1.44"
 
 [lints.clippy]
 unwrap_used = "deny"

--- a/crates/ramshared-vulkan/src/debug.rs
+++ b/crates/ramshared-vulkan/src/debug.rs
@@ -1,0 +1,56 @@
+#![cfg(debug_assertions)]
+
+use std::ffi::{c_void, CStr};
+use ash::vk;
+use tracing::{debug, error, info, warn};
+
+/// Vulkan debug messenger callback.
+/// SAFETY: `p_callback_data` must be a valid pointer to a `VkDebugUtilsMessengerCallbackDataEXT` structure as guaranteed by the Vulkan validation layers.
+pub(crate) unsafe extern "system" fn vulkan_debug_callback(
+    message_severity: vk::DebugUtilsMessageSeverityFlagsEXT,
+    _message_type: vk::DebugUtilsMessageTypeFlagsEXT,
+    p_callback_data: *const vk::DebugUtilsMessengerCallbackDataEXT,
+    _p_user_data: *mut c_void,
+) -> vk::Bool32 {
+    if p_callback_data.is_null() {
+        return vk::FALSE;
+    }
+    // SAFETY: verified non-null above. The Vulkan spec guarantees the pointer is valid for the duration of the callback.
+    let data = unsafe { &*p_callback_data };
+
+    if data.p_message.is_null() {
+        return vk::FALSE;
+    }
+
+    // SAFETY: the message pointer is non-null and guaranteed to be a null-terminated UTF-8 string by the Vulkan spec.
+    let msg = unsafe { CStr::from_ptr(data.p_message) }.to_string_lossy();
+
+    match message_severity {
+        vk::DebugUtilsMessageSeverityFlagsEXT::ERROR => error!("Vulkan validation: {}", msg),
+        vk::DebugUtilsMessageSeverityFlagsEXT::WARNING => warn!("Vulkan validation: {}", msg),
+        vk::DebugUtilsMessageSeverityFlagsEXT::INFO => info!("Vulkan validation: {}", msg),
+        vk::DebugUtilsMessageSeverityFlagsEXT::VERBOSE => debug!("Vulkan validation: {}", msg),
+        _ => warn!("Vulkan validation (unknown severity): {}", msg),
+    }
+
+    vk::FALSE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ptr;
+
+    #[test]
+    fn test_vulkan_debug_callback_null_pointers() {
+        unsafe {
+            let res = vulkan_debug_callback(
+                vk::DebugUtilsMessageSeverityFlagsEXT::ERROR,
+                vk::DebugUtilsMessageTypeFlagsEXT::GENERAL,
+                ptr::null(),
+                ptr::null_mut(),
+            );
+            assert_eq!(res, vk::FALSE);
+        }
+    }
+}

--- a/crates/ramshared-vulkan/src/instance.rs
+++ b/crates/ramshared-vulkan/src/instance.rs
@@ -1,0 +1,147 @@
+#[cfg(debug_assertions)]
+use std::ffi::{CStr, CString};
+use ash::vk;
+use ramshared_vram::VramError;
+use crate::vk_err;
+
+#[cfg(debug_assertions)]
+use crate::debug::vulkan_debug_callback;
+
+/// Debug resources returned alongside the instance.
+pub(crate) struct DebugResources {
+    #[cfg(debug_assertions)]
+    pub(crate) utils: ash::ext::debug_utils::Instance,
+    #[cfg(debug_assertions)]
+    pub(crate) messenger: vk::DebugUtilsMessengerEXT,
+}
+
+impl DebugResources {
+    pub(crate) fn destroy(&mut self) {
+        #[cfg(debug_assertions)]
+        unsafe {
+            self.utils.destroy_debug_utils_messenger(self.messenger, None);
+        }
+    }
+}
+
+/// Creates a Vulkan instance, enabling validation layers and debug messenger in debug builds.
+pub(crate) fn create_instance(
+    entry: &ash::Entry,
+) -> Result<(ash::Instance, Option<DebugResources>), VramError> {
+    let app = vk::ApplicationInfo::default().api_version(vk::API_VERSION_1_1);
+
+    #[cfg(debug_assertions)]
+    let mut layer_names = Vec::new();
+    #[cfg(debug_assertions)]
+    let mut extension_names = Vec::new();
+
+    #[cfg(debug_assertions)]
+    let validation_layer = CString::new("VK_LAYER_KHRONOS_validation")
+        .unwrap_or_else(|_| unreachable!("literal has no null bytes"));
+
+    #[cfg(debug_assertions)]
+    {
+        // SAFETY: enumerate_instance_layer_properties returns valid properties.
+        let available_layers = unsafe { entry.enumerate_instance_layer_properties() }
+            .map_err(|e| vk_err("enumerate_instance_layer_properties", e))?;
+
+        let has_validation = available_layers.iter().any(|layer| {
+            // SAFETY: layer_name is a null-terminated C string in the properties struct.
+            let name = unsafe { CStr::from_ptr(layer.layer_name.as_ptr()) };
+            name == validation_layer.as_c_str()
+        });
+
+        if has_validation {
+            layer_names.push(validation_layer.as_ptr());
+            extension_names.push(ash::ext::debug_utils::NAME.as_ptr());
+        } else {
+            tracing::warn!("VK_LAYER_KHRONOS_validation not found, validation disabled");
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    let layer_names: Vec<*const std::ffi::c_char> = Vec::new();
+    #[cfg(not(debug_assertions))]
+    let extension_names: Vec<*const std::ffi::c_char> = Vec::new();
+
+    #[allow(unused_mut)]
+    let mut ci = vk::InstanceCreateInfo::default()
+        .application_info(&app)
+        .enabled_layer_names(&layer_names)
+        .enabled_extension_names(&extension_names);
+
+    #[cfg(debug_assertions)]
+    let mut debug_info = vk::DebugUtilsMessengerCreateInfoEXT::default()
+        .message_severity(
+            vk::DebugUtilsMessageSeverityFlagsEXT::ERROR
+                | vk::DebugUtilsMessageSeverityFlagsEXT::WARNING
+                | vk::DebugUtilsMessageSeverityFlagsEXT::INFO
+                | vk::DebugUtilsMessageSeverityFlagsEXT::VERBOSE,
+        )
+        .message_type(
+            vk::DebugUtilsMessageTypeFlagsEXT::GENERAL
+                | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION
+                | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE,
+        )
+        .pfn_user_callback(Some(vulkan_debug_callback));
+
+    #[cfg(debug_assertions)]
+    if !layer_names.is_empty() {
+        ci = ci.push_next(&mut debug_info);
+    }
+
+    // SAFETY: ci is valid, application_info is valid, extension and layer names point to null-terminated C strings.
+    let instance = unsafe { entry.create_instance(&ci, None) }
+        .map_err(|e| vk_err("create_instance", e))?;
+
+    #[allow(unused_mut)]
+    let mut debug_resources = None;
+    #[cfg(debug_assertions)]
+    if !layer_names.is_empty() {
+        // Create debug utils messenger
+        let debug_utils_ext = ash::ext::debug_utils::Instance::new(entry, &instance);
+        // SAFETY: debug_info is valid, instance is valid.
+        match unsafe { debug_utils_ext.create_debug_utils_messenger(&debug_info, None) } {
+            Ok(messenger) => {
+                debug_resources = Some(DebugResources {
+                    utils: debug_utils_ext,
+                    messenger,
+                });
+            }
+            Err(e) => {
+                tracing::warn!("Failed to create debug utils messenger: {:?}", e);
+            }
+        }
+    }
+
+    Ok((instance, debug_resources))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "requires Vulkan loader + ICD (lavapipe is enough; run with --ignored)"]
+    fn test_create_instance() {
+        let entry = unsafe { ash::Entry::load() }.unwrap_or_else(|_| panic!("load entry"));
+        let (instance, debug) = create_instance(&entry).unwrap_or_else(|_| panic!("create_instance"));
+
+        let has_debug = debug.is_some();
+        if let Some(mut d) = debug {
+            d.destroy();
+        }
+
+        unsafe {
+            instance.destroy_instance(None);
+        }
+
+        if cfg!(debug_assertions) {
+            // Can't strictly assert has_debug because CI might not have the validation layers installed,
+            // but we can ensure the function didn't panic and returned successfully.
+            eprintln!("debug_assertions enabled, debug_utils present = {}", has_debug);
+        } else {
+            assert!(!has_debug, "release builds should not have debug utils");
+        }
+    }
+}

--- a/crates/ramshared-vulkan/src/lib.rs
+++ b/crates/ramshared-vulkan/src/lib.rs
@@ -19,6 +19,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use ash::vk;
 use ramshared_vram::{VramError, VramMemory, VramProvider};
 
+mod debug;
+mod instance;
+
 /// Single staging buffer per provider (no alloc on hot path, DT-8): 1 MiB. Larger I/O is sliced.
 const STAGING_BYTES: u64 = 1 << 20;
 
@@ -126,6 +129,7 @@ impl Drop for ResGuard {
 /// the queue is externally synchronized, DT-7). Reuses 1 staging buffer + 1 cmd buffer + 1 fence.
 pub struct VulkanProvider {
     instance: ash::Instance,
+    _debug: Option<instance::DebugResources>, // keeps debug messenger alive
     _entry: ash::Entry, // keeps the loader alive as long as the instance exists
     phys: vk::PhysicalDevice,
     device: ash::Device,
@@ -146,16 +150,13 @@ impl VulkanProvider {
     pub fn open(ordinal: u32) -> Result<Self, VramError> {
         // SAFETY: loads libvulkan.so.1 via libloading; symbols remain valid as long as `entry` lives.
         let entry = unsafe { ash::Entry::load() }.map_err(|e| vk_err("load", e))?;
-        let app = vk::ApplicationInfo::default().api_version(vk::API_VERSION_1_1);
-        let ci = vk::InstanceCreateInfo::default().application_info(&app);
-        // SAFETY: `ci`/`app` valid during call; `None` = default allocator.
-        let instance = unsafe { entry.create_instance(&ci, None) }
-            .map_err(|e| vk_err("create_instance", e))?;
+        let (instance, debug) = instance::create_instance(&entry)?;
 
         // From this point on, any error must destroy the instance (goto out_err idiom).
         match Self::after_instance(&instance, ordinal) {
             Ok((phys, name, bits)) => Ok(Self {
                 instance,
+                _debug: debug,
                 _entry: entry,
                 phys,
                 device: bits.device,
@@ -472,6 +473,13 @@ impl Drop for VulkanProvider {
             self.device.destroy_fence(self.fence, None);
             self.device.destroy_command_pool(self.cmd_pool, None);
             self.device.destroy_device(None);
+        }
+
+        if let Some(mut d) = self._debug.take() {
+            d.destroy();
+        }
+
+        unsafe {
             self.instance.destroy_instance(None);
         }
     }


### PR DESCRIPTION
## Summary

Enables Vulkan validation layers (`VK_LAYER_KHRONOS_validation`) when compiled with debug assertions, routing the `VK_EXT_debug_utils` messenger callbacks directly to the `tracing` crate. Refactors `ash::Instance` creation into an isolated module (`instance.rs`) and callback logic to (`debug.rs`) while properly dropping the messenger via RAII. Zero-cost in release builds.

## Issue

Vulkan validation layer integration for debug builds

## Owner

SecurityGpuWin100/2026-09-10/gpu-backends/030

## Labels

type:feature
area:gpu-backends

## Commits

| SHA | Message |
|---|---|
| d35f42d | feat(vulkan): enable validation layers in debug builds |

## Validation

```text
$ cargo test -p ramshared-vulkan
running 4 tests
test instance::tests::test_create_instance ... ignored, requires Vulkan loader + ICD (lavapipe is enough; run with --ignored)
test tests::open_enumerates_device_and_heap ... ignored, requires Vulkan loader + ICD (lavapipe/llvmpipe is enough; run with --ignored)
test tests::vulkan_roundtrip_write_then_read ... ignored, requires Vulkan loader + ICD (lavapipe is enough; run with --ignored)
test debug::tests::test_vulkan_debug_callback_null_pointers ... ok

test result: ok. 1 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

## Rollback trigger

vkCreateInstance failures or debug validation crashes.

---
*PR created automatically by Jules for task [2324372071284957698](https://jules.google.com/task/2324372071284957698) started by @emersonbusson*