### PR TITLE
refactor: extract string-based error types into a structured thiserror enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/ramshared-cli/Cargo.toml
+++ b/crates/ramshared-cli/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1"
 ratatui = { version = "0.30.0", default-features = false, features = ["crossterm"] }
 rustix = { version = "1.1.4", features = ["fs", "process"] }
 libc = "0.2"
+thiserror = "2.0.20"
 
 [lints.clippy]
 unwrap_used = "deny"

--- a/crates/ramshared-cli/src/cli_error.rs
+++ b/crates/ramshared-cli/src/cli_error.rs
@@ -1,0 +1,47 @@
+use thiserror::Error;
+
+/// Error types related to command line execution and parsing.
+#[derive(Clone, Debug, Eq, PartialEq, Error)]
+pub enum CliError {
+    /// Command is not recognized or not implemented.
+    #[error("unsupported command: {0}")]
+    UnsupportedCommand(String),
+
+    /// Missing or malformed options for a given command.
+    #[error("invalid {command} option: {options}")]
+    InvalidOption {
+        command: &'static str,
+        options: String,
+    },
+
+    /// No CUDA-compatible devices were found on the system.
+    #[error("CUDA found no devices")]
+    CudaNoDevices,
+
+    /// An unexpected error occurred while interacting with the CUDA API.
+    #[error("CUDA probe failed: {0}")]
+    CudaProbe(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_formats_correctly() {
+        let err = CliError::UnsupportedCommand("foo".to_string());
+        assert_eq!(err.to_string(), "unsupported command: foo");
+
+        let err2 = CliError::InvalidOption {
+            command: "bar",
+            options: "--baz".to_string(),
+        };
+        assert_eq!(err2.to_string(), "invalid bar option: --baz");
+
+        let err3 = CliError::CudaNoDevices;
+        assert_eq!(err3.to_string(), "CUDA found no devices");
+
+        let err4 = CliError::CudaProbe("cudaErrorUnknown".to_string());
+        assert_eq!(err4.to_string(), "CUDA probe failed: cudaErrorUnknown");
+    }
+}

--- a/crates/ramshared-cli/src/main.rs
+++ b/crates/ramshared-cli/src/main.rs
@@ -211,40 +211,21 @@ enum CliCommand {
     Help,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-enum CliParseError {
-    UnsupportedCommand(String),
-    InvalidOption {
-        command: &'static str,
-        options: Vec<String>,
-    },
-}
+pub mod cli_error;
+use cli_error::CliError;
 
-impl fmt::Display for CliParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            CliParseError::UnsupportedCommand(command) => {
-                write!(f, "unsupported command: {command}")
-            }
-            CliParseError::InvalidOption { command, options } => {
-                write!(f, "invalid {command} option: {}", options.join(" "))
-            }
-        }
-    }
-}
-
-fn parse_json_option(command: &'static str, options: &[String]) -> Result<bool, CliParseError> {
+fn parse_json_option(command: &'static str, options: &[String]) -> Result<bool, CliError> {
     match options {
         [] => Ok(false),
         [option] if option == "--json" => Ok(true),
-        _ => Err(CliParseError::InvalidOption {
+        _ => Err(CliError::InvalidOption {
             command,
-            options: options.to_vec(),
+            options: options.join(" "),
         }),
     }
 }
 
-fn parse_cli_command(args: &[String]) -> Result<CliCommand, CliParseError> {
+fn parse_cli_command(args: &[String]) -> Result<CliCommand, CliError> {
     let Some((command, options)) = args.split_first() else {
         return Ok(CliCommand::Help);
     };
@@ -254,9 +235,9 @@ fn parse_cli_command(args: &[String]) -> Result<CliCommand, CliParseError> {
             if options.is_empty() {
                 Ok(CliCommand::Version)
             } else {
-                Err(CliParseError::InvalidOption {
+                Err(CliError::InvalidOption {
                     command: "version",
-                    options: options.to_vec(),
+                    options: options.join(" "),
                 })
             }
         }
@@ -275,18 +256,18 @@ fn parse_cli_command(args: &[String]) -> Result<CliCommand, CliParseError> {
                     args: options.to_vec(),
                 })
             } else {
-                Err(CliParseError::InvalidOption {
+                Err(CliError::InvalidOption {
                     command: "supervise",
-                    options: options.to_vec(),
+                    options: options.join(" "),
                 })
             }
         }
         "recover" => match options {
             [option] if option == "--status" => Ok(CliCommand::Recover { resume: false }),
             [option] if option == "--resume" => Ok(CliCommand::Recover { resume: true }),
-            _ => Err(CliParseError::InvalidOption {
+            _ => Err(CliError::InvalidOption {
                 command: "recover",
-                options: options.to_vec(),
+                options: options.join(" "),
             }),
         },
         "doctor" => Ok(CliCommand::Doctor {
@@ -299,9 +280,9 @@ fn parse_cli_command(args: &[String]) -> Result<CliCommand, CliParseError> {
             if options.is_empty() {
                 Ok(CliCommand::Down)
             } else {
-                Err(CliParseError::InvalidOption {
+                Err(CliError::InvalidOption {
                     command: "down",
-                    options: options.to_vec(),
+                    options: options.join(" "),
                 })
             }
         }
@@ -309,12 +290,12 @@ fn parse_cli_command(args: &[String]) -> Result<CliCommand, CliParseError> {
             json: parse_json_option("status", options)?,
         }),
         cmd @ ("monitor" | "top") => Ok(CliCommand::Monitor {
-            options: MonitorOptions::parse(options).map_err(|_| CliParseError::InvalidOption {
+            options: MonitorOptions::parse(options).map_err(|_| CliError::InvalidOption {
                 command: match cmd {
                     "top" => "top",
                     _ => "monitor",
                 },
-                options: options.to_vec(),
+                options: options.join(" "),
             })?,
         }),
         "diagnose" => Ok(CliCommand::Diagnose {
@@ -324,7 +305,7 @@ fn parse_cli_command(args: &[String]) -> Result<CliCommand, CliParseError> {
             args: options.to_vec(),
         }),
         "-h" | "--help" => Ok(CliCommand::Help),
-        other => Err(CliParseError::UnsupportedCommand(other.to_string())),
+        other => Err(CliError::UnsupportedCommand(other.to_string())),
     }
 }
 
@@ -508,7 +489,7 @@ impl CliActionRunner for SystemCliActions {
                     ExitCode::from(1)
                 }
             },
-            Err(error) => to_exit::<String>(Err(error), stderr),
+            Err(error) => to_exit(Err(error.to_string()), stderr),
         }
     }
 }
@@ -991,7 +972,7 @@ fn probe_cuda() -> CudaProbe {
             nvidia_smi_status,
             nvidia_smi_output,
             gpu: None,
-            detail,
+            detail: detail.to_string(),
         },
     }
 }
@@ -1046,14 +1027,14 @@ fn run_nvidia_smi() -> (Option<PathBuf>, Option<i32>, Option<String>) {
 
 /// Real probe of CUDA via the audited `ramshared-cuda` crate (isolated FFI, RAII).
 /// Replaces the duplicated FFI that lived here (Day-0: only `unsafe` in ramshared-cuda).
-fn cuda_probe_via_lib() -> Result<GpuInfo, String> {
-    let cuda = Cuda::load().map_err(|e| e.to_string())?;
-    if cuda.device_count().map_err(|e| e.to_string())? < 1 {
-        return Err("CUDA found no devices".to_string());
+fn cuda_probe_via_lib() -> Result<GpuInfo, CliError> {
+    let cuda = Cuda::load().map_err(|e| CliError::CudaProbe(e.to_string()))?;
+    if cuda.device_count().map_err(|e| CliError::CudaProbe(e.to_string()))? < 1 {
+        return Err(CliError::CudaNoDevices);
     }
-    let dev = cuda.device(0).map_err(|e| e.to_string())?;
-    let ctx = cuda.create_context(&dev).map_err(|e| e.to_string())?;
-    let (free, total) = ctx.mem_info().map_err(|e| e.to_string())?;
+    let dev = cuda.device(0).map_err(|e| CliError::CudaProbe(e.to_string()))?;
+    let ctx = cuda.create_context(&dev).map_err(|e| CliError::CudaProbe(e.to_string()))?;
+    let (free, total) = ctx.mem_info().map_err(|e| CliError::CudaProbe(e.to_string()))?;
     Ok(GpuInfo {
         name: dev.name().to_string(),
         total_bytes: total as u64,
@@ -1819,7 +1800,7 @@ mod tests {
 
         let error = parse_cli_command(&cli_args(&["monitor", "--activate"]))
             .expect_err("monitor has no mutation controls");
-        assert!(matches!(error, CliParseError::InvalidOption { .. }));
+        assert!(matches!(error, CliError::InvalidOption { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This PR extracts string-based error types from `main.rs` into a structured, `thiserror`-backed `CliError` enum in a new `cli_error.rs` module. It replaces `CliParseError` and updates methods to propagate `CliError` accurately.

## Commits
- ccd926ce467a78e727670731f8f30732cd28a49c

## Validation
- `cargo check --manifest-path crates/ramshared-cli/Cargo.toml` passed successfully.
- `cargo clippy --all-targets --manifest-path crates/ramshared-cli/Cargo.toml` passed without warnings.
- Added and ran a unit test directly in `cli_error.rs` that validates display formatting to pass.
- Verified test isolation manually using `RAMSHARED_CLI_TEST_DISABLE_ROOT_CHECK=1 cargo test -p ramshared-cli` verifying my changes specifically passed.

## Rollback trigger
new errors introduced or tests failed due to string error conversion issues

---
*PR created automatically by Jules for task [14963627986468415918](https://jules.google.com/task/14963627986468415918) started by @emersonbusson*