### PR TITLE
feat(gpu): add per-thread CUDA context push-pop isolation

### DIFF
--- a/crates/ramshared-cuda/src/context_scope.rs
+++ b/crates/ramshared-cuda/src/context_scope.rs
@@ -1,0 +1,70 @@
+use crate::driver::{CudaError, Context};
+use crate::ffi::CuContext;
+
+/// A push-pop scope for a CUDA context.
+/// Ensures the context is current on the calling thread for the duration of the scope,
+/// and restores the previous context when dropped.
+pub struct ContextScope<'c, 'a> {
+    ctx: &'c Context<'a>,
+    popped: bool,
+}
+
+impl<'c, 'a> ContextScope<'c, 'a> {
+    pub(crate) fn new(ctx: &'c Context<'a>) -> Result<Self, CudaError> {
+        let syms = &ctx.cuda.syms;
+        // SAFETY: push the raw context onto the thread's stack.
+        // It becomes current for this thread, while previous context is pushed down.
+        let r = unsafe { (syms.ctx_push_current)(ctx.raw) };
+        crate::driver::check(syms, r, "cuCtxPushCurrent_v2")?;
+        Ok(Self { ctx, popped: false })
+    }
+
+    /// Explicitly pop the context early.
+    pub fn pop(mut self) -> Result<(), CudaError> {
+        let syms = &self.ctx.cuda.syms;
+        let mut popped_raw: CuContext = core::ptr::null_mut();
+        // SAFETY: pop the current context from the thread's stack.
+        let r = unsafe { (syms.ctx_pop_current)(&mut popped_raw) };
+        crate::driver::check(syms, r, "cuCtxPopCurrent_v2")?;
+        self.popped = true;
+        Ok(())
+    }
+}
+
+impl Drop for ContextScope<'_, '_> {
+    fn drop(&mut self) {
+        if !self.popped {
+            let syms = &self.ctx.cuda.syms;
+            let mut popped_raw: CuContext = core::ptr::null_mut();
+            // SAFETY: pop the current context from the thread's stack.
+            // Best effort error ignoring during drop.
+            unsafe {
+                let _ = (syms.ctx_pop_current)(&mut popped_raw);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use crate::Cuda;
+
+    #[test]
+    #[ignore = "requires a working CUDA GPU (run with --ignored on a GPU host)"]
+    fn test_context_scope_push_pop() {
+        let cuda = Cuda::load().expect("libcuda must load");
+        if cuda.device_count().unwrap() < 1 {
+            return;
+        }
+        let dev = cuda.device(0).unwrap();
+        let ctx = cuda.create_context(&dev).unwrap();
+
+        // Push scope
+        let scope = ctx.push_scope().expect("push_scope should succeed");
+
+        // Pop early explicitly
+        scope.pop().expect("explicit pop should succeed");
+    }
+}

--- a/crates/ramshared-cuda/src/driver.rs
+++ b/crates/ramshared-cuda/src/driver.rs
@@ -63,7 +63,7 @@ impl Drop for Lib {
 /// CUDA library loaded and initialized successfully (`cuInit(0)`).
 pub struct Cuda {
     _lib: Lib,
-    syms: Syms,
+    pub(crate) syms: Syms,
 }
 
 #[cfg(unix)]
@@ -105,6 +105,8 @@ impl Cuda {
                 device_get_name: load_sym(handle, c"cuDeviceGetName")?,
                 ctx_create: load_sym(handle, c"cuCtxCreate_v2")?,
                 ctx_destroy: load_sym(handle, c"cuCtxDestroy_v2")?,
+                ctx_push_current: load_sym(handle, c"cuCtxPushCurrent_v2")?,
+                ctx_pop_current: load_sym(handle, c"cuCtxPopCurrent_v2")?,
                 ctx_synchronize: load_sym(handle, c"cuCtxSynchronize")?,
                 mem_alloc: load_sym(handle, c"cuMemAlloc_v2")?,
                 mem_free: load_sym(handle, c"cuMemFree_v2")?,
@@ -190,11 +192,17 @@ impl Device {
 /// This is why the daemon executes all VRAM I/O on a single thread. Accessing from another thread
 /// would require calling `cuCtxSetCurrent` (not implemented here). The DEMOTE thread only calls `swapoff`.
 pub struct Context<'a> {
-    cuda: &'a Cuda,
-    raw: CuContext,
+    pub(crate) cuda: &'a Cuda,
+    pub(crate) raw: CuContext,
 }
 
 impl<'a> Context<'a> {
+    /// Creates a push-pop scope making this context current for the thread.
+    /// Returns a `ContextScope` which pops the context when dropped.
+    pub fn push_scope(&self) -> Result<crate::ContextScope<'_, 'a>, CudaError> {
+        crate::context_scope::ContextScope::new(self)
+    }
+
     /// Returns the free and total VRAM capacities in bytes (`cuMemGetInfo`).
     pub fn mem_info(&self) -> Result<(usize, usize), CudaError> {
         let (mut free, mut total) = (0_usize, 0_usize);
@@ -328,7 +336,7 @@ fn load_sym_opt<T: Copy>(handle: *mut c_void, name: &CStr) -> Option<T> {
     unsafe { load_sym(handle, name).ok() }
 }
 
-fn check(syms: &Syms, r: CuResult, op: &'static str) -> Result<(), CudaError> {
+pub(crate) fn check(syms: &Syms, r: CuResult, op: &'static str) -> Result<(), CudaError> {
     if r == CUDA_SUCCESS {
         Ok(())
     } else {

--- a/crates/ramshared-cuda/src/ffi.rs
+++ b/crates/ramshared-cuda/src/ffi.rs
@@ -27,6 +27,8 @@ pub type FnDeviceGetName = unsafe extern "C" fn(*mut c_char, c_int, CuDevice) ->
 pub type FnCtxCreate = unsafe extern "C" fn(*mut CuContext, c_uint, CuDevice) -> CuResult;
 pub type FnCtxDestroy = unsafe extern "C" fn(CuContext) -> CuResult;
 pub type FnCtxSynchronize = unsafe extern "C" fn() -> CuResult;
+pub type FnCtxPushCurrent = unsafe extern "C" fn(CuContext) -> CuResult;
+pub type FnCtxPopCurrent = unsafe extern "C" fn(*mut CuContext) -> CuResult;
 pub type FnMemAlloc = unsafe extern "C" fn(*mut CuDevicePtr, usize) -> CuResult;
 pub type FnMemFree = unsafe extern "C" fn(CuDevicePtr) -> CuResult;
 pub type FnMemcpyHtoD = unsafe extern "C" fn(CuDevicePtr, *const c_void, usize) -> CuResult;
@@ -44,6 +46,8 @@ pub struct Syms {
     pub ctx_create: FnCtxCreate,
     pub ctx_destroy: FnCtxDestroy,
     pub ctx_synchronize: FnCtxSynchronize,
+    pub ctx_push_current: FnCtxPushCurrent,
+    pub ctx_pop_current: FnCtxPopCurrent,
     pub mem_alloc: FnMemAlloc,
     pub mem_free: FnMemFree,
     pub memcpy_htod: FnMemcpyHtoD,

--- a/crates/ramshared-cuda/src/lib.rs
+++ b/crates/ramshared-cuda/src/lib.rs
@@ -33,9 +33,11 @@ use loader_win as loader;
 mod driver;
 mod ffi;
 pub mod probe;
+pub mod context_scope;
 mod vram_impl; // impl VramProvider/VramMemory for CUDA types (RF-G1)
 
 pub use driver::{Context, Cuda, CudaError, Device, DeviceMem};
+pub use context_scope::ContextScope;
 pub use probe::{PROBE_PATTERN_LEN, ProbePlanError, pattern_for_offset, plan_probe_offsets};
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Implement thread-local CUDA context management using cuCtxPushCurrent/cuCtxPopCurrent for safe multi-threading.

## Commits

|---|---|---|---|
| 9b82b21 | feat(gpu): add per-thread CUDA context push-pop isolation |

## Validation

cargo test passed

## Rollback trigger

Rollback trigger: issues with CUDA context isolation or runtime failures.

## Issue

Isolation

## Owner

SecurityGpuWin100/2026-09-10/gpu-backends/042

## Labels

type:feature
area:gpu

---
*PR created automatically by Jules for task [11523029746190124188](https://jules.google.com/task/11523029746190124188) started by @emersonbusson*