### PR TITLE
feat: extract cli completion generation script for multiple shells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +123,64 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+ "terminal_size",
+ "unicase",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -345,6 +453,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +594,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "palette"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +713,8 @@ dependencies = [
 name = "ramshared-cli"
 version = "0.11.0"
 dependencies = [
+ "clap",
+ "clap_complete",
  "libc",
  "ramshared-cuda",
  "ramshared-tier",
@@ -992,6 +1114,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1243,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasi"

--- a/crates/ramshared-cli/Cargo.toml
+++ b/crates/ramshared-cli/Cargo.toml
@@ -19,6 +19,8 @@ serde_json = "1"
 ratatui = { version = "0.30.0", default-features = false, features = ["crossterm"] }
 rustix = { version = "1.1.4", features = ["fs", "process"] }
 libc = "0.2"
+clap = { version = "4.5.21", features = ["derive", "env", "string", "unicode", "wrap_help"] }
+clap_complete = "4.5.38"
 
 [lints.clippy]
 unwrap_used = "deny"

--- a/crates/ramshared-cli/src/completion.rs
+++ b/crates/ramshared-cli/src/completion.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use std::process::ExitCode;
 
 use clap::{CommandFactory, Parser, Subcommand};
-use clap_complete::{generate, Shell};
+use clap_complete::{Shell, generate};
 
 /// CLI parser for completions mapping exactly to main.rs legacy args.
 #[derive(Parser)]

--- a/crates/ramshared-cli/src/completion.rs
+++ b/crates/ramshared-cli/src/completion.rs
@@ -1,0 +1,153 @@
+//! Shell completion generation for `ramshared` CLI using `clap`.
+#![forbid(unsafe_code)]
+
+use std::io::Write;
+use std::process::ExitCode;
+
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::{generate, Shell};
+
+/// CLI parser for completions mapping exactly to main.rs legacy args.
+#[derive(Parser)]
+#[command(name = "ramshared")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: CliCommands,
+}
+
+#[derive(Subcommand)]
+pub enum CliCommands {
+    /// Show ramshared version.
+    Version,
+
+    /// Run a supervised workload.
+    Run {
+        #[arg(long, help = "interactive|build|browser-test|batch")]
+        class: String,
+        #[arg(long, help = "Memory limit in MiB")]
+        memory_max: Option<usize>,
+        #[arg(last = true, help = "Command and arguments")]
+        args: Vec<String>,
+    },
+
+    /// Open an interactive shell session in a reserved scope.
+    Session {
+        #[arg(long, help = "interactive|build|browser-test|batch")]
+        class: String,
+        #[arg(long, help = "Memory limit in MiB")]
+        memory_max: Option<usize>,
+    },
+
+    /// Run supervisor daemon.
+    Supervise {
+        #[arg(long, help = "Run a single pass then exit")]
+        once: bool,
+    },
+
+    /// Recover crashed workloads or view recovery status.
+    Recover {
+        #[arg(long, group = "mode", help = "View status")]
+        status: bool,
+        #[arg(long, group = "mode", help = "Resume recovered workloads")]
+        resume: bool,
+    },
+
+    /// Check system dependencies and readiness.
+    Check {
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
+
+    /// Advanced diagnostics.
+    Doctor {
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
+
+    /// Setup and activate cascade.
+    Up {
+        #[arg(long, help = "VRAM size in MiB")]
+        vram: Option<usize>,
+        #[arg(long, help = "ZRAM size in MiB")]
+        zram: Option<usize>,
+        #[arg(long, help = "Path to daemon binary")]
+        daemon: Option<String>,
+    },
+
+    /// Deactivate cascade and teardown.
+    Down,
+
+    /// Show current status of cascade.
+    Status {
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
+
+    /// Real-time monitoring and telemetry.
+    Monitor {
+        #[arg(long, help = "Output JSON lines")]
+        jsonl: bool,
+        #[arg(long, help = "Compact mode")]
+        compact: bool,
+        #[arg(long, default_value_t = 1000, help = "Interval in ms")]
+        interval_ms: u64,
+        #[arg(long, default_value_t = 300, help = "History length in seconds")]
+        history_seconds: u64,
+        #[arg(long, help = "Output file path")]
+        output: Option<String>,
+        #[arg(long, help = "Heartbeat file path")]
+        heartbeat: Option<String>,
+        #[arg(long, help = "Run once and exit")]
+        once: bool,
+    },
+
+    /// Diagnose historical events.
+    Diagnose {
+        #[arg(long, help = "Path to events log")]
+        events: String,
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
+
+    /// Memory stress test.
+    Stress {
+        #[arg(long, help = "Start memory %")]
+        start: Option<u64>,
+        #[arg(long, help = "Target memory %")]
+        target: Option<u64>,
+        #[arg(long, help = "Step memory %")]
+        step: Option<u64>,
+        #[arg(long, help = "Interval in ms")]
+        interval_ms: Option<u64>,
+        #[arg(long, help = "Hold time in seconds")]
+        hold_sec: Option<u64>,
+        #[arg(long, help = "Minimum ram in MiB")]
+        min_ram_mb: Option<u64>,
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
+
+    /// Generate shell completions.
+    Completion {
+        #[arg(value_enum, help = "Shell to generate completions for")]
+        shell: Shell,
+    },
+}
+
+/// Generate shell completion script for the target shell and write to stdout.
+pub fn generate_script(shell: Shell, stdout: &mut dyn Write) -> ExitCode {
+    let mut cmd = Cli::command();
+    generate(shell, &mut cmd, "ramshared", stdout);
+    ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn verify_cli() {
+        Cli::command().debug_assert();
+    }
+}

--- a/crates/ramshared-cli/src/main.rs
+++ b/crates/ramshared-cli/src/main.rs
@@ -2514,3 +2514,4 @@ CONFIG_BLK_DEV_NBD=m\n\
         assert!(json.contains("\"min_free_kbytes\":32768"));
     }
 }
+// CI PR update

--- a/crates/ramshared-cli/src/main.rs
+++ b/crates/ramshared-cli/src/main.rs
@@ -11,9 +11,9 @@ use std::process::{Command, ExitCode};
 
 use ramshared_cuda::Cuda;
 
-mod completion;
 mod bounded_process;
 mod cascade;
+mod completion;
 mod diagnose;
 mod monitor;
 mod stress;
@@ -323,7 +323,8 @@ fn parse_cli_command(args: &[String]) -> Result<CliCommand, CliParseError> {
             args: options.to_vec(),
         }),
         "completion" => {
-            let shell = options.first()
+            let shell = options
+                .first()
                 .ok_or_else(|| CliParseError::InvalidOption {
                     command: "completion",
                     options: options.to_vec(),
@@ -387,13 +388,23 @@ trait CliActionRunner {
     ) -> ExitCode;
     fn recover(&mut self, resume: bool, stdout: &mut dyn Write, stderr: &mut dyn Write)
     -> ExitCode;
-    fn completion(&mut self, shell: clap_complete::Shell, stdout: &mut dyn Write, stderr: &mut dyn Write) -> ExitCode;
+    fn completion(
+        &mut self,
+        shell: clap_complete::Shell,
+        stdout: &mut dyn Write,
+        stderr: &mut dyn Write,
+    ) -> ExitCode;
 }
 
 struct SystemCliActions;
 
 impl CliActionRunner for SystemCliActions {
-    fn completion(&mut self, shell: clap_complete::Shell, stdout: &mut dyn Write, _stderr: &mut dyn Write) -> ExitCode {
+    fn completion(
+        &mut self,
+        shell: clap_complete::Shell,
+        stdout: &mut dyn Write,
+        _stderr: &mut dyn Write,
+    ) -> ExitCode {
         crate::completion::generate_script(shell, stdout)
     }
 

--- a/crates/ramshared-cli/src/main.rs
+++ b/crates/ramshared-cli/src/main.rs
@@ -11,6 +11,7 @@ use std::process::{Command, ExitCode};
 
 use ramshared_cuda::Cuda;
 
+mod completion;
 mod bounded_process;
 mod cascade;
 mod diagnose;
@@ -209,6 +210,7 @@ enum CliCommand {
     Diagnose { args: Vec<String> },
     Stress { args: Vec<String> },
     Help,
+    Completion { shell: clap_complete::Shell },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -320,6 +322,19 @@ fn parse_cli_command(args: &[String]) -> Result<CliCommand, CliParseError> {
         "diagnose" => Ok(CliCommand::Diagnose {
             args: options.to_vec(),
         }),
+        "completion" => {
+            let shell = options.first()
+                .ok_or_else(|| CliParseError::InvalidOption {
+                    command: "completion",
+                    options: options.to_vec(),
+                })?
+                .parse::<clap_complete::Shell>()
+                .map_err(|_| CliParseError::InvalidOption {
+                    command: "completion",
+                    options: options.to_vec(),
+                })?;
+            Ok(CliCommand::Completion { shell })
+        }
         "stress" | "bench" => Ok(CliCommand::Stress {
             args: options.to_vec(),
         }),
@@ -372,11 +387,16 @@ trait CliActionRunner {
     ) -> ExitCode;
     fn recover(&mut self, resume: bool, stdout: &mut dyn Write, stderr: &mut dyn Write)
     -> ExitCode;
+    fn completion(&mut self, shell: clap_complete::Shell, stdout: &mut dyn Write, stderr: &mut dyn Write) -> ExitCode;
 }
 
 struct SystemCliActions;
 
 impl CliActionRunner for SystemCliActions {
+    fn completion(&mut self, shell: clap_complete::Shell, stdout: &mut dyn Write, _stderr: &mut dyn Write) -> ExitCode {
+        crate::completion::generate_script(shell, stdout)
+    }
+
     fn check(&mut self, json: bool, stdout: &mut dyn Write, stderr: &mut dyn Write) -> ExitCode {
         let report = run_check();
         let output = if json {
@@ -546,6 +566,7 @@ fn run_from_args<R: CliActionRunner>(
         Ok(CliCommand::Monitor { options }) => actions.monitor(&options, stdout, stderr),
         Ok(CliCommand::Diagnose { args }) => actions.diagnose(&args, stdout, stderr),
         Ok(CliCommand::Stress { args }) => actions.stress(&args, stdout, stderr),
+        Ok(CliCommand::Completion { shell }) => actions.completion(shell, stdout, stderr),
         Ok(CliCommand::Help) => {
             print_usage(stderr);
             ExitCode::SUCCESS
@@ -608,6 +629,10 @@ fn print_usage(stderr: &mut dyn Write) {
     let _ = writeln!(
         stderr,
         "  ramshared stress [--start %] [--target %] [--step %] [--interval-ms N] [--hold-sec N] [--min-ram-mb N] [--json]"
+    );
+    let _ = writeln!(
+        stderr,
+        "  ramshared completion <bash|zsh|fish|powershell|elvish>"
     );
     let _ = writeln!(
         stderr,
@@ -1699,6 +1724,16 @@ mod tests {
             self.calls.push(CliCommand::Recover { resume });
             self.result()
         }
+
+        fn completion(
+            &mut self,
+            shell: clap_complete::Shell,
+            _stdout: &mut dyn std::io::Write,
+            _stderr: &mut dyn std::io::Write,
+        ) -> ExitCode {
+            self.calls.push(CliCommand::Completion { shell });
+            self.result()
+        }
     }
 
     fn cli_args(args: &[&str]) -> Vec<String> {
@@ -2210,6 +2245,7 @@ CONFIG_BLK_DEV_NBD=m\n\
             &["status"][..],
             &["status", "--json"][..],
             &["monitor", "--once"][..],
+            &["completion", "bash"][..],
             &["diagnose", "--events", "/dev/null"][..],
             &["--help"][..],
         ] {


### PR DESCRIPTION
## Summary
Extracted `clap_complete`-based shell completion generation logic into a new `completion` submodule for `ramshared-cli`. Added `completion` subcommand to support bash, zsh, and fish autocompletion scripts installable via standard package managers.

## Commits
* feat: extract cli completion generation script for multiple shells

## Validation
* Built successfully with `cargo check` and `cargo build`.
* `cargo clippy -p ramshared-cli` passes with zero warnings.
* `cargo test -p ramshared-cli` passes.

## Rollback trigger
test failures or build breakage.

---
*PR created automatically by Jules for task [2322456517420239190](https://jules.google.com/task/2322456517420239190) started by @emersonbusson*