### PR TITLE
feat: implement broker tenant VRAM quota

### DIFF
--- a/crates/ramshared-winsvc/src/broker_tenant.rs
+++ b/crates/ramshared-winsvc/src/broker_tenant.rs
@@ -159,7 +159,10 @@ impl BrokerTenant {
         if let Some(q) = &self.quota {
             let res = q.enforce(bytes);
             if let Err(limit) = res {
-                return Err(BrokerTenantError::QuotaExceeded { limit, requested: bytes });
+                return Err(BrokerTenantError::QuotaExceeded {
+                    limit,
+                    requested: bytes,
+                });
             }
         }
         write_msg(stream, &Msg::LeaseRequest { bytes })
@@ -367,7 +370,10 @@ mod tests {
         let err = t.request_lease(&mut stream, 2048).unwrap_err();
         assert!(matches!(
             err,
-            BrokerTenantError::QuotaExceeded { limit: 1024, requested: 2048 }
+            BrokerTenantError::QuotaExceeded {
+                limit: 1024,
+                requested: 2048
+            }
         ));
     }
 

--- a/crates/ramshared-winsvc/src/broker_tenant.rs
+++ b/crates/ramshared-winsvc/src/broker_tenant.rs
@@ -5,6 +5,9 @@
 use std::io::{BufRead, Write};
 use std::time::Duration;
 
+pub mod quota;
+use quota::TenantQuota;
+
 use ramshared_broker::model::{PsiSample, TransportKind};
 use ramshared_broker::protocol::{Msg, PROTO_VERSION, read_msg, write_msg};
 
@@ -40,6 +43,11 @@ pub enum BrokerTenantError {
         free: u64,
         need: u64,
     },
+    /// Tenant VRAM quota exceeded.
+    QuotaExceeded {
+        limit: u64,
+        requested: u64,
+    },
     Eof,
 }
 
@@ -58,6 +66,9 @@ impl std::fmt::Display for BrokerTenantError {
             BrokerTenantError::CoresidenceFailClosed { free, need } => {
                 write!(f, "coresidence_fail_closed free={free} need={need}")
             }
+            BrokerTenantError::QuotaExceeded { limit, requested } => {
+                write!(f, "quota_exceeded limit={limit} requested={requested}")
+            }
             BrokerTenantError::Eof => write!(f, "broker EOF"),
         }
     }
@@ -74,10 +85,20 @@ pub struct BrokerTenant {
     requested_bytes: Option<u64>,
     release_sent: ReleaseSent,
     heartbeat: Duration,
+    pub quota: Option<TenantQuota>,
 }
 
 impl BrokerTenant {
     pub fn new(tenant: impl Into<String>, heartbeat: Duration) -> Self {
+        Self::new_with_quota(tenant, heartbeat, None)
+    }
+
+    /// Create a new broker tenant with an optional quota limit.
+    pub fn new_with_quota(
+        tenant: impl Into<String>,
+        heartbeat: Duration,
+        quota: Option<TenantQuota>,
+    ) -> Self {
         Self {
             tenant: tenant.into(),
             tenant_id: None,
@@ -85,6 +106,7 @@ impl BrokerTenant {
             requested_bytes: None,
             release_sent: ReleaseSent::None,
             heartbeat,
+            quota,
         }
     }
 
@@ -134,6 +156,12 @@ impl BrokerTenant {
         stream: &mut S,
         bytes: u64,
     ) -> Result<(), BrokerTenantError> {
+        if let Some(q) = &self.quota {
+            let res = q.enforce(bytes);
+            if let Err(limit) = res {
+                return Err(BrokerTenantError::QuotaExceeded { limit, requested: bytes });
+            }
+        }
         write_msg(stream, &Msg::LeaseRequest { bytes })
             .map_err(|e| BrokerTenantError::Io(e.to_string()))?;
         Ok(())
@@ -328,6 +356,19 @@ mod tests {
         let mut t = BrokerTenant::new("wd", Duration::from_secs(5));
         let e = t.acquire(&mut dual, 1).unwrap_err();
         assert!(matches!(e, BrokerTenantError::Denied(r) if r == "lease_em_andamento"));
+    }
+
+    #[test]
+    fn request_lease_quota_exceeded() {
+        let mut stream = Dual::new(Vec::new());
+        let quota = crate::broker_tenant::quota::TenantQuota::new(1024);
+        let mut t = BrokerTenant::new_with_quota("wd", Duration::from_secs(5), Some(quota));
+
+        let err = t.request_lease(&mut stream, 2048).unwrap_err();
+        assert!(matches!(
+            err,
+            BrokerTenantError::QuotaExceeded { limit: 1024, requested: 2048 }
+        ));
     }
 
     #[test]

--- a/crates/ramshared-winsvc/src/broker_tenant/quota.rs
+++ b/crates/ramshared-winsvc/src/broker_tenant/quota.rs
@@ -1,0 +1,35 @@
+/// Quota tracking for a single broker tenant.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TenantQuota {
+    /// Maximum allowed memory limit in bytes.
+    pub limit: u64,
+}
+
+impl TenantQuota {
+    /// Create a new quota with the specified limit.
+    pub fn new(limit: u64) -> Self {
+        Self { limit }
+    }
+
+    /// Enforce the quota against a requested byte count.
+    pub fn enforce(&self, requested: u64) -> Result<(), u64> {
+        if requested > self.limit {
+            Err(self.limit)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enforce_quota() {
+        let q = TenantQuota::new(1024);
+        assert_eq!(q.enforce(512), Ok(()));
+        assert_eq!(q.enforce(1024), Ok(()));
+        assert_eq!(q.enforce(2048), Err(1024));
+    }
+}

--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -6234,10 +6234,7 @@ mod tests {
 
     #[test]
     fn daemon_broker_ram_binds_loopback_and_cleans_owned_socket() {
-        let path = std::env::temp_dir().join(format!(
-            "rs-d-broker-{}.sock",
-            std::process::id()
-        ));
+        let path = std::env::temp_dir().join(format!("rs-d-broker-{}.sock", std::process::id()));
         let _ = std::fs::remove_file(&path);
         let listeners = bind_broker_listeners(
             &path,

--- a/crates/ramshared-wsl2d/src/main.rs
+++ b/crates/ramshared-wsl2d/src/main.rs
@@ -6235,9 +6235,8 @@ mod tests {
     #[test]
     fn daemon_broker_ram_binds_loopback_and_cleans_owned_socket() {
         let path = std::env::temp_dir().join(format!(
-            "ramshared-daemon-broker-{}-{}.sock",
-            std::process::id(),
-            std::thread::current().name().unwrap_or("test")
+            "rs-d-broker-{}.sock",
+            std::process::id()
         ));
         let _ = std::fs::remove_file(&path);
         let listeners = bind_broker_listeners(

--- a/docs/governance/rust-slice-coverage.json
+++ b/docs/governance/rust-slice-coverage.json
@@ -157,7 +157,7 @@
         "-p",
         "ramshared-winsvc",
         "--files",
-        "crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs",
+        "crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs,crates/ramshared-winsvc/src/broker_tenant/quota.rs",
         "--min",
         "80"
       ],
@@ -171,7 +171,8 @@
         "crates/ramshared-winsvc/src/broker_tenant.rs",
         "crates/ramshared-winsvc/src/runtime.rs",
         "crates/ramshared-winsvc/src/service.rs",
-        "crates/ramshared-winsvc/src/host_safety.rs"
+        "crates/ramshared-winsvc/src/host_safety.rs",
+        "crates/ramshared-winsvc/src/broker_tenant/quota.rs"
       ],
       "min": 80
     },
@@ -341,11 +342,25 @@
           "source": "crates/ramshared-cuda/src/lib.rs",
           "package": "ramshared-cuda",
           "test_module": "tests",
-          "cargo_test": ["cargo", "test", "-p", "ramshared-cuda", "--lib"],
+          "cargo_test": [
+            "cargo",
+            "test",
+            "-p",
+            "ramshared-cuda",
+            "--lib"
+          ],
           "ignored_gpu_tests": [
             {
               "name": "gpu_roundtrip_256mib",
-              "command": ["cargo", "test", "-p", "ramshared-cuda", "--", "--ignored", "--test-threads=1"],
+              "command": [
+                "cargo",
+                "test",
+                "-p",
+                "ramshared-cuda",
+                "--",
+                "--ignored",
+                "--test-threads=1"
+              ],
               "evidence": "validation.md"
             }
           ]
@@ -368,15 +383,21 @@
         "--report-json",
         "tmp/memory-broker-wsl2d-backend-cov.json"
       ],
-      "packages": ["ramshared-wsl2d"],
-      "files": ["crates/ramshared-wsl2d/src/backend.rs"],
+      "packages": [
+        "ramshared-wsl2d"
+      ],
+      "files": [
+        "crates/ramshared-wsl2d/src/backend.rs"
+      ],
       "min": 80
     },
     {
       "id": "memory-broker-wsl2d-backend-gpu-test-relocation",
       "kind": "rust-ignored-test-relocation",
       "spec": "docs/specs/no-milestone/memory-broker/SPEC.md",
-      "files": ["crates/ramshared-wsl2d/src/backend.rs"],
+      "files": [
+        "crates/ramshared-wsl2d/src/backend.rs"
+      ],
       "base_revision": "69f7469fa999b7d079341ee6bf8ebb006d517b51",
       "base_source_sha256": "b58d99366164b7e898baa42492fead82416a6169ec06ce16fb274b06b6d99663",
       "verification": {
@@ -400,14 +421,54 @@
         "ignored_gpu_tests": [
           {
             "name": "vram_backend_serves_nbd_write_then_read",
-            "command": ["cargo", "test", "-p", "ramshared-wsl2d", "--test", "backend_gpu", "vram_backend_serves_nbd_write_then_read", "--", "--ignored", "--test-threads=1"],
-            "historical_command": ["cargo", "test", "-p", "ramshared-wsl2d", "backend::tests::vram_backend_serves_nbd_write_then_read", "--", "--ignored", "--test-threads=1"],
+            "command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "--test",
+              "backend_gpu",
+              "vram_backend_serves_nbd_write_then_read",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
+            "historical_command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "backend::tests::vram_backend_serves_nbd_write_then_read",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
             "evidence": "validation.md"
           },
           {
             "name": "vram_gauge_outros_captures_real_graphics_usage",
-            "command": ["cargo", "test", "-p", "ramshared-wsl2d", "--test", "backend_gpu", "vram_gauge_outros_captures_real_graphics_usage", "--", "--ignored", "--test-threads=1"],
-            "historical_command": ["cargo", "test", "-p", "ramshared-wsl2d", "backend::tests::vram_gauge_outros_captures_real_graphics_usage", "--", "--ignored", "--test-threads=1"],
+            "command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "--test",
+              "backend_gpu",
+              "vram_gauge_outros_captures_real_graphics_usage",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
+            "historical_command": [
+              "cargo",
+              "test",
+              "-p",
+              "ramshared-wsl2d",
+              "backend::tests::vram_gauge_outros_captures_real_graphics_usage",
+              "--",
+              "--ignored",
+              "--test-threads=1"
+            ],
             "evidence": "validation.md"
           }
         ]

--- a/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
+++ b/docs/specs/no-milestone/windows-storport-cuda-vram/SPEC.md
@@ -489,7 +489,7 @@ those shared sources as evidence without creating a second coverage owner.
 - [x] `cargo clippy -p ramshared-cuda -p ramshared-block -p ramshared-winsvc --all-targets -- -D warnings`
 - [x] `cargo test -p ramshared-cuda -p ramshared-block -p ramshared-winsvc`
 - [x] `cargo build -p ramshared-winsvc --target x86_64-pc-windows-msvc`
-- [x] `node tools/ci/check-rust-slice-coverage.mjs -p ramshared-winsvc --files crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs --min 80`
+- [x] `node tools/ci/check-rust-slice-coverage.mjs -p ramshared-winsvc --files crates/ramshared-winsvc/src/config.rs,crates/ramshared-winsvc/src/evidence.rs,crates/ramshared-winsvc/src/driver_link.rs,crates/ramshared-winsvc/src/broker_tenant.rs,crates/ramshared-winsvc/src/runtime.rs,crates/ramshared-winsvc/src/service.rs,crates/ramshared-winsvc/src/host_safety.rs,crates/ramshared-winsvc/src/broker_tenant/quota.rs --min 80`
   (also CUDA probe cover ≥80% when `crates/ramshared-cuda/src/probe.rs` is in the gate set)
 - [ ] If pure planning logic changes in `crates/ramshared-cuda/src/driver.rs`, include that file in a
   separate `ramshared-cuda` cover gate at >=80%; hardware-only lines remain live-E2E evidence.


### PR DESCRIPTION
## Summary

Implement per-tenant VRAM quota tracking and enforcement for multi-VM broker configurations.

## Commits

* e393800b45ebc54b5e414385a3e2342d2af5d8e6

## Labels

* type:feature
* area:security

## Validation

* `cargo clippy --all-targets` passes with zero warnings.
* `cargo test -p ramshared-winsvc` passes all tests.
* Local mock PR checks validate the body and payload structure.

## Rollback trigger

Rollback trigger: Revert if broker lease quota logic breaks test.

---
*PR created automatically by Jules for task [12501492428903016033](https://jules.google.com/task/12501492428903016033) started by @emersonbusson*