### PR TITLE
feat(gpu-backends): enforce minimum CUDA compute capability via cuDeviceGetAttribute

### DIFF
--- a/crates/ramshared-cuda/src/driver.rs
+++ b/crates/ramshared-cuda/src/driver.rs
@@ -113,6 +113,7 @@ impl Cuda {
                 memset_d8: load_sym(handle, c"cuMemsetD8_v2")?,
                 mem_get_info: load_sym(handle, c"cuMemGetInfo_v2")?,
                 get_error_string: load_sym_opt(handle, c"cuGetErrorString"),
+                device_get_attribute: load_sym(handle, c"cuDeviceGetAttribute")?,
             }
         };
 
@@ -151,7 +152,15 @@ impl Cuda {
             .to_string_lossy()
             .into_owned();
 
-        Ok(Device { raw, name, ordinal })
+        let mut major = 0;
+        let mut minor = 0;
+        // SAFETY: major/minor point to valid local memory; raw is a valid CUdevice handle.
+        let r = unsafe { (self.syms.device_get_attribute)(&mut major, crate::ffi::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, raw) };
+        check(&self.syms, r, "cuDeviceGetAttribute")?;
+        let r = unsafe { (self.syms.device_get_attribute)(&mut minor, crate::ffi::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, raw) };
+        check(&self.syms, r, "cuDeviceGetAttribute")?;
+
+        Ok(Device { raw, name, ordinal, major, minor })
     }
 
     /// Creates a CUDA context on the specified device (becomes current on the calling thread).
@@ -160,7 +169,17 @@ impl Cuda {
         // SAFETY: raw points to a valid local; device.raw is a valid CUdevice handle.
         let r = unsafe { (self.syms.ctx_create)(&mut raw, 0, device.raw) };
         check(&self.syms, r, "cuCtxCreate")?;
-        Ok(Context { cuda: self, raw })
+        let ctx = Context { cuda: self, raw };
+
+        let (_, total) = ctx.mem_info()?;
+        crate::probe::validate_hardware_specs(device.major, device.minor, total)
+            .map_err(|e| CudaError::Driver {
+                op: "validate_hardware_specs",
+                code: -1,
+                msg: e.to_string(),
+            })?;
+
+        Ok(ctx)
     }
 }
 
@@ -170,6 +189,10 @@ pub struct Device {
     raw: CuDevice,
     name: String,
     ordinal: i32,
+    /// Compute capability major version.
+    pub major: i32,
+    /// Compute capability minor version.
+    pub minor: i32,
 }
 
 impl Device {

--- a/crates/ramshared-cuda/src/ffi.rs
+++ b/crates/ramshared-cuda/src/ffi.rs
@@ -35,6 +35,11 @@ pub type FnMemsetD8 = unsafe extern "C" fn(CuDevicePtr, u8, usize) -> CuResult;
 pub type FnMemGetInfo = unsafe extern "C" fn(*mut usize, *mut usize) -> CuResult;
 pub type FnGetErrorString = unsafe extern "C" fn(CuResult, *mut *const c_char) -> CuResult;
 
+pub type CuDeviceAttribute = c_int;
+pub const CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR: CuDeviceAttribute = 75;
+pub const CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR: CuDeviceAttribute = 76;
+pub type FnDeviceGetAttribute = unsafe extern "C" fn(*mut c_int, CuDeviceAttribute, CuDevice) -> CuResult;
+
 /// Table of resolved symbols from the CUDA driver library.
 pub struct Syms {
     pub init: FnInit,
@@ -51,4 +56,5 @@ pub struct Syms {
     pub memset_d8: FnMemsetD8,
     pub mem_get_info: FnMemGetInfo,
     pub get_error_string: Option<FnGetErrorString>,
+    pub device_get_attribute: FnDeviceGetAttribute,
 }

--- a/crates/ramshared-cuda/src/probe.rs
+++ b/crates/ramshared-cuda/src/probe.rs
@@ -51,7 +51,7 @@ pub fn validate_hardware_specs(
     minor: i32,
     total_memory: usize,
 ) -> Result<(), ProbePlanError> {
-    if !(1..=99).contains(&major) || !(0..=99).contains(&minor) {
+    if !(6..=99).contains(&major) || !(0..=99).contains(&minor) {
         return Err(ProbePlanError::InvalidComputeCapability { major, minor });
     }
     if total_memory == 0 || total_memory > MAX_TOTAL_MEMORY_BYTES {
@@ -158,9 +158,9 @@ mod tests {
             })
         ));
         assert!(matches!(
-            validate_hardware_specs(1, -1, 1024),
+            validate_hardware_specs(6, -1, 1024),
             Err(ProbePlanError::InvalidComputeCapability {
-                major: 1,
+                major: 6,
                 minor: -1
             })
         ));


### PR DESCRIPTION
## Issue
CUDA compute capability detection and minimum version enforcement.

## Owner
SecurityGpuWin100/2026-09-10/gpu-backends/048

## Summary
Enforces a minimum CUDA compute capability (>= 6.0) and validates total GPU memory limits during the VRAM provider initialization. 
Queries cuDeviceGetAttribute for CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR and CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR.

## Labels
type:feature
area:gpu-backends

## Commits
| SHA | Message |
|---|---|
| a57e2bd | feat(gpu-backends): enforce minimum CUDA compute capability via cuDeviceGetAttribute |

## Validation
- `cargo clippy --all-targets` passed with 0 warnings.
- `cargo test` passed with no regressions.
- Passed local unit tests ensuring proper CUDA error mapping.
- `pre_commit_instructions` followed for comprehensive checks.

## Rollback trigger
If it fails to initialize the CUDA backend properly due to incorrect query parameters. Rollback trigger: test failure.

---
*PR created automatically by Jules for task [6385612239056830574](https://jules.google.com/task/6385612239056830574) started by @emersonbusson*