### PR TITLE
Configure Windows service recovery actions on failure

### DIFF
--- a/crates/ramshared-winsvc/src/main.rs
+++ b/crates/ramshared-winsvc/src/main.rs
@@ -148,6 +148,12 @@ mod windows_svc {
             // SCM default without service dispatcher running returns 1
             assert_eq!(code, 1);
         }
+
+        #[test]
+        fn dump_cmd_path_is_expected() {
+            let dump_cmd = OsString::from(r"C:\Program Files\RamShared\tools\crash_dump.bat");
+            assert_eq!(dump_cmd.to_string_lossy(), r"C:\Program Files\RamShared\tools\crash_dump.bat");
+        }
     }
 
     fn service_main(_args: Vec<OsString>) {
@@ -740,11 +746,29 @@ mod windows_svc {
             })?;
             service.set_failure_actions_on_non_crash_failures(false)?;
         } else {
+            let dump_cmd = OsString::from(r"C:\Program Files\RamShared\tools\crash_dump.bat");
             service.update_failure_actions(ServiceFailureActions {
                 reset_period: ServiceFailureResetPeriod::Never,
                 reboot_msg: None,
-                command: None,
-                actions: Some(vec![]),
+                command: Some(dump_cmd),
+                actions: Some(vec![
+                    ServiceAction {
+                        action_type: ServiceActionType::RunCommand,
+                        delay: Duration::from_secs(10),
+                    },
+                    ServiceAction {
+                        action_type: ServiceActionType::Restart,
+                        delay: Duration::from_secs(60),
+                    },
+                    ServiceAction {
+                        action_type: ServiceActionType::Restart,
+                        delay: Duration::from_secs(120),
+                    },
+                    ServiceAction {
+                        action_type: ServiceActionType::Restart,
+                        delay: Duration::from_secs(300),
+                    },
+                ]),
             })?;
         }
         Ok(())


### PR DESCRIPTION
## Summary
Configured `SC_ACTION_RESTART` with progressive delay and `SC_ACTION_RUN_COMMAND` for crash dump collection in `ramshared-winsvc`'s `register_one`.
## Commits
- b744a6f2d12947dd41e356b89f2cb2bd5358ae2b
## Validation
- Verified with `cargo test -p ramshared-winsvc` and `cargo clippy -p ramshared-winsvc` (zero warnings).
## Rollback trigger
If the service fails to start or gets into a restart loop, rollback this commit.

---
*PR created automatically by Jules for task [16605669347001773321](https://jules.google.com/task/16605669347001773321) started by @emersonbusson*