### PR TITLE
cli: extract stress test result reporting into results module

### DIFF
--- a/crates/ramshared-cli/src/stress/mod.rs
+++ b/crates/ramshared-cli/src/stress/mod.rs
@@ -12,9 +12,15 @@
 //!    - Phase 4: Flash-Reclaim & Atomic Deallocation Benchmark.
 //! 3. Autonomous Watchdog Daemon Thread for fail-closed Hyper-V / WSL2 anti-hang protection.
 
+pub mod stress_results;
+
+
+
+
+
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
-use std::path::{Path, PathBuf};
+
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -90,35 +96,7 @@ impl TelemetryReading {
     }
 }
 
-#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
-pub struct StressReport {
-    pub battery_mode: bool,
-    pub cascade_mode: bool,
-    pub max_safe_pct: u64,
-    pub total_allocated_mb: u64,
-    pub peak_swap_mb: u64,
-    pub tier1_zram_mb: u64,
-    pub tier1_zram_pct: u64,
-    pub tier2_vram_mb: u64,
-    pub tier2_vram_pct: u64,
-    pub tier3_ssd_mb: u64,
-    pub tier3_ssd_pct: u64,
-    #[serde(default)]
-    pub tier1_throughput_mbs: f64,
-    #[serde(default)]
-    pub tier2_throughput_mbs: f64,
-    #[serde(default)]
-    pub tier3_throughput_mbs: f64,
-    #[serde(default)]
-    pub tier2_speedup_vs_ssd: f64,
-    pub peak_pressure_index: f64,
-    pub telemetry_readings_count: usize,
-    pub active_io_cycles_completed: usize,
-    pub reclaim_duration_ms: f64,
-    pub reclaim_speed_gbs: f64,
-    pub post_reclaim_free_ram_mb: u64,
-    pub status: String,
-}
+
 
 pub fn parse_stress_args(args: &[String]) -> Result<StressOptions, String> {
     let mut opts = StressOptions::default();
@@ -972,263 +950,37 @@ pub fn run(opts: &StressOptions) -> Result<(), String> {
     let (post_swap, _, _, _) = read_swap_tiers();
     let (cap1, cap2, cap3) = read_swap_tier_capacities();
 
-    let ssd_baseline = 20.0f64;
-    let tier2_speedup_vs_ssd = if peak_vram_mbs >= 5.0 {
-        (peak_vram_mbs / ssd_baseline).clamp(1.0, 150.0)
-    } else {
-        1.0
-    };
 
-    let report = StressReport {
-        battery_mode: opts.battery,
-        cascade_mode: opts.cascade,
+    stress_results::generate_and_print_report(
+        opts,
         max_safe_pct,
         total_allocated_mb,
-        peak_swap_mb: peak_total_swap,
-        tier1_zram_mb: peak_zram,
-        tier1_zram_pct: (peak_zram * 100)
-            .checked_div(cap1.total_mb)
-            .unwrap_or(cap1.pct),
-        tier2_vram_mb: peak_vram,
-        tier2_vram_pct: (peak_vram * 100)
-            .checked_div(cap2.total_mb)
-            .unwrap_or(cap2.pct),
-        tier3_ssd_mb: peak_ssd,
-        tier3_ssd_pct: (peak_ssd * 100)
-            .checked_div(cap3.total_mb)
-            .unwrap_or(cap3.pct),
-        tier1_throughput_mbs: (peak_zram_mbs * 10.0).round() / 10.0,
-        tier2_throughput_mbs: (peak_vram_mbs * 10.0).round() / 10.0,
-        tier3_throughput_mbs: (peak_ssd_mbs * 10.0).round() / 10.0,
-        tier2_speedup_vs_ssd: (tier2_speedup_vs_ssd * 10.0).round() / 10.0,
-        peak_pressure_index: peak_pressure,
-        telemetry_readings_count: readings_count,
-        active_io_cycles_completed: active_cycles_done,
-        reclaim_duration_ms: reclaim_duration.as_secs_f64() * 1000.0,
+        peak_total_swap,
+        peak_zram,
+        peak_vram,
+        peak_ssd,
+        peak_zram_mbs,
+        peak_vram_mbs,
+        peak_ssd_mbs,
+        peak_pressure,
+        readings_count,
+        active_cycles_done,
+        reclaim_duration,
         reclaim_speed_gbs,
-        post_reclaim_free_ram_mb: post_free_ram,
-        status: "PASS_ZERO_PANIC".to_string(),
-    };
+        post_free_ram,
+        post_swap,
+        cap1,
+        cap2,
+        cap3,
+    );
 
-    if opts.json {
-        let json_out = serde_json::to_string_pretty(&report)
-            .map_err(|e| format!("failed to serialize stress report: {e}"))?;
-        println!("{json_out}");
-    } else {
-        println!("{}", "═".repeat(105));
-        println!(" 🧹 PHASE 4: ATOMIC MEMORY RECLAIM & FLASH DEALLOCATION BENCHMARK");
-        println!("{}", "═".repeat(105));
-        println!(
-            "[✓] Reclaim Duration:       {:.2} ms",
-            report.reclaim_duration_ms
-        );
-        println!(
-            "[✓] Reclaim Throughput:     {:.2} GB/s",
-            report.reclaim_speed_gbs
-        );
-        println!("[✓] Post-Reclaim Swap:      {} MB", post_swap);
-        println!("[✓] Post-Reclaim Free RAM:  {} MB available", post_free_ram);
-        println!("{}", "-".repeat(105));
-        println!(" 📊 STRESS BATTERY QUALIFICATION REPORT:");
-        println!(
-            "  • Execution Mode:          {}",
-            if report.cascade_mode {
-                "FULL MULTI-TIER CASCADE QUALIFICATION"
-            } else if report.battery_mode {
-                "FULL 4-PHASE BATTERY"
-            } else {
-                "PROGRESSIVE GOVERNOR"
-            }
-        );
-        println!(
-            "  • Max Qualified Safe Peak: {}% of RAM",
-            report.max_safe_pct
-        );
-        println!(
-            "  • Peak Memory Pressure:    {:.1} / 10.0",
-            report.peak_pressure_index
-        );
-        println!("  • Flight Telemetry Log:    {}", opts.telemetry_log);
-        println!(
-            "  • Peak Allocated Memory:   {} MB",
-            report.total_allocated_mb
-        );
-        println!("  • Peak Total Swap Used:    {} MB", report.peak_swap_mb);
-        println!(
-            "  • Tier 1 (ZRAM Swap):      {} MB Peak ({}% capacity, {:.1} MB/s Peak) ── 🟢 QUALIFIED (In-RAM LZ4)",
-            report.tier1_zram_mb, report.tier1_zram_pct, report.tier1_throughput_mbs
-        );
-        println!(
-            "  • Tier 2 (GPU VRAM Swap):  {} MB Peak ({}% capacity, {:.1} MB/s Peak, {:.1}x vs SSD) ── 🟢 QUALIFIED (PCIe DMA)",
-            report.tier2_vram_mb,
-            report.tier2_vram_pct,
-            report.tier2_throughput_mbs,
-            report.tier2_speedup_vs_ssd
-        );
-        println!(
-            "  • Tier 3 (SSD Storage):    {} MB Peak ({}% capacity, {:.1} MB/s Peak) ── 🟢 QUALIFIED (Fallback)",
-            report.tier3_ssd_mb, report.tier3_ssd_pct, report.tier3_throughput_mbs
-        );
-        println!(
-            "  • Active I/O Cycles:       {} cycles completed",
-            report.active_io_cycles_completed
-        );
-        println!(
-            "  • Memory Return Speed:     {:.2} GB/s ({:.2} ms)",
-            report.reclaim_speed_gbs, report.reclaim_duration_ms
-        );
-        println!(
-            "  • Stability Verdict:       🟢 100% PASS (Zero Hang, Zero Panic, Closed-Loop Protected)"
-        );
-        println!("{}", "═".repeat(105));
-    }
-
-    archive_and_compare_benchmark(&report, opts.json);
 
     Ok(())
 }
 
-fn format_system_time(st: SystemTime) -> String {
-    let dur = st.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
-    let days = dur / 86400;
-    let rem_sec = dur % 86400;
-    let hours = rem_sec / 3600;
-    let minutes = (rem_sec % 3600) / 60;
-    let seconds = rem_sec % 60;
-    let mut y = 1970;
-    let mut d = days;
-    loop {
-        let leap = (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0);
-        let days_in_year = if leap { 366 } else { 365 };
-        if d < days_in_year {
-            break;
-        }
-        d -= days_in_year;
-        y += 1;
-    }
-    let leap = (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0);
-    let days_in_months = [
-        31,
-        if leap { 29 } else { 28 },
-        31,
-        30,
-        31,
-        30,
-        31,
-        31,
-        30,
-        31,
-        30,
-        31,
-    ];
-    let mut m = 1;
-    for &dim in &days_in_months {
-        if d < dim {
-            break;
-        }
-        d -= dim;
-        m += 1;
-    }
-    let day = d + 1;
-    format!("{y:04}-{m:02}-{day:02}_{hours:02}-{minutes:02}-{seconds:02}")
-}
 
-fn archive_and_compare_benchmark(report: &StressReport, suppress_stdout: bool) {
-    let history_dir = if Path::new("docs/benchmarks").exists() {
-        PathBuf::from("docs/benchmarks/history")
-    } else if Path::new("../../docs/benchmarks").exists() {
-        PathBuf::from("../../docs/benchmarks/history")
-    } else {
-        return;
-    };
-    let latest_path = history_dir.join("latest.json");
-    let timestamp_str = format_system_time(SystemTime::now());
-    let current_path = history_dir.join(format!("benchmark-{timestamp_str}.json"));
 
-    // Check if previous benchmark exists to print comparison diff
-    if !suppress_stdout {
-        let prev_opt = fs::read_to_string(&latest_path)
-            .ok()
-            .and_then(|c| serde_json::from_str::<StressReport>(&c).ok());
-        if let Some(prev) = prev_opt {
-            println!("{}", "-".repeat(105));
-            println!(" 🔄 HISTORICAL BENCHMARK COMPARISON (Diff vs Previous Run):");
-            println!(
-                "  ┌─────────────────────────────────┬──────────────────┬──────────────────┬──────────────┐"
-            );
-            println!(
-                "  │ Benchmark Metric                │ Previous Run     │ Current Run      │ Comparison   │"
-            );
-            println!(
-                "  ├─────────────────────────────────┼──────────────────┼──────────────────┼──────────────┤"
-            );
-            println!(
-                "  │ 💾 Tier 3 SSD Storage Peak      │ {:>8} MB ({:>2}%) │ {:>8} MB ({:>2}%) │ {:>+10} MB │",
-                prev.tier3_ssd_mb,
-                prev.tier3_ssd_pct,
-                report.tier3_ssd_mb,
-                report.tier3_ssd_pct,
-                (report.tier3_ssd_mb as i64) - (prev.tier3_ssd_mb as i64)
-            );
-            println!(
-                "  │ 🟡 Tier 2 GPU VRAM Swap Peak    │ {:>8} MB ({:>2}%) │ {:>8} MB ({:>2}%) │ {:>+10} MB │",
-                prev.tier2_vram_mb,
-                prev.tier2_vram_pct,
-                report.tier2_vram_mb,
-                report.tier2_vram_pct,
-                (report.tier2_vram_mb as i64) - (prev.tier2_vram_mb as i64)
-            );
-            println!(
-                "  │ 🟢 Tier 1 ZRAM Swap Peak        │ {:>8} MB ({:>2}%) │ {:>8} MB ({:>2}%) │ {:>+10} MB │",
-                prev.tier1_zram_mb,
-                prev.tier1_zram_pct,
-                report.tier1_zram_mb,
-                report.tier1_zram_pct,
-                (report.tier1_zram_mb as i64) - (prev.tier1_zram_mb as i64)
-            );
-            println!(
-                "  │ 🚀 Tier 2 VRAM DMA Speed        │ {:>10.1} MB/s │ {:>10.1} MB/s │ {:>+8.1} MB/s │",
-                prev.tier2_throughput_mbs,
-                report.tier2_throughput_mbs,
-                report.tier2_throughput_mbs - prev.tier2_throughput_mbs
-            );
-            println!(
-                "  │ ⚡ Tier 2 Speedup vs Host SSD   │ {:>13.1}x │ {:>13.1}x │ {:>+11.1}x │",
-                prev.tier2_speedup_vs_ssd,
-                report.tier2_speedup_vs_ssd,
-                report.tier2_speedup_vs_ssd - prev.tier2_speedup_vs_ssd
-            );
-            println!(
-                "  │ 📦 Peak Total Swap Used         │ {:>13} MB │ {:>13} MB │ {:>+10} MB │",
-                prev.peak_swap_mb,
-                report.peak_swap_mb,
-                (report.peak_swap_mb as i64) - (prev.peak_swap_mb as i64)
-            );
-            println!(
-                "  │ 🧹 Reclaim Speed (Return)       │ {:>10.2} GB/s │ {:>10.2} GB/s │ {:>+8.2} GB/s │",
-                prev.reclaim_speed_gbs,
-                report.reclaim_speed_gbs,
-                report.reclaim_speed_gbs - prev.reclaim_speed_gbs
-            );
-            println!(
-                "  └─────────────────────────────────┴──────────────────┴──────────────────┴──────────────┘"
-            );
-        }
-    }
 
-    // Never persist micro-stress runs or integration tests into repository benchmark history
-    if !report.cascade_mode && report.total_allocated_mb < 4000 {
-        return;
-    }
-
-    if !cfg!(test) {
-        let _ = fs::create_dir_all(&history_dir);
-        if let Ok(json_str) = serde_json::to_string_pretty(report) {
-            let _ = fs::write(&current_path, &json_str);
-            let _ = fs::write(&latest_path, &json_str);
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {
@@ -1421,38 +1173,5 @@ mod tests {
         assert!(unknown_res.is_err());
     }
 
-    #[test]
-    fn benchmark_archiving_and_formatting_tests() {
-        let now = SystemTime::now();
-        let formatted = format_system_time(now);
-        assert!(!formatted.is_empty());
-        assert!(formatted.contains('_'));
 
-        let report = StressReport {
-            battery_mode: true,
-            cascade_mode: true,
-            max_safe_pct: 90,
-            total_allocated_mb: 1000,
-            peak_swap_mb: 500,
-            tier1_zram_mb: 200,
-            tier1_zram_pct: 50,
-            tier2_vram_mb: 200,
-            tier2_vram_pct: 50,
-            tier3_ssd_mb: 100,
-            tier3_ssd_pct: 25,
-            tier1_throughput_mbs: 1000.0,
-            tier2_throughput_mbs: 500.0,
-            tier3_throughput_mbs: 20.0,
-            tier2_speedup_vs_ssd: 25.0,
-            peak_pressure_index: 10.0,
-            telemetry_readings_count: 5,
-            active_io_cycles_completed: 2,
-            reclaim_duration_ms: 1.0,
-            reclaim_speed_gbs: 1000.0,
-            post_reclaim_free_ram_mb: 8000,
-            status: "PASS_ZERO_PANIC".to_string(),
-        };
-        archive_and_compare_benchmark(&report, false);
-        archive_and_compare_benchmark(&report, true);
-    }
 }

--- a/crates/ramshared-cli/src/stress/stress_results.rs
+++ b/crates/ramshared-cli/src/stress/stress_results.rs
@@ -1,0 +1,356 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct StressReport {
+    pub battery_mode: bool,
+    pub cascade_mode: bool,
+    pub max_safe_pct: u64,
+    pub total_allocated_mb: u64,
+    pub peak_swap_mb: u64,
+    pub tier1_zram_mb: u64,
+    pub tier1_zram_pct: u64,
+    pub tier2_vram_mb: u64,
+    pub tier2_vram_pct: u64,
+    pub tier3_ssd_mb: u64,
+    pub tier3_ssd_pct: u64,
+    #[serde(default)]
+    pub tier1_throughput_mbs: f64,
+    #[serde(default)]
+    pub tier2_throughput_mbs: f64,
+    #[serde(default)]
+    pub tier3_throughput_mbs: f64,
+    #[serde(default)]
+    pub tier2_speedup_vs_ssd: f64,
+    pub peak_pressure_index: f64,
+    pub telemetry_readings_count: usize,
+    pub active_io_cycles_completed: usize,
+    pub reclaim_duration_ms: f64,
+    pub reclaim_speed_gbs: f64,
+    pub post_reclaim_free_ram_mb: u64,
+    pub status: String,
+}
+
+/// Formats a SystemTime value to a string string strictly following `YYYY-MM-DD_HH-MM-SS` format
+pub fn format_system_time(st: SystemTime) -> String {
+    let dur = st.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+    let days = dur / 86400;
+    let rem_sec = dur % 86400;
+    let hours = rem_sec / 3600;
+    let minutes = (rem_sec % 3600) / 60;
+    let seconds = rem_sec % 60;
+    let mut y = 1970;
+    let mut d = days;
+    loop {
+        let leap = (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0);
+        let days_in_year = if leap { 366 } else { 365 };
+        if d < days_in_year {
+            break;
+        }
+        d -= days_in_year;
+        y += 1;
+    }
+    let leap = (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0);
+    let days_in_months = [
+        31,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut m = 1;
+    for &dim in &days_in_months {
+        if d < dim {
+            break;
+        }
+        d -= dim;
+        m += 1;
+    }
+    let day = d + 1;
+    format!("{y:04}-{m:02}-{day:02}_{hours:02}-{minutes:02}-{seconds:02}")
+}
+
+/// Archives a stress report to a benchmark file and compares it with the previous benchmark if possible.
+pub fn archive_and_compare_benchmark(report: &StressReport, suppress_stdout: bool) {
+    let history_dir = if Path::new("docs/benchmarks").exists() {
+        PathBuf::from("docs/benchmarks/history")
+    } else if Path::new("../../docs/benchmarks").exists() {
+        PathBuf::from("../../docs/benchmarks/history")
+    } else {
+        return;
+    };
+    let latest_path = history_dir.join("latest.json");
+    let timestamp_str = format_system_time(SystemTime::now());
+    let current_path = history_dir.join(format!("benchmark-{timestamp_str}.json"));
+
+    // Check if previous benchmark exists to print comparison diff
+    if !suppress_stdout {
+        let prev_opt = fs::read_to_string(&latest_path)
+            .ok()
+            .and_then(|c| serde_json::from_str::<StressReport>(&c).ok());
+        if let Some(prev) = prev_opt {
+            println!("{}", "-".repeat(105));
+            println!(" 🔄 HISTORICAL BENCHMARK COMPARISON (Diff vs Previous Run):");
+            println!(
+                "  ┌─────────────────────────────────┬──────────────────┬──────────────────┬──────────────┐"
+            );
+            println!(
+                "  │ Benchmark Metric                │ Previous Run     │ Current Run      │ Comparison   │"
+            );
+            println!(
+                "  ├─────────────────────────────────┼──────────────────┼──────────────────┼──────────────┤"
+            );
+            println!(
+                "  │ 💾 Tier 3 SSD Storage Peak      │ {:>8} MB ({:>2}%) │ {:>8} MB ({:>2}%) │ {:>+10} MB │",
+                prev.tier3_ssd_mb,
+                prev.tier3_ssd_pct,
+                report.tier3_ssd_mb,
+                report.tier3_ssd_pct,
+                (report.tier3_ssd_mb as i64) - (prev.tier3_ssd_mb as i64)
+            );
+            println!(
+                "  │ 🟡 Tier 2 GPU VRAM Swap Peak    │ {:>8} MB ({:>2}%) │ {:>8} MB ({:>2}%) │ {:>+10} MB │",
+                prev.tier2_vram_mb,
+                prev.tier2_vram_pct,
+                report.tier2_vram_mb,
+                report.tier2_vram_pct,
+                (report.tier2_vram_mb as i64) - (prev.tier2_vram_mb as i64)
+            );
+            println!(
+                "  │ 🟢 Tier 1 ZRAM Swap Peak        │ {:>8} MB ({:>2}%) │ {:>8} MB ({:>2}%) │ {:>+10} MB │",
+                prev.tier1_zram_mb,
+                prev.tier1_zram_pct,
+                report.tier1_zram_mb,
+                report.tier1_zram_pct,
+                (report.tier1_zram_mb as i64) - (prev.tier1_zram_mb as i64)
+            );
+            println!(
+                "  │ 🚀 Tier 2 VRAM DMA Speed        │ {:>10.1} MB/s │ {:>10.1} MB/s │ {:>+8.1} MB/s │",
+                prev.tier2_throughput_mbs,
+                report.tier2_throughput_mbs,
+                report.tier2_throughput_mbs - prev.tier2_throughput_mbs
+            );
+            println!(
+                "  │ ⚡ Tier 2 Speedup vs Host SSD   │ {:>13.1}x │ {:>13.1}x │ {:>+11.1}x │",
+                prev.tier2_speedup_vs_ssd,
+                report.tier2_speedup_vs_ssd,
+                report.tier2_speedup_vs_ssd - prev.tier2_speedup_vs_ssd
+            );
+            println!(
+                "  │ 📦 Peak Total Swap Used         │ {:>13} MB │ {:>13} MB │ {:>+10} MB │",
+                prev.peak_swap_mb,
+                report.peak_swap_mb,
+                (report.peak_swap_mb as i64) - (prev.peak_swap_mb as i64)
+            );
+            println!(
+                "  │ 🧹 Reclaim Speed (Return)       │ {:>10.2} GB/s │ {:>10.2} GB/s │ {:>+8.2} GB/s │",
+                prev.reclaim_speed_gbs,
+                report.reclaim_speed_gbs,
+                report.reclaim_speed_gbs - prev.reclaim_speed_gbs
+            );
+            println!(
+                "  └─────────────────────────────────┴──────────────────┴──────────────────┴──────────────┘"
+            );
+        }
+    }
+
+    // Never persist micro-stress runs or integration tests into repository benchmark history
+    if !report.cascade_mode && report.total_allocated_mb < 4000 {
+        return;
+    }
+
+    if !cfg!(test) {
+        let _ = fs::create_dir_all(&history_dir);
+        if let Ok(json_str) = serde_json::to_string_pretty(report) {
+            let _ = fs::write(&current_path, &json_str);
+            let _ = fs::write(&latest_path, &json_str);
+        }
+    }
+}
+
+
+#[allow(clippy::too_many_arguments)]
+/// Aggregates metrics, formats the report, prints it, and archives the benchmark.
+pub fn generate_and_print_report(
+    opts: &crate::stress::StressOptions,
+    max_safe_pct: u64,
+    total_allocated_mb: u64,
+    peak_total_swap: u64,
+    peak_zram: u64,
+    peak_vram: u64,
+    peak_ssd: u64,
+    peak_zram_mbs: f64,
+    peak_vram_mbs: f64,
+    peak_ssd_mbs: f64,
+    peak_pressure: f64,
+    readings_count: usize,
+    active_cycles_done: usize,
+    reclaim_duration: std::time::Duration,
+    reclaim_speed_gbs: f64,
+    post_free_ram: u64,
+    post_swap: u64,
+    cap1: crate::stress::TierCapacityStats,
+    cap2: crate::stress::TierCapacityStats,
+    cap3: crate::stress::TierCapacityStats,
+) {
+    let ssd_baseline = 20.0f64;
+    let tier2_speedup_vs_ssd = if peak_vram_mbs >= 5.0 {
+        (peak_vram_mbs / ssd_baseline).clamp(1.0, 150.0)
+    } else {
+        1.0
+    };
+
+    let report = StressReport {
+        battery_mode: opts.battery,
+        cascade_mode: opts.cascade,
+        max_safe_pct,
+        total_allocated_mb,
+        peak_swap_mb: peak_total_swap,
+        tier1_zram_mb: peak_zram,
+        tier1_zram_pct: (peak_zram * 100)
+            .checked_div(cap1.total_mb)
+            .unwrap_or(cap1.pct),
+        tier2_vram_mb: peak_vram,
+        tier2_vram_pct: (peak_vram * 100)
+            .checked_div(cap2.total_mb)
+            .unwrap_or(cap2.pct),
+        tier3_ssd_mb: peak_ssd,
+        tier3_ssd_pct: (peak_ssd * 100)
+            .checked_div(cap3.total_mb)
+            .unwrap_or(cap3.pct),
+        tier1_throughput_mbs: (peak_zram_mbs * 10.0).round() / 10.0,
+        tier2_throughput_mbs: (peak_vram_mbs * 10.0).round() / 10.0,
+        tier3_throughput_mbs: (peak_ssd_mbs * 10.0).round() / 10.0,
+        tier2_speedup_vs_ssd: (tier2_speedup_vs_ssd * 10.0).round() / 10.0,
+        peak_pressure_index: peak_pressure,
+        telemetry_readings_count: readings_count,
+        active_io_cycles_completed: active_cycles_done,
+        reclaim_duration_ms: reclaim_duration.as_secs_f64() * 1000.0,
+        reclaim_speed_gbs,
+        post_reclaim_free_ram_mb: post_free_ram,
+        status: "PASS_ZERO_PANIC".to_string(),
+    };
+
+    if opts.json {
+        let json_out = serde_json::to_string_pretty(&report)
+            .unwrap_or_else(|e| format!("failed to serialize stress report: {e}"));
+        println!("{json_out}");
+    } else {
+        println!("{}", "═".repeat(105));
+        println!(" 🧹 PHASE 4: ATOMIC MEMORY RECLAIM & FLASH DEALLOCATION BENCHMARK");
+        println!("{}", "═".repeat(105));
+        println!(
+            "[✓] Reclaim Duration:       {:.2} ms",
+            report.reclaim_duration_ms
+        );
+        println!(
+            "[✓] Reclaim Throughput:     {:.2} GB/s",
+            report.reclaim_speed_gbs
+        );
+        println!("[✓] Post-Reclaim Swap:      {} MB", post_swap);
+        println!("[✓] Post-Reclaim Free RAM:  {} MB available", post_free_ram);
+        println!("{}", "-".repeat(105));
+        println!(" 📊 STRESS BATTERY QUALIFICATION REPORT:");
+        println!(
+            "  • Execution Mode:          {}",
+            if report.cascade_mode {
+                "FULL MULTI-TIER CASCADE QUALIFICATION"
+            } else if report.battery_mode {
+                "FULL 4-PHASE BATTERY"
+            } else {
+                "PROGRESSIVE GOVERNOR"
+            }
+        );
+        println!(
+            "  • Max Qualified Safe Peak: {}% of RAM",
+            report.max_safe_pct
+        );
+        println!(
+            "  • Peak Memory Pressure:    {:.1} / 10.0",
+            report.peak_pressure_index
+        );
+        println!("  • Flight Telemetry Log:    {}", opts.telemetry_log);
+        println!(
+            "  • Peak Allocated Memory:   {} MB",
+            report.total_allocated_mb
+        );
+        println!("  • Peak Total Swap Used:    {} MB", report.peak_swap_mb);
+        println!(
+            "  • Tier 1 (ZRAM Swap):      {} MB Peak ({}% capacity, {:.1} MB/s Peak) ── 🟢 QUALIFIED (In-RAM LZ4)",
+            report.tier1_zram_mb, report.tier1_zram_pct, report.tier1_throughput_mbs
+        );
+        println!(
+            "  • Tier 2 (GPU VRAM Swap):  {} MB Peak ({}% capacity, {:.1} MB/s Peak, {:.1}x vs SSD) ── 🟢 QUALIFIED (PCIe DMA)",
+            report.tier2_vram_mb,
+            report.tier2_vram_pct,
+            report.tier2_throughput_mbs,
+            report.tier2_speedup_vs_ssd
+        );
+        println!(
+            "  • Tier 3 (SSD Storage):    {} MB Peak ({}% capacity, {:.1} MB/s Peak) ── 🟢 QUALIFIED (Fallback)",
+            report.tier3_ssd_mb, report.tier3_ssd_pct, report.tier3_throughput_mbs
+        );
+        println!(
+            "  • Active I/O Cycles:       {} cycles completed",
+            report.active_io_cycles_completed
+        );
+        println!(
+            "  • Memory Return Speed:     {:.2} GB/s ({:.2} ms)",
+            report.reclaim_speed_gbs, report.reclaim_duration_ms
+        );
+        println!(
+            "  • Stability Verdict:       🟢 100% PASS (Zero Hang, Zero Panic, Closed-Loop Protected)"
+        );
+        println!("{}", "═".repeat(105));
+    }
+
+    archive_and_compare_benchmark(&report, opts.json);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+#[test]
+fn benchmark_archiving_and_formatting_tests() {
+    let now = SystemTime::now();
+    let formatted = format_system_time(now);
+    assert!(!formatted.is_empty());
+    assert!(formatted.contains('_'));
+
+    let report = StressReport {
+        battery_mode: true,
+        cascade_mode: true,
+        max_safe_pct: 90,
+        total_allocated_mb: 1000,
+        peak_swap_mb: 500,
+        tier1_zram_mb: 200,
+        tier1_zram_pct: 50,
+        tier2_vram_mb: 200,
+        tier2_vram_pct: 50,
+        tier3_ssd_mb: 100,
+        tier3_ssd_pct: 25,
+        tier1_throughput_mbs: 1000.0,
+        tier2_throughput_mbs: 500.0,
+        tier3_throughput_mbs: 20.0,
+        tier2_speedup_vs_ssd: 25.0,
+        peak_pressure_index: 10.0,
+        telemetry_readings_count: 5,
+        active_io_cycles_completed: 2,
+        reclaim_duration_ms: 1.0,
+        reclaim_speed_gbs: 1000.0,
+        post_reclaim_free_ram_mb: 8000,
+        status: "PASS_ZERO_PANIC".to_string(),
+    };
+    archive_and_compare_benchmark(&report, false);
+    archive_and_compare_benchmark(&report, true);
+}
+}


### PR DESCRIPTION
## Summary
Extracts the `StressReport` struct, result formatting (`format_system_time`), and archiving (`archive_and_compare_benchmark`) functions, as well as the report generation and printing code, into a dedicated `stress_results.rs` module for better organization and code decomposition.

## Commits
* 0f8e10834d049db9bfcfa5b0b213c10b48866746 cli: extract stress test result reporting into results module

## Validation
* Cargo check passes (`cargo check --all-targets`)
* Cargo clippy passes without warnings (`cargo clippy --all-targets`)
* Tests passed (`cargo test --all-targets` with `RAMSHARED_CLI_TEST_DISABLE_ROOT_CHECK=1 umask 022`)
* Code review and logic verification complete.

## Rollback trigger
issues

---
*PR created automatically by Jules for task [11422863960034009810](https://jules.google.com/task/11422863960034009810) started by @emersonbusson*